### PR TITLE
fix mobiles killed number in world command

### DIFF
--- a/code/code/misc/info.cc
+++ b/code/code/misc/info.cc
@@ -3317,7 +3317,7 @@ void TBeing::doWorld()
   // db.query("select count(*) as count from trophymob");
 
   // just use the inefficient query for now
-  db.query("select count(distinct mobvnum) from trophy");
+  db.query("select count(distinct mobvnum) as count from trophy");
   if(db.fetchRow())
     unkmobcount=convertTo<int>(db["count"]);
 


### PR DESCRIPTION
Fix query to give number of mobiles never killed when user types "world"