### PR TITLE
gcc7 cleanups

### DIFF
--- a/code/code/cmd/cmd_news.cc
+++ b/code/code/cmd/cmd_news.cc
@@ -6,225 +6,27 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <dirent.h>
-#include <algorithm>
-
 #include "extern.h"
 #include "being.h"
 #include "statistics.h"
 #include <fstream>
 
-class newsFileList {
-  public:
-    sstring fileName;
-    time_t modTime;
-    sstring prependStr;
-
-  newsFileList(sstring a, time_t tim, sstring b) :
-    fileName(a),
-    modTime(tim),
-    prependStr(b)
-  {}
-  newsFileList() :
-    fileName(""),
-    modTime(0),
-    prependStr("")
-  {}
-};
-
-class newsFileSorter {
-  public:
-    bool operator() (const newsFileList &, const newsFileList &) const;
-};
-
-bool newsFileSorter::operator() (const newsFileList &x, const newsFileList &y) const
-{
-  return  (x.modTime > y.modTime);
-}
-
 void TBeing::doNews(const char *argument)
 {
+  if (!desc)
+    return;
+
+  news_used_num++;
+
   char arg[MAX_INPUT_LENGTH];
   one_argument(argument, arg, cElements(arg));
-
-  // check files mod times and see what has changed recently
-  DIR *dfd;
-  struct dirent *dp;
-  time_t now = time(0);
-  char buf[256];
-  struct stat theStat;
-  std::vector<newsFileList>vecFiles(0);
-
-  vecFiles.clear();
-
-  dfd = opendir(Path::HELP);
-  if (!dfd) {
-    vlogf(LOG_FILE, "doNews: Failed opening directory.");
-    return;
-  }
-  while ((dp = readdir(dfd))) {
-    if (!strcmp(dp->d_name, ".") ||
-        !strcmp(dp->d_name, "..") ||
-        !strcmp(dp->d_name, "_builder") ||
-        !strcmp(dp->d_name, "_immortal") ||
-        !strcmp(dp->d_name, "_spells") ||
-        !strcmp(dp->d_name, "_skills"))
-      continue;
-
-    sprintf(buf, "%s/%s", Path::HELP, dp->d_name);
-    if (!stat(buf, &theStat)) {
-      if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-        newsFileList nfl(dp->d_name, theStat.st_mtime, "help ");
-
-        vecFiles.push_back(nfl);
-      }
-    }
-  }
-  closedir(dfd);
-
-  dfd = opendir(Path::SKILL_HELP);
-  if (!dfd) {
-    vlogf(LOG_FILE, "doNews: Failed opening directory.");
-    return;
-  }
-  while ((dp = readdir(dfd))) {
-    if (!strcmp(dp->d_name, ".") ||
-        !strcmp(dp->d_name, ".."))
-      continue;
-
-    sprintf(buf, "%s/%s", Path::SKILL_HELP, dp->d_name);
-    if (!stat(buf, &theStat)) {
-      if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-        newsFileList nfl(dp->d_name, theStat.st_mtime, "help ");
-        vecFiles.push_back(nfl);
-      }
-    }
-  }
-  closedir(dfd);
-
-  dfd = opendir(Path::SPELL_HELP);
-  if (!dfd) {
-    vlogf(LOG_FILE, "doNews: Failed opening directory.");
-    return;
-  }
-  while ((dp = readdir(dfd))) {
-    if (!strcmp(dp->d_name, ".") ||
-        !strcmp(dp->d_name, ".."))
-      continue;
-
-    sprintf(buf, "%s/%s", Path::SPELL_HELP, dp->d_name);
-    if (!stat(buf, &theStat)) {
-      if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-        newsFileList nfl(dp->d_name, theStat.st_mtime, "help ");
-        vecFiles.push_back(nfl);
-      }
-    }
-  }
-  closedir(dfd);
-
-  if (GetMaxLevel() > MAX_MORT && isImmortal()) {
-    dfd = opendir(Path::BUILDER_HELP);
-    if (!dfd) {
-      vlogf(LOG_FILE, "doNews: Failed opening directory.");
-      return;
-    }
-    while ((dp = readdir(dfd))) {
-      if (!strcmp(dp->d_name, ".") ||
-          !strcmp(dp->d_name, ".."))
-        continue;
-
-      sprintf(buf, "%s/%s", Path::BUILDER_HELP, dp->d_name);
-      if (!stat(buf, &theStat)) {
-        if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-          newsFileList nfl(dp->d_name, theStat.st_mtime, "help ");
-          vecFiles.push_back(nfl);
-        }
-      }
-    }
-    closedir(dfd);
-  }
-
-  if (hasWizPower(POWER_IMMORTAL_HELP) && isImmortal()) {
-    dfd = opendir(Path::IMMORTAL_HELP);
-    if (!dfd) {
-      vlogf(LOG_FILE, "doNews: Failed opening directory.");
-      return;
-    }
-    while ((dp = readdir(dfd))) {
-      if (!strcmp(dp->d_name, ".") ||
-          !strcmp(dp->d_name, ".."))
-        continue;
-
-      sprintf(buf, "%s/%s", Path::IMMORTAL_HELP, dp->d_name);
-      if (!stat(buf, &theStat)) {
-        if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-          newsFileList nfl(dp->d_name, theStat.st_mtime, "help ");
-          vecFiles.push_back(nfl);
-        }
-      }
-    }
-    closedir(dfd);
-  }
-
-  // motd, and wizmotd
-  if (!stat(File::MOTD, &theStat)) {
-    if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-      newsFileList nfl("motd", theStat.st_mtime, "");
-      vecFiles.push_back(nfl);
-    } else if (isImmortal()) {
-      // slightly bizarre way of doing this, but wizmotd has same cmd as motd
-      if (!stat(File::WIZMOTD, &theStat)) {
-        if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-          newsFileList nfl("motd", theStat.st_mtime, "");
-          vecFiles.push_back(nfl);
-        }
-      }
-    }
-  }
-
-  // credits
-  if (!stat(File::CREDITS, &theStat)) {
-    if (now - theStat.st_mtime <= (3 * SECS_PER_REAL_DAY)) {
-      newsFileList nfl("credits", theStat.st_mtime, "");
-      vecFiles.push_back(nfl);
-    }
-  }
-
   sstring str;
 
