### PR TITLE
Fixing bad directory verification.

### DIFF
--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -392,7 +392,7 @@ void bootDb(void)
 
   bootPulse("Verifying runtime lib dirs.");
   verify_path("roomdata/saved");
-  verify_path("immmortals");
+  verify_path("immortals");
   verify_path_azdir("rent");
   verify_path_azdir("account");
   verify_path_azdir("player");


### PR DESCRIPTION
This verification not only checks for the existence of a directory, it also creates it if it doesn't exist. So the directory it looks for was given with a typo, so it creates that, and then the code goes on to use the directory that didn't have the typo in the name. Could crash if it verifies immmortals, when immortals doesn't exist in the first place.