### PR TITLE
Buffer Overflow bug fix.

### DIFF
--- a/code/code/misc/guild.cc
+++ b/code/code/misc/guild.cc
@@ -1174,7 +1174,7 @@ char * display_permission(unsigned int perms) {
 }
 
 char * display_guild_flags(unsigned int flags) {
-  char buf[256];
+  char buf[512];
   sprintf(buf, "%s%s%s%s%s%s%s",
 	  (IS_SET(flags, GUILD_ACTIVE) ?  
 	   "\n\r This guild is activated." : "\n\r This guild is NOT activated."),


### PR DESCRIPTION
GCC7 caught a likely buffer overflow in the guild code. This fix increases the buffer size to handle the string that will eventually be constructed to fit. 512 is somewhat bigger than the 328 bytes or so needed, but allows safe expansion for a line or so.