-  /*
-  char timebuf[256];
-
-  str += "<H> News\n\r";
-  str += "------------------------------------------------------\n\r";
-
-  if (vecFiles.size()) {
-    std::sort(vecFiles.begin(), vecFiles.end(), newsFileSorter());
-
-    str += "The following information files have changed recently:\n\r";
-    str += "------------------------------------------------------\n\r";
-
-    unsigned int iter;
-    for (iter = 0; iter < vecFiles.size(); iter++) {
-      strcpy(timebuf, ctime(&(vecFiles[iter].modTime)));
-      timebuf[strlen(timebuf) - 1] = '\0';
-  
-      sprintf(buf, "%s : %s%s\n\r", timebuf, 
-            vecFiles[iter].prependStr.c_str(),
-            vecFiles[iter].fileName.c_str()); 
-      str += buf;
-    }
-  }
-  */
-
-#if 1
-
-  if(*arg){
+  if (*arg){
     std::ifstream news(File::NEWS);
     sstring s;
 
+    char buf[256];
     while(news.getline(buf, 256)){
       if(!*buf){
 	if(s.find(arg) != sstring::npos){
@@ -232,22 +34,13 @@ void TBeing::doNews(const char *argument)
 	}
 	s="";
       }
-      
+
       s+=buf;
       s+="\n\r";
     }
-  } else 
+  } else {
     file_to_sstring(File::NEWS, str, CONCAT_YES);
-
-  if (desc) {
-    news_used_num++;
-    desc->page_string(str.toCRLF());
   }
 
-#else
-  if (desc) {
-    news_used_num++;
-    desc->start_page_file(File::NEWS, "No news is good news!\n\r");
-  }
-#endif
+  desc->page_string(str.toCRLF());
 }

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -483,11 +483,11 @@ int TBeing::rawKill(spellNumT dmg_type, TBeing *tKiller, float exp_lost)
 
     if (per->polyed == POLY_TYPE_SWITCH) {  // switch
       remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-      doReturn("", WEAR_NOWHERE, CMD_RETURN, FALSE);
+      doReturn("", WEAR_NOWHERE, true, false);
       return rawKill(dmg_type, tKiller);
     }
     remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-    doReturn("", WEAR_NOWHERE, CMD_RETURN);
+    doReturn("", WEAR_NOWHERE, true);
     
     if ((per->rawKill(dmg_type, tKiller)) == DELETE_THIS) {
       per->reformGroup();
@@ -591,7 +591,7 @@ int TBeing::die(spellNumT dam_type, TBeing *tKiller)
     }
     per = desc->original;
     if (per->polyed == POLY_TYPE_SWITCH) {  // switch
-      doReturn("", WEAR_NOWHERE, CMD_RETURN, FALSE);
+      doReturn("", WEAR_NOWHERE, true, false);
       rawKill(dam_type, tKiller);
       return DELETE_THIS;
     } else if ((polymorph = dieReturn("", dam_type, 1)) == DELETE_THIS) {
@@ -657,7 +657,7 @@ int TBeing::dieReturn(const char *, spellNumT dam_type, int cmd)
     return FALSE;
   } else {
     remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-    doReturn("", WEAR_NOWHERE, CMD_RETURN, FALSE);
+    doReturn("", WEAR_NOWHERE, true, false);
   }
   return DELETE_THIS;
 }

--- a/code/code/misc/immortal.cc
+++ b/code/code/misc/immortal.cc
@@ -2779,7 +2779,7 @@ void TPerson::doPurge(const char *argument)
         (vict->desc || IS_SET(vict->specials.act, ACT_POLYSELF))) {
         sendTo("Sorry, you can't directly purge a poly'ed mob, you made them return.\n\r");
          vict->remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-         vict->doReturn("", WEAR_NOWHERE, CMD_RETURN);
+         vict->doReturn("", WEAR_NOWHERE, true);
          return;
         // delete vict;
         // vict = NULL;
@@ -6348,7 +6348,7 @@ int TBeing::doAs(const char *arg)
             desc->original->getName() % arg);
     sendTo("Please don't do things that will cause your original character to be destroyed.\n\r");
     remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-    doReturn("", WEAR_NOWHERE, CMD_RETURN);
+    doReturn("", WEAR_NOWHERE, true);
     return FALSE;
   }
 

--- a/code/code/misc/magic_off.cc
+++ b/code/code/misc/magic_off.cc
@@ -43,7 +43,7 @@ void TBeing::shatterWeapon(wearSlotT slot, int scrap_it)
   char buf[256];
   wearSlotT hand;
 
-  if (((slot >= WEAR_HAND_R) && (slot <= WEAR_ARM_L)) || (slot == HOLD_RIGHT) || (HOLD_LEFT)) {
+  if (((slot >= WEAR_HAND_R) && (slot <= WEAR_ARM_L)) || (slot == HOLD_RIGHT) || (slot == HOLD_LEFT)) {
     if ((slot == WEAR_HAND_R) || (slot == WEAR_ARM_R) || (slot == HOLD_RIGHT))
       hand = HOLD_RIGHT;
     else

--- a/code/code/misc/periodic.cc
+++ b/code/code/misc/periodic.cc
@@ -889,7 +889,7 @@ int TBeing::updateAffects()
     }
   }
   if (shouldReturn) {
-    doReturn("", WEAR_NOWHERE, CMD_RETURN); 
+    doReturn("", WEAR_NOWHERE, true);
     return ALREADY_DELETED;
   }
   return 0;
@@ -1630,7 +1630,7 @@ int TBeing::updateHalfTickStuff()
       
       if(desc && desc->original && desc->original->polyed && !desc->original->isImmortal() && (desc->original->polyed == POLY_TYPE_SHAPESHIFT)) {
         sendTo("Your shape can not survive without a connection to nature.\n\r");
-        doReturn("", WEAR_NOWHERE, CMD_RETURN); 
+        doReturn("", WEAR_NOWHERE, true);
         return ALREADY_DELETED;
       }
     }

--- a/code/code/misc/player_data.cc
+++ b/code/code/misc/player_data.cc
@@ -2271,7 +2271,6 @@ int numFifties(race_t race, bool perma, sstring account_name)
   sstring account_path = format("account/%c/%s") % LOWER(account_name[0]) %
           account_name.lower();
   sstring togfile_name;
-  char tog_file_name[128];
   bool char_is_perma;
 
   if (!(dfd = opendir(account_path.c_str()))) {
@@ -2290,9 +2289,8 @@ int numFifties(race_t race, bool perma, sstring account_name)
     byte max_level = 0;
 
     // perma death characters only get the bonus from perma 50's
-    sprintf(tog_file_name, "player/%c/%s.toggle", LOWER(dp->d_name[0]),
-      dp->d_name);
-    if(!(fp = fopen(tog_file_name, "r"))) {
+    sstring tog_file_name = format("player/%c/%s.toggle") % LOWER(dp->d_name[0]) % dp->d_name;
+    if(!(fp = fopen(tog_file_name.c_str(), "r"))) {
       vlogf(LOG_MAROR, format("Error loading toggles for player %s in numFifties.")
         % dp->d_name);
       continue;

--- a/code/code/misc/structs.cc
+++ b/code/code/misc/structs.cc
@@ -253,7 +253,7 @@ TBeing::~TBeing()
   if (desc) {
     if (desc->original) {
       remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-      doReturn("", WEAR_NOWHERE, CMD_RETURN);
+      doReturn("", WEAR_NOWHERE, true);
     }
   }
 
@@ -988,7 +988,7 @@ TPerson::~TPerson()
     for (t_desc = descriptor_list; t_desc; t_desc = t_desc->next) {
       if (t_desc->original && t_desc->original == this) {
         t_desc->character->remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-        t_desc->character->doReturn("", WEAR_NOWHERE, CMD_RETURN);
+        t_desc->character->doReturn("", WEAR_NOWHERE, true);
       }
     }
   }

--- a/code/code/spec/spec_objs.cc
+++ b/code/code/spec/spec_objs.cc
@@ -5506,7 +5506,7 @@ int lycanthropyCure(TBeing *ch, cmdTypeT cmd, const char *arg, TObj *o, TObj *)
   int returnVal = FALSE;
   if(ch->desc && ch->desc->original) {
     TBeing *per = ch->desc->original;
-    ch->doReturn("", WEAR_NOWHERE, CMD_RETURN);
+    ch->doReturn("", WEAR_NOWHERE, true);
     act("A whispy wolf-like form detaches itself from your body and then dissipates.", TRUE, per, NULL, NULL, TO_CHAR, NULL);
     act("A whispy wolf-like form detaches itself from $n's body and then dissipates.",
       TRUE, per, NULL, NULL, TO_ROOM, NULL);

--- a/code/code/sys/connect.cc
+++ b/code/code/sys/connect.cc
@@ -3806,12 +3806,11 @@ void Descriptor::deleteAccount()
 {
   DIR *dfd;
   struct dirent *dp;
-  char buf[256];
 
   vlogf(LOG_PIO, format("Account %s self-deleted.") % account->name);
 
-  sprintf(buf, "account/%c/%s", LOWER(account->name[0]), sstring(account->name).lower().c_str());
-  if (!(dfd = opendir(buf))) {
+  sstring dir_path = ((sstring)(format("account/%c/%s") % account->name[0] % account->name)).lower();
+  if (!(dfd = opendir(dir_path.c_str()))) {
     vlogf(LOG_FILE, format("Unable to walk directory for delete account (%s account)") %  account->name);
     return;
   }
@@ -3819,9 +3818,9 @@ void Descriptor::deleteAccount()
     if (!strcmp(dp->d_name, ".") || !strcmp(dp->d_name, ".."))
       continue;
 
-    sprintf(buf, "account/%c/%s/%s", LOWER(account->name[0]), sstring(account->name).lower().c_str(), dp->d_name);
-    if (unlink(buf) != 0)
-      vlogf(LOG_FILE, format("error in unlink (4) (%s) %d") %  buf % errno);
+    sstring file_path = format("%s/%s") % dir_path % dp->d_name;
+    if (unlink(file_path.c_str()) != 0)
+      vlogf(LOG_FILE, format("error in unlink (4) (%s) %d") % file_path % errno);
 
     // these are in the dir, but are not "players"
     if (!strcmp(dp->d_name, "comment") ||
@@ -3837,8 +3836,7 @@ void Descriptor::deleteAccount()
   db.query("delete from account where name='%s'",
 	   sstring(account->name).lower().c_str());
 
-  sprintf(buf, "account/%c/%s", LOWER(account->name[0]), sstring(account->name).lower().c_str());
-  rmdir(buf);
+  rmdir(dir_path.c_str());
   AccountStats::account_number--;
   closedir(dfd);
 }

--- a/code/code/sys/connect.cc
+++ b/code/code/sys/connect.cc
@@ -556,7 +556,7 @@ if (snoop.snoop_by && snoop.snoop_by->desc) {
 if (character) {
   if (original) {
     character->remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-    character->doReturn("", WEAR_NOWHERE, CMD_RETURN);
+    character->doReturn("", WEAR_NOWHERE, true);
   }
 
   if ((connected >= CON_REDITING) || !connected) {

--- a/code/code/sys/socket.cc
+++ b/code/code/sys/socket.cc
@@ -1488,7 +1488,7 @@ bool procCharLycanthropy::run(const TPulse &pl, TBeing *tmp_ch) const
     if(Weather::moonType() != "full" || 
        Weather::sunIsUp() || !Weather::moonIsUp()){
       tmp_ch->remQuestBit(TOG_TRANSFORMED_LYCANTHROPE);
-      tmp_ch->doReturn("", WEAR_NOWHERE, CMD_RETURN);
+      tmp_ch->doReturn("", WEAR_NOWHERE, true);
     } else if(!tmp_ch->fight() && tmp_ch->roomp && 
 	      !tmp_ch->roomp->isRoomFlag(ROOM_PEACEFUL) &&
 	      !::number(0,24)){


### PR DESCRIPTION
Various fatal warnings emitted by gcc7. When rebased on the gcc5 fixes, this compiles with every version of clang and gcc that's officially compatible.