### PR TITLE
doTell: convert most users to TBeing* instead of char*

### DIFF
--- a/code/code/disc/disc_psionics.cc
+++ b/code/code/disc/disc_psionics.cc
@@ -146,7 +146,7 @@ int TBeing::doPTell(const char *arg, bool visible){
 
   sstring garbed = garble(vict, message, Garble::SPEECH_TELL);
 
-  rc = vict->triggerSpecialOnPerson(this, CMD_OBJ_TOLD_TO_PLAYER, garbed.c_str());
+  rc = vict->triggerSpecialOnPerson(this, CMD_OBJ_TOLD_TO_PLAYER, garbed);
   if (IS_SET_DELETE(rc, DELETE_THIS)) {
     delete vict;
     vict = NULL;

--- a/code/code/game/game_craps.cc
+++ b/code/code/game/game_craps.cc
@@ -664,7 +664,7 @@ void Craps::checkField(int diceroll, TBeing *ch)
 
   if ((diceroll >= 5) && (diceroll <= 8)) {
     if (crap_man) {
-      crap_man->doTell(ch->getName(), format("The roll is %d. You lose your bet on the field (%d).") % diceroll % d->bet.field_bet);
+      crap_man->doTell(ch, format("The roll is %d. You lose your bet on the field (%d).") % diceroll % d->bet.field_bet);
       observerReaction(ch, GAMBLER_LOST);
     }
   } else {
@@ -678,7 +678,7 @@ void Craps::checkField(int diceroll, TBeing *ch)
       observerReaction(ch, GAMBLER_WON);
     }
     if (crap_man) {
-      crap_man->doTell(ch->getName(), buf);
+      crap_man->doTell(ch, buf);
     }
 
   }
@@ -912,11 +912,11 @@ int Craps::rollDice()
 
   if ((table_man = FindMobInRoomWithProcNum(m_ch->in_room, SPEC_CRAPSGUY))) {
     if (!can_bet_craps(m_ch)) {
-      table_man->doTell(m_ch->getName(), "You can't roll until I say so!");
+      table_man->doTell(m_ch, "You can't roll until I say so!");
       return FALSE;
     }
     if (!m_ch->desc->bet.come) {
-      table_man->doTell(m_ch->getName(), "Sorry to keep the table, you need to place a come bet.");
+      table_man->doTell(m_ch, "Sorry to keep the table, you need to place a come bet.");
       return FALSE;
     }
   }

--- a/code/code/misc/ai_responses.cc
+++ b/code/code/misc/ai_responses.cc
@@ -109,7 +109,7 @@ int TMonster::modifiedDoCommand(cmdTypeT cmd, const sstring &arg, TBeing *mob, c
     case CMD_LOAD:
     case CMD_RESP_CHECKLOAD:
       if (mobVnum() < 0) {
-        doTell(mob->getNameNOC(this), "I would load it, but i'm a prototype.  Sorry.");
+        doTell(mob, "I would load it, but i'm a prototype.  Sorry.");
         return FALSE; // continue the script, even tho this is a 'dummy' trigger.
       }
       value = convertTo<int>(arg);
@@ -166,7 +166,7 @@ int TMonster::modifiedDoCommand(cmdTypeT cmd, const sstring &arg, TBeing *mob, c
     case CMD_RESP_LOADMOB:
       {
         if (mobVnum() < 0) {
-          doTell(mob->getNameNOC(this), "I would load it, but i'm a prototype.  Sorry.");
+          doTell(mob, "I would load it, but i'm a prototype.  Sorry.");
           return FALSE; // continue the script, even tho this is a 'dummy' trigger.
         }
 
@@ -997,7 +997,7 @@ int TMonster::checkResponsesReal(TBeing *speaker, TThing *resp_targ, const sstri
           value = convertTo<int>(tStString);
 
           if (speaker->getMoney() < value) {
-            doTell(speaker->getNameNOC(this), "I'm afraid you don't have enough for that.");
+            doTell(speaker, "I'm afraid you don't have enough for that.");
 
             return TRUE;
           } else {

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -743,7 +743,6 @@ class TBeing : public TThing {
     double pietyGain(double);
     void goBerserk(TBeing *);
     void checkForQuestTog(TBeing *);
-    void sendCheatMessage(char *);
     void stopFighting();
     int canBeParalyzeLimbed();
     int checkIdling();

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -597,7 +597,7 @@ class TBeing : public TThing {
     int numClasses() const;
 
     int triggerSpecial(TThing *, cmdTypeT cmd, const char *arg); 
-    int triggerSpecialOnPerson(TThing *, cmdTypeT cmd, const char *arg); 
+    int triggerSpecialOnPerson(TThing *, cmdTypeT cmd, const sstring &arg); 
     void sendCastingMessages(bool, bool, int, skillUseTypeT, int);
     void sendFinalCastingMessages(bool, bool, skillUseTypeT);
 

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1816,7 +1816,16 @@ class TBeing : public TThing {
     void lookingAtObj(TThing *);
     void doShout(const sstring &);
     int doWhisper(const sstring &);
+
+    int doTell(const TBeing *vict, const sstring &message, bool visible = TRUE) {
+        return doTell(const_cast<TBeing *>(vict), message, visible);
+    }
+    int doTell(TBeing &vict, const sstring &message, bool visible = TRUE) {
+        return doTell(&vict, message, visible);
+    }
     int doTell(const sstring &, const sstring &, bool visible = TRUE);
+    int doTell(TBeing *, const sstring &, bool visible = TRUE);
+
     int doClientMessage(const char *);
     int doAsk(const sstring &);
     int doSign(const sstring &);

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -1532,8 +1532,8 @@ void TBeing::checkForQuestTog(TBeing *vict)
       af.be = this;
 
       vict->affectTo(&af, -1);
-      vict->doTell(getName(), "You have acted honorably in attacking me.");
-      vict->doTell(getName(), "Let this fight be to the death!");
+      vict->doTell(this, "You have acted honorably in attacking me.");
+      vict->doTell(this, "Let this fight be to the death!");
 //      vlogf(LOG_COMBAT, format("Setting quest bit for %d on %s vs %s") %  bitnum % vict->getName() % getName());
       // some specials stun the critter so it doesn't start fighting.
       // we need to set them fighting so that if char stuns and flees
@@ -1552,43 +1552,31 @@ void TBeing::checkForQuestTog(TBeing *vict)
         }
       }
       if (!found2 && awake()) {
-        vict->doTell(getName(), "You have acted dishonorably in attacking me while I was unprepared.");
-        vict->doTell(getName(), "This battle will avail you naught unless you fight me at my prime.");
+        vict->doTell(this, "You have acted dishonorably in attacking me while I was unprepared.");
+        vict->doTell(this, "This battle will avail you naught unless you fight me at my prime.");
       }
     }
   }
 }
 
-void TBeing::sendCheatMessage(char *cheater)
+void sendCheatMessage(TBeing &vict, TBeing &cheater)
 {
-  char nameBuf[MAX_NAME_LENGTH];
-
-  sprintf(nameBuf, "%s", cheater);
-  switch (mobVnum()) {
+  switch (vict.mobVnum()) {
     case Mob::TROLL_GIANT:
     case Mob::CAPTAIN_RYOKEN:
     case Mob::TREE_SPIRIT:
-      doTell(nameBuf, "You have failed to defeat me in single combat.");
-      doTell(nameBuf, "An honorable deikhan would allow me to heal completely before attacking again.");
+      vict.doTell(cheater, "You have failed to defeat me in single combat.");
+      vict.doTell(cheater, "An honorable deikhan would allow me to heal completely before attacking again.");
       break;
     case Mob::JOHN_RUSTLER:
-      doTell(nameBuf, "You have failed to defeat me in single combat.");
-      doTell(nameBuf, "An honorable ranger would allow me to heal completely before attacking again.");
-      break;      
     case Mob::ORC_MAGI:
-      sendTo("<c>You realize you did not follow the guidelines of your quest, so this fight will be for naught.<1>\n\r");
-      setQuestBit(TOG_FAILED_TO_KILL_MAGI);
-      break;
     case Mob::CLERIC_VOLCANO:
-      doTell(nameBuf, "You have failed to defeat me in single combat.");
-      doTell(nameBuf, "An honorable ranger would allow me to heal completely before attacking again.");
-      break;
     case Mob::CLERIC_ARDEN:
-      doTell(nameBuf, "You have failed to defeat me in single combat.");
-      doTell(nameBuf, "An honorable ranger would allow me to heal completely before attacking again.");
+      vict.doTell(cheater, "You have failed to defeat me in single combat.");
+      vict.doTell(cheater, "An honorable ranger would allow me to heal completely before attacking again.");
       break;
     default:
-      vlogf(LOG_COMBAT, format("Somehow got to getCheatMessage without a valid toggle bit %s.") %  getName());
+      vlogf(LOG_COMBAT, format("Somehow non-quest mob %s got to getCheatMessage.") %  vict.getName());
       break;
   }
 }
@@ -1598,7 +1586,6 @@ void TBeing::stopFighting()
 {
   TBeing *tmp;
   affectedData *af, *af2;
-  char nameBuf[MAX_NAME_LENGTH];
 
   stopmusic();
 
@@ -1631,12 +1618,10 @@ void TBeing::stopFighting()
     if (af->type == AFFECT_COMBAT && af->modifier == COMBAT_SOLO_KILL) {
       // stopFighting is called from a bunch of places, including mob death
       // we have trapped death, so anything else that gets here implies
-      // combat stopped for some other reason
-      // ie, mob fled, got paralyzed, teleported, etc.
+      // combat stopped for some other reason - mob fled, got paralyzed, teleported, etc.
       if (awake()) {
         vlogf(LOG_COMBAT, format("Removing Solo Combat Affect from: %s") %  getName());
-        sprintf(nameBuf, "%s", fname(af->be->name).c_str());
-        sendCheatMessage(nameBuf);
+        sendCheatMessage(*this, *(TBeing *)af->be);
         affectRemove(af);
       }
 #if 0

--- a/code/code/misc/gaining.cc
+++ b/code/code/misc/gaining.cc
@@ -19,88 +19,88 @@
 void TBeing::setSpellEligibleToggle(TMonster *trainer, spellNumT spell, silentTypeT silent) 
 {
   if (!silent && trainer) {
-    trainer->doTell(fname(name), format("You now have the training to learn %s!") % discArray[spell]->name);
+    trainer->doTell(this, format("You now have the training to learn %s!") % discArray[spell]->name);
   }
 
   switch (spell) {
     case SPELL_TORNADO:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "Alas, I do not have the knowledge to train you in tornado.");
-        trainer->doTell(fname(name), "Seek out the wise elf Salrik to see if you can learn it from him.  I will let him know that I have sent you.");
+        trainer->doTell(this, "Alas, I do not have the knowledge to train you in tornado.");
+        trainer->doTell(this, "Seek out the wise elf Salrik to see if you can learn it from him.  I will let him know that I have sent you.");
       }
       setQuestBit(TOG_TORNADO_ELIGIBLE);
       break;
 
     case SKILL_BARKSKIN:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "However, before I train you in barkskin, I must ask you  to perform a small task to prove your worth.");
-	trainer->doTell(fname(name), "In order to prove you are ready for such knowledge, bring me some barkskin.");
+        trainer->doTell(this, "However, before I train you in barkskin, I must ask you  to perform a small task to prove your worth.");
+	trainer->doTell(this, "In order to prove you are ready for such knowledge, bring me some barkskin.");
       }
       setQuestBit(TOG_ELIGIBLE_BARKSKIN);
       break;
       
     case SPELL_EARTHQUAKE:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "However, before I train you in earthquake, I must ask you to perform a small task to prove your worth.");
-        trainer->doTell(fname(name), "In order to prove you are ready for such knowledge, bring me a yellow boot.");
+        trainer->doTell(this, "However, before I train you in earthquake, I must ask you to perform a small task to prove your worth.");
+        trainer->doTell(this, "In order to prove you are ready for such knowledge, bring me a yellow boot.");
       }
       setQuestBit(TOG_ELIGIBLE_EARTHQUAKE);
       break;
       
     case SKILL_DUAL_WIELD:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "However, before I train you in dual wield, I must ask you to perform a small task to prove your worth.");
-        trainer->doTell(fname(name), "In order to prove you are ready for such knowledge, bring me some mandrake.");
+        trainer->doTell(this, "However, before I train you in dual wield, I must ask you to perform a small task to prove your worth.");
+        trainer->doTell(this, "In order to prove you are ready for such knowledge, bring me some mandrake.");
       }
       setQuestBit(TOG_ELIGIBLE_DUAL_WIELD);
       break;
       
     case SPELL_FIREBALL:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "Alas, I do not have the knowledge to train you in fireball.");
-        trainer->doTell(fname(name), "Seek out the mischevious mage Kallam to see if you can learn it from him.  I will let him know that I have sent you.");
+        trainer->doTell(this, "Alas, I do not have the knowledge to train you in fireball.");
+        trainer->doTell(this, "Seek out the mischevious mage Kallam to see if you can learn it from him.  I will let him know that I have sent you.");
       }
       setQuestBit(TOG_ELIGIBLE_FIREBALL);
       break;
 
     case SPELL_ICE_STORM:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "Alas, I do not have the knowledge to train you in ice storm.");
-        trainer->doTell(fname(name), "Seek out the water mage, Cardac, to see if you can learn it from him.  I will let him know that I have sent you.");
+        trainer->doTell(this, "Alas, I do not have the knowledge to train you in ice storm.");
+        trainer->doTell(this, "Seek out the water mage, Cardac, to see if you can learn it from him.  I will let him know that I have sent you.");
       }
       setQuestBit(TOG_ELIGIBLE_ICE_STORM);
       break;
 
     case SPELL_STONE_SKIN:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "Alas, I do not have the knowledge to train you in stone skin.");
-        trainer->doTell(fname(name), "However, I do remember a dwarf that perhaps has such knowledge of using defensive Earth Magic.");
-        trainer->doTell(fname(name), "I think the City in the Clouds has the dwarf you seek.  He is a very important abassador there.");
-        trainer->doTell(fname(name), "Seek him out, he may hold the secrets you desire.");
+        trainer->doTell(this, "Alas, I do not have the knowledge to train you in stone skin.");
+        trainer->doTell(this, "However, I do remember a dwarf that perhaps has such knowledge of using defensive Earth Magic.");
+        trainer->doTell(this, "I think the City in the Clouds has the dwarf you seek.  He is a very important abassador there.");
+        trainer->doTell(this, "Seek him out, he may hold the secrets you desire.");
       }
       setQuestBit(TOG_ELIGIBLE_STONESKIN);
       break;
 
     case SPELL_GALVANIZE:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "Alas, I do not have the knowledge to train you in galvanize.");
-        trainer->doTell(fname(name), "Seek out the wizened mage, Fabnir, to see if you can learn it from him.  I will let him know that I have sent you.");
+        trainer->doTell(this, "Alas, I do not have the knowledge to train you in galvanize.");
+        trainer->doTell(this, "Seek out the wizened mage, Fabnir, to see if you can learn it from him.  I will let him know that I have sent you.");
       }
       setQuestBit(TOG_ELIGIBLE_GALVANIZE);
       break;
 
     case SPELL_POWERSTONE:
       if (!silent && trainer) {
-        trainer->doTell(fname(name), "Alas, I do not have the knowledge to train you in powerstone.");
-        trainer->doTell(fname(name), "Seek out the wise alchemist, Fabnir, to see if you can learn it from him.  I will let him know that I have sent you.");
+        trainer->doTell(this, "Alas, I do not have the knowledge to train you in powerstone.");
+        trainer->doTell(this, "Seek out the wise alchemist, Fabnir, to see if you can learn it from him.  I will let him know that I have sent you.");
       }
       setQuestBit(TOG_ELIGIBLE_POWERSTONE);
       break;
 
     case SKILL_ADVANCED_KICKING:
       if(!silent && trainer){
-	trainer->doTell(fname(name), "Although you are eligible to learn advanced kicking, you must first master kick.");
-	trainer->doTell(fname(name), "When you have mastered kick, speak with your guildmaster and I will tell you how to learn advanced kicking.");
+	trainer->doTell(this, "Although you are eligible to learn advanced kicking, you must first master kick.");
+	trainer->doTell(this, "When you have mastered kick, speak with your guildmaster and I will tell you how to learn advanced kicking.");
       }
       break;
 
@@ -1241,7 +1241,7 @@ int CDGenericTrainer(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TO
       accclass = SHAMAN_LEVEL_IND;
   else if (!*classbuf) {
     /* more than 1 class is appropriate, user needs to specify */
-    me->doTell(fname(ch->name), "You need to specify a class.");
+    me->doTell(ch, "You need to specify a class.");
     sprintf(buf,
          "Type \"practice %s <number>\" to learn this discipline.", 
          TrainerInfo[offset].abbrev);
@@ -1280,24 +1280,24 @@ int CDGenericTrainer(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TO
 
   if (ch->checkForPreReqs(ch, me, discipline, accclass, doneBas)) {
     if (practices <= 0) {
-      me->doTell(fname(ch->name), "I also would not be able to train you further in this discipline.");
+      me->doTell(ch, "I also would not be able to train you further in this discipline.");
     }
     return TRUE;
   }
  
   if (practices <= 0) {
-    me->doTell(fname(ch->name), "You have come far.  I can train you no farther in this discipline.");
-    me->doTell(fname(ch->name), "You must find another master who can further your training.");
+    me->doTell(ch, "You have come far.  I can train you no farther in this discipline.");
+    me->doTell(ch, "You must find another master who can further your training.");
     return TRUE;
   }
 
   // set the number they actually have as another limiting factor
   practices = min((int) ch->getPracs(accclass), practices);
   if (practices <= 0) {
-    me->doTell(fname(ch->name), "You have no more practices you can use here.");
+    me->doTell(ch, "You have no more practices you can use here.");
     return TRUE;
   } else if (practices < pracs) {
-      me->doTell(fname(ch->name), format("I will only be able to use %d of your requested practices.") % practices);
+      me->doTell(ch, format("I will only be able to use %d of your requested practices.") % practices);
   }
   if (ch->doTraining(ch, me, accclass, offset, min(practices, pracs))) 
     return TRUE;
@@ -1420,7 +1420,7 @@ int TBeing::checkTrainDeny(const TBeing *ch, TMonster *me, discNumT discipline, 
 {
 
   if ((ch->getDiscipline(discipline))->getNatLearnedness() >= MAX_DISC_LEARNEDNESS) {
-    me->doTell(fname(ch->name), "You are already fully learned in this discipline.");
+    me->doTell(ch, "You are already fully learned in this discipline.");
     return TRUE;
   }
   if ((ch->getDiscipline(discipline))->getNatLearnedness() + pracs > MAX_DISC_LEARNEDNESS) {
@@ -1441,49 +1441,49 @@ int TBeing::checkForPreReqs(const TBeing *ch, TMonster *me, discNumT discipline,
 
  if (discipline == DISC_BAREHAND) {
    if (ch->getRawNatSkillValue(SKILL_BAREHAND_PROF) < WEAPON_GAIN_LEARNEDNESS) {
-     me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+     me->doTell(ch, "You aren't proficient enough yet.");
      return TRUE;
    }
  }
  if (discipline == DISC_SLASH) {
    if (ch->getRawNatSkillValue(SKILL_SLASH_PROF) < WEAPON_GAIN_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+      me->doTell(ch, "You aren't proficient enough yet.");
       return TRUE;
     }
   }
   if (discipline == DISC_PIERCE) {
     if (ch->getRawNatSkillValue(SKILL_PIERCE_PROF) < WEAPON_GAIN_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+      me->doTell(ch, "You aren't proficient enough yet.");
       return TRUE;
     }
   }
   if (discipline == DISC_BLUNT) {
     if (ch->getRawNatSkillValue(SKILL_BLUNT_PROF) < WEAPON_GAIN_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+      me->doTell(ch, "You aren't proficient enough yet.");
       return TRUE;
     }
   }
   if (discipline == DISC_RANGED) {
     if (ch->getRawNatSkillValue(SKILL_RANGED_PROF) < WEAPON_GAIN_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+      me->doTell(ch, "You aren't proficient enough yet.");
       return TRUE;
     }
   }
   if (discipline == DISC_DEFENSE) {
     if (ch->getRawNatSkillValue(SKILL_DEFENSE) < WEAPON_GAIN_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+      me->doTell(ch, "You aren't proficient enough yet.");
       return TRUE;
     }
   }
   if (discipline == DISC_ADVANCED_ADVENTURING) {
     if (ch->getDiscipline(DISC_ADVENTURING)->getNatLearnedness() < WEAPON_GAIN_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You aren't proficient enough yet.");
+      me->doTell(ch, "You aren't proficient enough yet.");
       return TRUE;
     }
   }
   if (discipline == DISC_PSIONICS) {
     if (!ch->hasQuestBit(TOG_PSIONICIST)){
-      me->doTell(fname(ch->name), "You do not have the ability to learn psionics.");
+      me->doTell(ch, "You do not have the ability to learn psionics.");
       return TRUE;
     }
 
@@ -1551,20 +1551,20 @@ int TBeing::checkForPreReqs(const TBeing *ch, TMonster *me, discNumT discipline,
   switch (found) {
     case 2:
       if (combat >= MAX_DISC_LEARNEDNESS) {
-        me->doTell(fname(ch->name), "Tsk! Tsk! You have not kept up with your basic training and you expect advanced learning.");
+        me->doTell(ch, "Tsk! Tsk! You have not kept up with your basic training and you expect advanced learning.");
         sprintf(buf, "Hmmm. I think you should learn more from your %s trainer.", me->getProfName().c_str());
       } else if (!combatLearn) {
-        me->doTell(fname(ch->name), "Tsk! Tsk! You have not kept up with your basic training and you expect advanced learning.");
+        me->doTell(ch, "Tsk! Tsk! You have not kept up with your basic training and you expect advanced learning.");
         sprintf(buf, "Hmmm. I think you should learn more from the %s trainer.", tmp_buf.c_str());
       } else {
-        me->doTell(fname(ch->name), "Tsk! Tsk! You have not finished any of your basic training and you expect advanced learning.");
+        me->doTell(ch, "Tsk! Tsk! You have not finished any of your basic training and you expect advanced learning.");
         sprintf(buf, "Hmmm. I think you should learn more from one of your basic trainers.");
       }
-      me->doTell(fname(ch->name), buf);
+      me->doTell(ch, buf);
       return TRUE;
     case 1:
-      me->doTell(fname(ch->name), "Tsk! Tsk! You have not kept up with your general training and you expect me to teach you more.");
-      me->doTell(fname(ch->name), format("Go learn more about %s before you come back to me.") % tmp_buf);
+      me->doTell(ch, "Tsk! Tsk! You have not kept up with your general training and you expect me to teach you more.");
+      me->doTell(ch, format("Go learn more about %s before you come back to me.") % tmp_buf);
       return TRUE;
   }
   return FALSE;
@@ -1602,15 +1602,15 @@ int TBeing::doTraining(TBeing *ch, TMonster *me, classIndT accclass, int offset,
     // basic level check
     if ((ch->getDiscipline(TrainerInfo[offset].disc))->getNatLearnedness() >=
          me->GetMaxLevel()) {
-       me->doTell(fname(ch->name), "I can train you no farther in this discipline.");
-       me->doTell(fname(ch->name), "You must find another master who can further your training.");
+       me->doTell(ch, "I can train you no farther in this discipline.");
+       me->doTell(ch, "You must find another master who can further your training.");
 
       break;
     }
     // basic maxed check
     if ((ch->getDiscipline(TrainerInfo[offset].disc))->getNatLearnedness() >=
          MAX_DISC_LEARNEDNESS) {
-      me->doTell(fname(ch->name), "You are now fully trained in this discipline.");
+      me->doTell(ch, "You are now fully trained in this discipline.");
       break;
     }
 

--- a/code/code/misc/guild.cc
+++ b/code/code/misc/guild.cc
@@ -363,22 +363,22 @@ int guildRegistrar(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, 
       return FALSE;
     }
     if (count == 1) {
-      myself->doTell(fname(ch->name), "If you want me to help you, you have to use the right syntax.");
-      myself->doTell(fname(ch->name), "Try 'fedit create <keywords>'");
+      myself->doTell(ch, "If you want me to help you, you have to use the right syntax.");
+      myself->doTell(ch, "Try 'fedit create <keywords>'");
       return TRUE;
     }
-    myself->doTell(fname(ch->name), "Ah, so you wish to found a new guild?");
-    myself->doTell(fname(ch->name), "Let me just make sure your paperwork is in order.");
+    myself->doTell(ch, "Ah, so you wish to found a new guild?");
+    myself->doTell(ch, "Let me just make sure your paperwork is in order.");
     
     
     if(ch->isImmortal()) {
-      myself->doTell(fname(ch->name), "Actually... for an immortal I think I can skip the paperwork.");
+      myself->doTell(ch, "Actually... for an immortal I think I can skip the paperwork.");
       myself->doAction(fname(ch->name), CMD_SMILE);
     } else {
       if(ch->inRoom() != Room::GUILD_BUREAU) {
 	myself->doAction("", CMD_BLINK);
 	myself->doSay("Uh, it seem I've misplaced my office.");
-	myself->doTell(fname(ch->name), "Tell ya what, I'll meet you there, and then we'll go over your paperwork.");
+	myself->doTell(ch, "Tell ya what, I'll meet you there, and then we'll go over your paperwork.");
 	act("$n hurries off back to $s office.", 0, myself, 0, 0, TO_ROOM);
 	--(*myself);
 	*real_roomp(Room::GUILD_BUREAU) += *myself;
@@ -491,27 +491,27 @@ int guildRegistrar(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, 
       // logic: guild doesn't exist, guild is hidden and hasn't extended an offer, or
       // guild is inactive - deny.
       
-      myself->doTell(fname(ch->name), "I'm sorry, it appears that guild does not show up in any of my records.");
+      myself->doTell(ch, "I'm sorry, it appears that guild does not show up in any of my records.");
       
       return TRUE;
     }
     if(ch->getGuildID()>=0) {
-      myself->doTell(fname(ch->name), "You are already a member of a guild... you'll have to disband before you join another.");
-      myself->doTell(fname(ch->name), "There is also a twenty four hour wait period before you may join another guild.");
+      myself->doTell(ch, "You are already a member of a guild... you'll have to disband before you join another.");
+      myself->doTell(ch, "There is also a twenty four hour wait period before you may join another guild.");
       
       return TRUE;
     }
     if(ch->recentlyDefected()) {
-      myself->doTell(fname(ch->name), "You recently defected from your guild, you'll have to wait to join another.");
+      myself->doTell(ch, "You recently defected from your guild, you'll have to wait to join another.");
       return TRUE;
     }
     
     if(!ch->hasOffer(f)) {
-      myself->doTell(fname(ch->name), format("%s has not extended a recruitment offer to you.") % f->getName());
+      myself->doTell(ch, format("%s has not extended a recruitment offer to you.") % f->getName());
       if(!IS_SET(f->flags, GUILD_OPEN_RECRUITMENT)) {
 	return TRUE;
       } else {
-	myself->doTell(fname(ch->name), "However, they offer open recruitment, so I can sign you up anyway.");
+	myself->doTell(ch, "However, they offer open recruitment, so I can sign you up anyway.");
       }
       
     }
@@ -535,7 +535,7 @@ int guildRegistrar(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, 
     
   }
   if (cmd == CMD_LIST) {
-    myself->doTell(fname(ch->name), "I currently have these guilds registered as active.");
+    myself->doTell(ch, "I currently have these guilds registered as active.");
     act("$n gets a sheet of paper from $s desk and holds it out to you.\n\rIt reads as follows:\n\r",
         FALSE, myself, 0, ch, TO_VICT);
     act("$n says something to $N.\n\r$n gets a sheet of paper from $s desk and holds it out to $N.\n\r",
@@ -543,7 +543,7 @@ int guildRegistrar(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, 
     
     ch->show_guild("showallguilds");
     ch->sendTo("\n\r");
-    myself->doTell(fname(ch->name), "I've marked the guilds that have open recruitment with an [<R>X<1>].");
+    myself->doTell(ch, "I've marked the guilds that have open recruitment with an [<R>X<1>].");
     return TRUE;
   }
   return FALSE;

--- a/code/code/misc/hospital.cc
+++ b/code/code/misc/hospital.cc
@@ -267,14 +267,14 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
 
  /* Go thru and print out what ails the person. */
   if (cmd == CMD_LIST) {
-    me->doTell(ch->getName(), "I will list out what ails you, along with a price.");
+    me->doTell(ch, "I will list out what ails you, along with a price.");
     for (i = MIN_WEAR; i < MAX_WEAR; i++) {
       if (i == HOLD_RIGHT || i == HOLD_LEFT)
         continue;
       if (!ch->slotChance(i))
         continue;
       if (ch->isLimbFlags(i, PART_MISSING)) {
-        me->doTell(ch->getName(), format("%d) Your %s is missing! (%d talens)") %
+        me->doTell(ch, format("%d) Your %s is missing! (%d talens)") %
 		   ++count % ch->describeBodySlot(i) % limb_regen_price(ch, i, shop_nr));
         continue;
       } else {
@@ -282,19 +282,19 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
           if (1<<j == PART_BANDAGED)
             continue;
           if (ch->isLimbFlags(i, 1 << j)) {
-            me->doTell(ch->getName(), format("%d) Your %s is %s. (%d talens)") %
+            me->doTell(ch, format("%d) Your %s is %s. (%d talens)") %
 		       ++count % ch->describeBodySlot(i) % body_flags[j] %
 		       limb_wound_price(ch, i, 1 << j, shop_nr));
           }
         }
         if (ch->getCurLimbHealth(i) < ch->getMaxLimbHealth(i)) {
           double perc = (double) ch->getCurLimbHealth(i) / (double) ch->getMaxLimbHealth(i);
-          me->doTell(ch->getName(), format("%d) Your %s is %s. (%d talens)") %
+          me->doTell(ch, format("%d) Your %s is %s. (%d talens)") %
 		     ++count % ch->describeBodySlot(i) %
 		     LimbHealth(perc) % limb_heal_price(ch, i, shop_nr));
         }
         if ((stuck = ch->getStuckIn(i))) {
-          me->doTell(ch->getName(), format("%d) You have %s stuck in your %s. (%d talens)") % ++count % stuck->shortDescr % ch->describeBodySlot(i) % limb_expel_price(ch, i, shop_nr));
+          me->doTell(ch, format("%d) You have %s stuck in your %s. (%d talens)") % ++count % stuck->shortDescr % ch->describeBodySlot(i) % limb_expel_price(ch, i, shop_nr));
         }
       }
     }
@@ -303,23 +303,23 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       for (aff = ch->affected; aff; aff = aff->next) {
         if (aff->type == AFFECT_DISEASE) {
 	  if (ch->GetMaxLevel() < 12) {
-	    me->doTell(ch->getName(), "Hmm, you are just a newbie, guess I will have to take you at reduced rates.\n\r");
+	    me->doTell(ch, "Hmm, you are just a newbie, guess I will have to take you at reduced rates.\n\r");
 	  }
 	  buf=format("%d) You have %s. (%d talens)") %
 	    ++count % DiseaseInfo[affToDisease(*aff)].name %
 	    doctorCost(shop_nr, ch, affToDisease(*aff));
-	  me->doTell(ch->getName(), buf);
+	  me->doTell(ch, buf);
         } else if (aff->type == SPELL_BLINDNESS) {
           if (!aff->shouldGenerateText())
             continue;
-          me->doTell(ch->getName(), format("%d) Affect: %s. (%d talens).\n\r") %
+          me->doTell(ch, format("%d) Affect: %s. (%d talens).\n\r") %
                     ++count % discArray[aff->type]->name %
                     spell_regen_price(ch, SPELL_BLINDNESS, shop_nr));
 	}
       }  // affects loop
     }
     if (!count) {
-      me->doTell(ch->getName(), "I see nothing at all wrong with you!");
+      me->doTell(ch, "I see nothing at all wrong with you!");
     }
     return TRUE;
    /* Allow them to buy cures for their ailments. */
@@ -327,7 +327,7 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     for (; isspace(*arg); arg++);
 
     if (!*arg || !arg) {
-      me->doTell(ch->getName(), "What do you want to buy? Try listing to see what ails you!");
+      me->doTell(ch, "What do you want to buy? Try listing to see what ails you!");
       return TRUE;
     }
 
@@ -335,16 +335,16 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     // fight right next to him (or get him to hate you and follow you)
     // would create a *NICE* situation for the player
     if (ch->fight()) {
-      me->doTell(ch->getName(), "Come back when you aren't fighting.");
+      me->doTell(ch, "Come back when you aren't fighting.");
       return TRUE;
     }
     if (me->master == ch) {
-      me->doTell(ch->getName(), "Your money is no good here.");
+      me->doTell(ch, "Your money is no good here.");
       return TRUE;
     }
 
     if(!sstring(arg).isNumber()){
-      me->doTell(ch->getName(), "To buy a cure, type \"buy <number>\". Try listing to see what ails you!");
+      me->doTell(ch, "To buy a cure, type \"buy <number>\". Try listing to see what ails you!");
       return TRUE;
     }
     bought = convertTo<int>(arg);
@@ -357,17 +357,17 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       if (ch->isLimbFlags(i, PART_MISSING)) {
         if (++count == bought) {
           if ((ch->getMoney()) < (cost = limb_regen_price(ch, i, shop_nr))) {
-            me->doTell(ch->getName(), format("You don't have enough money to regenerate your %s!") % ch->describeBodySlot(i));
+            me->doTell(ch, format("You don't have enough money to regenerate your %s!") % ch->describeBodySlot(i));
             return TRUE;
           } else {
             if (!ch->limbConnections(i)) {
-              me->doTell(ch->getName(), format("You can't regenerate your %s until something else is regenerated first.") % ch->describeBodySlot(i));
+              me->doTell(ch, format("You can't regenerate your %s until something else is regenerated first.") % ch->describeBodySlot(i));
               return TRUE;
             }
             int cashCost = min(ch->getMoney(), cost);
 
 	    if(me->getMoney() < cashCost){
-	      me->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+	      me->doTell(ch, "I don't have enough money to cover my operating expenses!");
 	      return TRUE;
 	    }
 
@@ -401,13 +401,13 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
           if (ch->isLimbFlags(i, 1 << j)) {
             if (++count == bought) {
               if ((ch->getMoney()) < (cost = limb_wound_price(ch, i, 1 << j, shop_nr))) {
-                me->doTell(ch->getName(), "You don't have enough money to do that!");
+                me->doTell(ch, "You don't have enough money to do that!");
                 return TRUE;
               } else {
                 int cashCost = min(ch->getMoney(), cost);
 		
 		if(me->getMoney() < cashCost){
-		  me->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+		  me->doTell(ch, "I don't have enough money to cover my operating expenses!");
 		  return TRUE;
 		}
 
@@ -439,13 +439,13 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       if (ch->getCurLimbHealth(i) < ch->getMaxLimbHealth(i)) {
         if (++count == bought) {
           if ((ch->getMoney()) < (cost = limb_heal_price(ch, i, shop_nr))) {
-            me->doTell(ch->getName(), format("You don't have enough money to heal your %s!") % ch->describeBodySlot(i));
+            me->doTell(ch, format("You don't have enough money to heal your %s!") % ch->describeBodySlot(i));
             return TRUE;
           } else {
             int cashCost = min(ch->getMoney(), cost);
 
 	    if(me->getMoney() < cashCost){
-	      me->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+	      me->doTell(ch, "I don't have enough money to cover my operating expenses!");
 	      return TRUE;
 	    }
 
@@ -473,13 +473,13 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       if ((stuck = ch->getStuckIn(i))) {
         if (++count == bought) {
           if ((ch->getMoney()) < (cost = limb_expel_price(ch, i, shop_nr))) {
-            me->doTell(ch->getName(), format("You don't have enough money to expel %s from your %s!") % stuck->shortDescr % ch->describeBodySlot(i));
+            me->doTell(ch, format("You don't have enough money to expel %s from your %s!") % stuck->shortDescr % ch->describeBodySlot(i));
             return TRUE;
           } else {
             int cashCost = min(ch->getMoney(), cost);
 
 	    if(me->getMoney() < cashCost){
-	      me->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+	      me->doTell(ch, "I don't have enough money to cover my operating expenses!");
 	      return TRUE;
 	    }
 
@@ -515,13 +515,13 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
 	    cost = doctorCost(shop_nr, ch, affToDisease(*aff));
 
 	    if ((ch->getMoney()) < cost) {
-	      me->doTell(fname(ch->name), format("You don't have enough money to cure %s!") % DiseaseInfo[affToDisease(*aff)].name);
+	      me->doTell(ch, format("You don't have enough money to cure %s!") % DiseaseInfo[affToDisease(*aff)].name);
 	      return TRUE;
 	    } else {
 	      int cashCost = min(ch->getMoney(), cost);
 
 	      if(me->getMoney() < cashCost){
-		me->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+		me->doTell(ch, "I don't have enough money to cover my operating expenses!");
 		return TRUE;
 	      }
 
@@ -550,13 +550,13 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
             cost = spell_regen_price(ch, SPELL_BLINDNESS, shop_nr);
 
             if ((ch->getMoney()) < cost) {
-              me->doTell(fname(ch->name), format("You don't have enough money to cure %s!") % discArray[aff->type]->name);
+              me->doTell(ch, format("You don't have enough money to cure %s!") % discArray[aff->type]->name);
               return TRUE;
             } else {
               int cashCost = min(ch->getMoney(), cost);
 
 	      if(me->getMoney() < cashCost){
-		me->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+		me->doTell(ch, "I don't have enough money to cover my operating expenses!");
 		return TRUE;
 	      }
 
@@ -578,7 +578,7 @@ int doctor(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       }
     }
     if (!count) {
-      me->doTell(ch->getName(), " I see nothing at all wrong with you!");
+      me->doTell(ch, " I see nothing at all wrong with you!");
     }
     ch->doSave(SILENT_YES);
     return TRUE;
@@ -671,7 +671,7 @@ int healing_room(TBeing *, cmdTypeT cmd, const char *, TRoom *rp)
     }
 
     if(doctor->getMoney() < cost) {
-      doctor->doTell(healed->getName(), "I don't have enough money to cover my operating expenses!");
+      doctor->doTell(healed, "I don't have enough money to cover my operating expenses!");
       return TRUE;
     }
 
@@ -724,7 +724,7 @@ int emergency_room(TBeing *ch, cmdTypeT cmd, const char *arg, TRoom *rp)
     }
     
     if(doctor->getMoney() < cost){
-      doctor->doTell(ch->getName(), "I don't have enough money to cover my operating expenses!");
+      doctor->doTell(ch, "I don't have enough money to cover my operating expenses!");
       return TRUE;
     }
 

--- a/code/code/misc/mail.cc
+++ b/code/code/misc/mail.cc
@@ -116,13 +116,13 @@ void postmasterValue(TBeing *ch, TBeing *postmaster, const char *arg)
 
   if (is_abbrev(item, sstring("talens")) || is_abbrev(talen, sstring("talens")))
   {
-    postmaster->doTell(fname(ch->name), format("When sending talens, I charge an additional %d talens for handling fees.") % int((float)STAMP_PRICE * profit_buy * 2));
+    postmaster->doTell(ch, format("When sending talens, I charge an additional %d talens for handling fees.") % int((float)STAMP_PRICE * profit_buy * 2));
     return;
   }
 
   if(item == "faction")
   {
-    postmaster->doTell(fname(ch->name), format("Bulk faction mail from me will cost about %d talens.") % int((float)FACTION_STAMP_PRICE * profit_buy));
+    postmaster->doTell(ch, format("Bulk faction mail from me will cost about %d talens.") % int((float)FACTION_STAMP_PRICE * profit_buy));
     return;
   }
 
@@ -132,32 +132,32 @@ void postmasterValue(TBeing *ch, TBeing *postmaster, const char *arg)
     TObj *obj = thing ? dynamic_cast<TObj*>(thing) : NULL;
     if (obj == NULL)
     {
-      postmaster->doTell(fname(ch->name), "I don't see that item on you.");
+      postmaster->doTell(ch, "I don't see that item on you.");
       return;
     }
     int cost = int((float)STAMP_PRICE * profit_buy * (obj->getWeight() + 3));
     if (obj->isMonogrammed())
     {
-      postmaster->doTell(fname(ch->name), "This item appears to be monogrammed.  You may only mail it to its owner.");
+      postmaster->doTell(ch, "This item appears to be monogrammed.  You may only mail it to its owner.");
       cost = STAMP_PRICE;
     }
     if (!obj->canBeMailed(""))
     {
-      postmaster->doTell(fname(ch->name), "Sorry, I can't ship that.");
+      postmaster->doTell(ch, "Sorry, I can't ship that.");
       return;
     }
-    postmaster->doTell(fname(ch->name), format("Shipping %s will cost you %d talens.") % obj->getName() % cost);
+    postmaster->doTell(ch, format("Shipping %s will cost you %d talens.") % obj->getName() % cost);
     return;
   }
 
-  postmaster->doTell(fname(ch->name), format("My price for regular postage is %d talens.") % int((float)STAMP_PRICE * profit_buy));
+  postmaster->doTell(ch, format("My price for regular postage is %d talens.") % int((float)STAMP_PRICE * profit_buy));
 }
 
 
 int postmasterGiven(TBeing *ch, TMonster *me, TObj *o)
 {
   if (!o || o->objVnum() != Obj::GENERIC_L_TOKEN) {
-    me->doTell(ch->getName(), "What in the hells is this?!");
+    me->doTell(ch, "What in the hells is this?!");
     me->doGive(ch, o);
     return 0;
   }
@@ -168,7 +168,7 @@ int postmasterGiven(TBeing *ch, TMonster *me, TObj *o)
   sstring playerTag = "[link$" + nameLower + "$";
   size_t startTag = objName.find(playerTag);
   if (startTag == sstring::npos) {
-    me->doTell(ch->getName(), "Are you sure this is your token? It doesn't look right...");
+    me->doTell(ch, "Are you sure this is your token? It doesn't look right...");
     me->doGive(ch, o);
     return 0;
   }
@@ -198,8 +198,8 @@ int postmasterGiven(TBeing *ch, TMonster *me, TObj *o)
     objName.replace(dueTag+1, endTag-dueTag-1, dueDate.c_str(), dueDate.length());
     o->name = objName;
 
-    me->doTell(ch->getName(), "It appears your belongings are arriving via magical transport in ten minutes.");
-    me->doTell(ch->getName(), "In the meantime, hold on to this token and give it to me when your package has arrived.");
+    me->doTell(ch, "It appears your belongings are arriving via magical transport in ten minutes.");
+    me->doTell(ch, "In the meantime, hold on to this token and give it to me when your package has arrived.");
     me->doGive(ch, o);
     ch->doQueueSave();
 
@@ -212,8 +212,8 @@ int postmasterGiven(TBeing *ch, TMonster *me, TObj *o)
     int minutes = ct / 60;
     int seconds = ct % 60;
 
-    me->doTell(ch->getName(), "Sorry, your object hasn't materialized from voidspace yet.");
-    me->doTell(ch->getName(), format("It looks like it won't be ready for another %i minutes and %i seconds.") % minutes % seconds);
+    me->doTell(ch, "Sorry, your object hasn't materialized from voidspace yet.");
+    me->doTell(ch, format("It looks like it won't be ready for another %i minutes and %i seconds.") % minutes % seconds);
     me->doGive(ch, o);
 
     return 0;
@@ -237,7 +237,7 @@ int postmasterGiven(TBeing *ch, TMonster *me, TObj *o)
       linkbag = stored;
     }
     if (!linkbag) {
-      me->doTell(ch->getName(), "Well that's strange; you don't have a linkbag.  Use the 'report' command for help.");
+      me->doTell(ch, "Well that's strange; you don't have a linkbag.  Use the 'report' command for help.");
       me->doGive(ch, o); 
       ch->doQueueSave();
       return 0;
@@ -249,8 +249,8 @@ int postmasterGiven(TBeing *ch, TMonster *me, TObj *o)
     linkbag->obj_flags.decay_time = MAX_PC_CORPSE_EQUIPPED_TIME;
     linkbag->obj_flags.wear_flags &= ~ITEM_TAKE;
 
-    me->doTell(ch->getName(), "Great!  It looks like your things are ready.");
-    me->doTell(ch->getName(), "I'll just drop them here in the room.  Please take out your items and clean up.");
+    me->doTell(ch, "Great!  It looks like your things are ready.");
+    me->doTell(ch, "I'll just drop them here in the room.  Please take out your items and clean up.");
     ch->doQueueSave();
 
     return DELETE_ITEM;

--- a/code/code/misc/meeting.cc
+++ b/code/code/misc/meeting.cc
@@ -72,9 +72,9 @@ static bool checkForSay(TBeing *ch, TMonster *myself, cmdTypeT cmd, const char *
     arg += strlen(ORGANIZER_ID);
     if (!strncasecmp(arg, " show list", 10)) {
       sstring tmpString;
-      myself->doTell(fname(ch->name), "The current speaker list:");
+      myself->doTell(ch, "The current speaker list:");
       if (job->speech_list.empty()) {
-        myself->doTell(fname(ch->name), "Empty");
+        myself->doTell(ch, "Empty");
       } else {
         unsigned int i;
         tmpString += "";
@@ -82,15 +82,15 @@ static bool checkForSay(TBeing *ch, TMonster *myself, cmdTypeT cmd, const char *
           tmpString += job->speech_list[i];
           tmpString += " ";
         }
-        myself->doTell(fname(ch->name), tmpString);
+        myself->doTell(ch, tmpString);
       }
       if (job->speech_dur > 0) {
-        myself->doTell(fname(ch->name), format("Speech time is restricted to %d seconds.") % job->speech_dur);
+        myself->doTell(ch, format("Speech time is restricted to %d seconds.") % job->speech_dur);
         if (!job->speech_list.empty()) {
-          myself->doTell(fname(ch->name), format("%s has %ld seconds remaining.") % job->speech_list[0] % (job->speech_dur +job->start_time - time(0)));
+          myself->doTell(ch, format("%s has %ld seconds remaining.") % job->speech_list[0] % (job->speech_dur +job->start_time - time(0)));
         }
       } else {
-        myself->doTell(fname(ch->name), "Speech time is unrestricted.");
+        myself->doTell(ch, "Speech time is unrestricted.");
       }
       *rc = true;
       return true;
@@ -99,7 +99,7 @@ static bool checkForSay(TBeing *ch, TMonster *myself, cmdTypeT cmd, const char *
         unsigned int i;
         for (i = 0; i < job->speech_list.size(); i++) {
           if (ch->name == job->speech_list[i]){
-            myself->doTell(fname(ch->name), "You are already in the speaker list.");
+            myself->doTell(ch, "You are already in the speaker list.");
             *rc = true;
             return true;
           }
@@ -111,7 +111,7 @@ static bool checkForSay(TBeing *ch, TMonster *myself, cmdTypeT cmd, const char *
       }
 
       job->speech_list.push_back(ch->name);
-      myself->doTell(fname(ch->name), "You have been added as a speaker.");
+      myself->doTell(ch, "You have been added as a speaker.");
 
       // start the cpounter if we just launched
       if (job->speech_list.size() == 1)
@@ -282,7 +282,7 @@ int meeting_organizer(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *mysel
     // silly bastards that aliased emote to work like a say should be shot
     // it screws up meeting logs, so deny such activity
     
-    myself->doTell(fname(ch->name), "Emotting is disabled at the moment.");
+    myself->doTell(ch, "Emotting is disabled at the moment.");
     return TRUE;
   }
 
@@ -352,18 +352,18 @@ int meeting_organizer(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *mysel
     }
   }
 
-  myself->doTell(fname(ch->name), "To maintain order at the meeting, you are restricted to the following commands:");
-  myself->doTell(fname(ch->name), "movement, utility, NOD, SHAKE, AGREE, DISAGREE");
-  myself->doTell(fname(ch->name), format("To be added to the speaker list : say %s add me") % ORGANIZER_ID);
-  myself->doTell(fname(ch->name), format("To review the speaker list : say %s show list") % ORGANIZER_ID);
-  myself->doTell(fname(ch->name), format("To relinquish the speaker position : say %s done") % ORGANIZER_ID);
+  myself->doTell(ch, "To maintain order at the meeting, you are restricted to the following commands:");
+  myself->doTell(ch, "movement, utility, NOD, SHAKE, AGREE, DISAGREE");
+  myself->doTell(ch, format("To be added to the speaker list : say %s add me") % ORGANIZER_ID);
+  myself->doTell(ch, format("To review the speaker list : say %s show list") % ORGANIZER_ID);
+  myself->doTell(ch, format("To relinquish the speaker position : say %s done") % ORGANIZER_ID);
 
   if (ch->GetMaxLevel() > MAX_MORT) {
-    myself->doTell(fname(ch->name), format("To pause/restart the speaker clock : say %s pause") % ORGANIZER_ID);
-    myself->doTell(fname(ch->name), format("To open/close debate to all : say %s open_debate") % ORGANIZER_ID);
-    myself->doTell(fname(ch->name), format("To set the speech time : say %s speech_time <seconds>") % ORGANIZER_ID);
-    myself->doTell(fname(ch->name), format("To clear the speaker list : say %s clear") % ORGANIZER_ID);
-    myself->doTell(fname(ch->name), format("To log/unlog the meeting : say %s log") % ORGANIZER_ID);
+    myself->doTell(ch, format("To pause/restart the speaker clock : say %s pause") % ORGANIZER_ID);
+    myself->doTell(ch, format("To open/close debate to all : say %s open_debate") % ORGANIZER_ID);
+    myself->doTell(ch, format("To set the speech time : say %s speech_time <seconds>") % ORGANIZER_ID);
+    myself->doTell(ch, format("To clear the speaker list : say %s clear") % ORGANIZER_ID);
+    myself->doTell(ch, format("To log/unlog the meeting : say %s log") % ORGANIZER_ID);
   }
 
   return TRUE;

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -2290,7 +2290,7 @@ sstring add_bars(const sstring &s){
 // returns DELETE_THIS, DELETE_VICT, TRUE or FALSE
 int TBeing::triggerSpecialOnPerson(TThing *ch, cmdTypeT cmd, const sstring &argument)
 {
-  char *arg = argument.c_str()
+  const char *arg = argument.c_str();
   wearSlotT j;
   int rc;
   TThing *t;

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -2288,8 +2288,9 @@ sstring add_bars(const sstring &s){
 
 
 // returns DELETE_THIS, DELETE_VICT, TRUE or FALSE
-int TBeing::triggerSpecialOnPerson(TThing *ch, cmdTypeT cmd, const char *arg)
+int TBeing::triggerSpecialOnPerson(TThing *ch, cmdTypeT cmd, const sstring &argument)
 {
+  char *arg = argument.c_str()
   wearSlotT j;
   int rc;
   TThing *t;

--- a/code/code/misc/rent.cc
+++ b/code/code/misc/rent.cc
@@ -2215,7 +2215,7 @@ void charge_rent_tax(TBeing *ch, TMonster *recep, int shop_nr)
     return;
 
   sstring msg = shop_index[shop_nr].message_buy;
-  recep->doTell(ch->getName(), format(msg) % tax);
+  recep->doTell(ch, format(msg) % tax);
 
   TShopOwned tso(shop_nr, recep, ch);
   tso.doBuyTransaction(tax, "rent tax", TX_BUYING_SERVICE);
@@ -2349,7 +2349,7 @@ int receptionist(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *recep, TOb
     recep->doAction(fname(ch->name), CMD_GROWL);
 
     if (!tStString.empty())
-      recep->doTell(ch->getNameNOC(ch), tStString);
+      recep->doTell(ch, tStString);
 
     for (dir = MIN_DIR; dir < MAX_DIR; dir++) {
       if (exit_ok(exitp = recep->exitDir(dir), NULL)) {

--- a/code/code/misc/repair.cc
+++ b/code/code/misc/repair.cc
@@ -411,8 +411,8 @@ static int getRepairItem(TBeing *repair, TBeing *buyer, int ticket, TNote *obj)
     minutes = (diff % 3600)/60;
     seconds = diff % 60;
 
-    repair->doTell(fname(buyer->name), "Your item isn't ready yet.");
-    repair->doTell(fname(buyer->getName()),  format("It will be ready in %d hours, %d minutes and %d seconds.") % hours % minutes % seconds);
+    repair->doTell(buyer, "Your item isn't ready yet.");
+    repair->doTell(buyer,  format("It will be ready in %d hours, %d minutes and %d seconds.") % hours % minutes % seconds);
     delete fixed_obj;
     return FALSE;
   }
@@ -434,7 +434,7 @@ static int getRepairItem(TBeing *repair, TBeing *buyer, int ticket, TNote *obj)
 
   unlink(((sstring)(format("mobdata/repairs/%d/%d") % repair->mobVnum() % ticket)).c_str());
 
-  repair->doTell(fname(buyer->name), format("Ah yes, %s, here is %s.") %
+  repair->doTell(buyer, format("Ah yes, %s, here is %s.") %
 		 buyer->getName() % fixed_obj->shortDescr);
   repair->doSay("Thank you for your business!");
 
@@ -466,14 +466,14 @@ static bool will_not_repair(TBeing *ch, TMonster *repair, TObj *obj, silentTypeT
 
   if (!obj->isRentable()) {
     if (!silent) {
-      repair->doTell(fname(ch->name), 
+      repair->doTell(ch, 
 		     "I'm sorry, but that item is unrepairable.");
     }
     return TRUE;
   }
   if (obj->getStructPoints() == obj->getMaxStructPoints()) {
     if (!silent) {
-      repair->doTell(fname(ch->name), 
+      repair->doTell(ch, 
 		     "It doesn't look like that item needs any repairing.");
     }
     return TRUE;
@@ -481,7 +481,7 @@ static bool will_not_repair(TBeing *ch, TMonster *repair, TObj *obj, silentTypeT
   if (obj->getStructPoints() >= obj->maxFix(NULL, DEPRECIATION_NO)) {
     // check depreciation alone
     if (!silent) {
-      repair->doTell(fname(ch->name), 
+      repair->doTell(ch, 
 		 "That item's damage isn't something that can be repaired.");
     }
     return TRUE;
@@ -489,21 +489,21 @@ static bool will_not_repair(TBeing *ch, TMonster *repair, TObj *obj, silentTypeT
   if (obj->getStructPoints() >= obj->maxFix(repair, DEPRECIATION_NO)) {
     // check repairman's skill
     if (!silent) {
-      repair->doTell(fname(ch->name), "I hate to admit it, but I don't think I have the skill to fix that further.");
+      repair->doTell(ch, "I hate to admit it, but I don't think I have the skill to fix that further.");
     }
     return TRUE;
   } 
   if (!repair_time(repair, obj)) {
     // probably superfluous
     if (!silent) {
-      repair->doTell(fname(ch->name), format("%s looks fine to me.") % 
+      repair->doTell(ch, format("%s looks fine to me.") % 
 		     obj->getName());
     }
     return TRUE;
   }
   if (obj->objVnum() == -1) {
     if (!silent) {
-      repair->doTell(fname(ch->name), 
+      repair->doTell(ch, 
 		     format("I can't take temporary items like %s.") % 
 		     obj->getName());
     }
@@ -511,24 +511,24 @@ static bool will_not_repair(TBeing *ch, TMonster *repair, TObj *obj, silentTypeT
   }
   if (obj->isObjStat(ITEM_NODROP)) {
     if (!silent) {
-      repair->doTell(fname(ch->name), "I can't take cursed items.");
+      repair->doTell(ch, "I can't take cursed items.");
     }
     return TRUE;
   }
   if (obj->isObjStat(ITEM_BURNING)) {
     if (!silent) {
-      repair->doTell(fname(ch->name), "HOLY CRAP GET THAT THING OUT OF HERE BEFORE YOU BURN THE WHOLE PLACE DOWN!.");
+      repair->doTell(ch, "HOLY CRAP GET THAT THING OUT OF HERE BEFORE YOU BURN THE WHOLE PLACE DOWN!.");
     }
     return TRUE;
   }
   if (obj->isObjStat(ITEM_CHARRED)) {
     if (!silent) {
-      repair->doTell(fname(ch->name), "I can repair this, but it is very badly fire-damaged.");
+      repair->doTell(ch, "I can repair this, but it is very badly fire-damaged.");
     }
   }
   if (obj->isObjStat(ITEM_RUSTY)){
     if(!silent){
-      repair->doTell(fname(ch->name), "This is a little rusty, but I can polish it up.");
+      repair->doTell(ch, "This is a little rusty, but I can polish it up.");
     }
   }
   if (obj_index[obj->getItemIndex()].getNumber() > 
@@ -536,7 +536,7 @@ static bool will_not_repair(TBeing *ch, TMonster *repair, TObj *obj, silentTypeT
     // item over max-exist, never supposed to happen, but could
     // make it unrepairable to encourage it to scrap
     if (!silent) {
-      repair->doTell(fname(ch->name), "Someone has put out a contract to reclaim that item.  It's just too dangerous for me to take it.");
+      repair->doTell(ch, "Someone has put out a contract to reclaim that item.  It's just too dangerous for me to take it.");
     }
 
     return TRUE;
@@ -545,7 +545,7 @@ static bool will_not_repair(TBeing *ch, TMonster *repair, TObj *obj, silentTypeT
   if (!obj->stuff.empty()) {
     // probably a mage-belt with components in it....
     if (!silent) {
-      repair->doTell(fname(ch->name), "Sorry, you'll have to empty it out before I can do any work on it.");
+      repair->doTell(ch, "Sorry, you'll have to empty it out before I can do any work on it.");
     }
     return TRUE;
   }
@@ -566,7 +566,7 @@ void repairman_value(const char *arg, TMonster *repair, TBeing *buyer)
   for (;*arg && *arg == ' ';arg++);
 
   if (!*arg) {
-    repair->doTell(fname(buyer->name), "Can you be a little more specific about what you want to value....\n\r");
+    repair->doTell(buyer, "Can you be a little more specific about what you want to value....\n\r");
     return;
   }
 
@@ -581,12 +581,12 @@ void repairman_value(const char *arg, TMonster *repair, TBeing *buyer)
           int matCost = 0;
           int repairCost = valued->repairPrice(repair, buyer, DEPRECIATION_NO, false, &matCost);
           const char* plural = matCost != 1 ? "s" : "";
-          repair->doTell(fname(buyer->name),
+          repair->doTell(buyer,
                          format("It'll cost you %d talens to repair %s to a status of %s.") %
                          repairCost %
                          valued->getName() %
                          valued->equip_condition(valued->maxFix(repair, DEPRECIATION_NO)));
-          repair->doTell(fname(buyer->name),
+          repair->doTell(buyer,
                          format("%d talen%s of that cost is for raw materials.") %
                          matCost %
                          plural);
@@ -596,9 +596,9 @@ void repairman_value(const char *arg, TMonster *repair, TBeing *buyer)
     }
 
     if (!iCostForAll)
-      repair->doTell(fname(buyer->name), format("%s, You don't have anything I can repair in your inventory...") % buyer->getName());
+      repair->doTell(buyer, format("%s, You don't have anything I can repair in your inventory...") % buyer->getName());
     else
-      repair->doTell(fname(buyer->name), format("It will cost a total of %d talens to repair all the listed items.") % iCostForAll);
+      repair->doTell(buyer, format("It will cost a total of %d talens to repair all the listed items.") % iCostForAll);
 
     return;
   }
@@ -606,7 +606,7 @@ void repairman_value(const char *arg, TMonster *repair, TBeing *buyer)
   TThing *t_valued = searchLinkedListVis(buyer, arg, buyer->stuff);
   valued = dynamic_cast<TObj *>(t_valued);
   if (!valued) {
-    repair->doTell(fname(buyer->name), 
+    repair->doTell(buyer, 
 		   format("%s, You don't have that item.\n\r") % 
 		   buyer->getName());
     return;
@@ -617,12 +617,12 @@ void repairman_value(const char *arg, TMonster *repair, TBeing *buyer)
   int singleMatCost = 0;
   int singleRepairCost = valued->repairPrice(repair, buyer, DEPRECIATION_NO, false, &singleMatCost);
   const char* costPlural = singleMatCost != 1 ? "s" : "";
-  repair->doTell(fname(buyer->name),
+  repair->doTell(buyer,
                  format("It'll cost you %d talens to repair %s to a status of %s.") %
                  singleRepairCost %
                  valued->getName() %
                  valued->equip_condition(valued->maxFix(repair, DEPRECIATION_NO)));
-  repair->doTell(fname(buyer->name),
+  repair->doTell(buyer,
                  format("%d talen%s of that cost is for raw materials.") %
                  singleMatCost %
                  costPlural);
@@ -630,8 +630,8 @@ void repairman_value(const char *arg, TMonster *repair, TBeing *buyer)
   when_ready = ct + repair_time(repair, valued);
   ready = asctime(localtime(&when_ready));
   ready[19] = '\0'; // remove the year
-  repair->doTell(fname(buyer->name), format("I can have it ready by %s.") % ready);
-  repair->doTell(fname(buyer->name), format("That's %s.") % secsToString(when_ready-ct));
+  repair->doTell(buyer, format("I can have it ready by %s.") % ready);
+  repair->doTell(buyer, format("That's %s.") % secsToString(when_ready-ct));
 }
 
 // returns DELETE_THIS if buyer goes poof
@@ -718,7 +718,7 @@ int repairman_give(const char *arg, TMonster *repair, TBeing *buyer)
   t = searchLinkedListVis(buyer, obj_name, buyer->stuff);
   TObj *tobj = dynamic_cast<TObj *>(t);
   if (!tobj) {
-    repair->doTell(fname(buyer->name), "You don't have that item.");
+    repair->doTell(buyer, "You don't have that item.");
     return FALSE;
   }
   int rc5;
@@ -763,17 +763,17 @@ void TObj::giveToRepair(TMonster *repair, TBeing *buyer, int *found)
   if (will_not_repair(buyer, repair, this, SILENT_NO))
     return;
 
-  repair->doTell(fname(buyer->name), format("It'll cost you %d talens to repair %s to a status of %s.") % (repairPrice(repair, buyer, DEPRECIATION_YES, false, NULL)) % getName() % equip_condition(maxFix(repair, DEPRECIATION_YES)));
+  repair->doTell(buyer, format("It'll cost you %d talens to repair %s to a status of %s.") % (repairPrice(repair, buyer, DEPRECIATION_YES, false, NULL)) % getName() % equip_condition(maxFix(repair, DEPRECIATION_YES)));
 
   when_ready = ct + repair_time(repair, this);
   ready = asctime(localtime(&when_ready));
   ready[19] = '\0'; // remove the year
-  repair->doTell(fname(buyer->name), format("It will be ready %s.") % ready);
-  repair->doTell( fname(buyer->name), format("That's %s.") % secsToString(when_ready-ct));
+  repair->doTell(buyer, format("It will be ready %s.") % ready);
+  repair->doTell(buyer, format("That's %s.") % secsToString(when_ready-ct));
   repair_number++;
-  repair->doTell(fname(buyer->name), "Payment is due when you pick your item up.");
-  repair->doTell(fname(buyer->name), format("Here is your ticket, %s") % buyer->getName());
-  repair->doTell(fname(buyer->name), "If you lose the ticket, it might be hard to reclaim your item.");
+  repair->doTell(buyer, "Payment is due when you pick your item up.");
+  repair->doTell(buyer, format("Here is your ticket, %s") % buyer->getName());
+  repair->doTell(buyer, "If you lose the ticket, it might be hard to reclaim your item.");
   ticket = make_ticket(repair, buyer, this, when_ready, repair_number);
   *buyer += *ticket;
   save_repairman_file(repair, buyer, this, when_ready, repair_number);
@@ -821,16 +821,16 @@ void TNote::giveToRepairNote(TMonster *repair, TBeing *buyer, int *found)
   *found = TRUE;
 
   if (action_description.empty()) {
-    repair->doTell(fname(buyer->name), "That ticket is blank!");
+    repair->doTell(buyer, "That ticket is blank!");
     return;
   }
   if (getRepairman() != mob_index[repair->getMobIndex()].virt) {
-    repair->doTell(fname(buyer->name), "That isn't one of my tickets!");
+    repair->doTell(buyer, "That isn't one of my tickets!");
     return;
   }
   strcpy(buf, getName().c_str());
   if (sscanf(buf, "a small ticket marked number %d", &iNumber) != 1) {
-    repair->doTell(fname(buyer->name), "That ticket isn't from THIS shop!");
+    repair->doTell(buyer, "That ticket isn't from THIS shop!");
   } else {
     if (getRepairItem(repair, buyer, iNumber, this)) {
       *found = DELETE_THIS;

--- a/code/code/misc/shop.cc
+++ b/code/code/misc/shop.cc
@@ -524,7 +524,7 @@ void shopping_buy(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
 
   argm = sstring(arg).trim();
   if (argm.empty()) {
-    keeper->doTell(ch->name, "What do you want to buy??");
+    keeper->doTell(ch, "What do you want to buy??");
     return;
   }
   if ((num = getabunch(argm.c_str(), newarg)))
@@ -567,12 +567,12 @@ void shopping_buy(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
   }
 
   if(!temp1){
-    keeper->doTell(ch->name, shop_index[shop_nr].no_such_item1);
+    keeper->doTell(ch, shop_index[shop_nr].no_such_item1);
     return;
   }
 
   if (temp1->getValue() <= 0) {
-    keeper->doTell(ch->name, shop_index[shop_nr].no_such_item1);
+    keeper->doTell(ch, shop_index[shop_nr].no_such_item1);
     delete temp1;
     temp1 = NULL;
     return;
@@ -631,7 +631,7 @@ int TObj::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
   
   tmp = number_objects_in_list(this, keeper->stuff);
   if (num > tmp) {
-    keeper->doTell(ch->name, format("I don't have %d of that item. Here %s the %d I do have.") %
+    keeper->doTell(ch, format("I don't have %d of that item. Here %s the %d I do have.") %
 		   num  % ((tmp > 1) ? "are" : "is") % tmp);
   } else
     tmp = num;
@@ -650,7 +650,7 @@ int TObj::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
     TObj *temp1 = dynamic_cast<TObj *>(t_temp1);
       
     if ((ch->getMoney() < cost) && !ch->hasWizPower(POWER_GOD)) {
-      keeper->doTell(ch->name, shop_index[shop_nr].missing_cash2);
+      keeper->doTell(ch, shop_index[shop_nr].missing_cash2);
 	
       switch (shop_index[shop_nr].temper1) {
 	case 0:
@@ -679,12 +679,12 @@ int TObj::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
   keeper->saveItems(shop_nr);
 
   if (!count) {
-    keeper->doTell(ch->name, "I can't seem to find any of those!");
+    keeper->doTell(ch, "I can't seem to find any of those!");
     return -1;
   }
 
   //  ch->sendTo(format("You manage to swindle the shopkeeper into a %i%s discount.\n\r") % (int)(swindle*100) % "%");
-  keeper->doTell(ch->name, format(shop_index[shop_nr].message_buy) %
+  keeper->doTell(ch, format(shop_index[shop_nr].message_buy) %
 		 (cost * count));
 
   ch->sendTo(COLOR_OBJECTS, format("You now have %s (*%d).\n\r") % 
@@ -706,37 +706,37 @@ bool will_not_buy(TBeing *ch, TMonster *keeper, TObj *temp1, int shop_nr)
 
   if(temp1->objectSell(ch, keeper)){
     if(ch->isImmortal())
-      keeper->doTell(ch->getName(), "Since you're immortal, I'll make an exception.");
+      keeper->doTell(ch, "Since you're immortal, I'll make an exception.");
     else 
       return TRUE;
   }
   if(Config::NoDamagedItemsShop()){
     if (temp1->getStructPoints() != temp1->getMaxStructPoints()) {
-      keeper->doTell(ch->getName(), "I don't buy damaged goods.");
+      keeper->doTell(ch, "I don't buy damaged goods.");
       return TRUE;
     }
   }
 
   if (!temp1->stuff.empty()) {
-    keeper->doTell(ch->getName(), "Sorry, I don't buy items that contain other items.");
+    keeper->doTell(ch, "Sorry, I don't buy items that contain other items.");
     return TRUE;
   }
   // Notes have been denied by objectSell() above
   if (!temp1->action_description.empty()) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy monogrammed goods.");
+    keeper->doTell(ch, "I'm sorry, I don't buy monogrammed goods.");
     return TRUE;
   }
   if(temp1->isObjStat(ITEM_BURNING) || temp1->isObjStat(ITEM_CHARRED)){
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy fire damaged goods.");
+    keeper->doTell(ch, "I'm sorry, I don't buy fire damaged goods.");
     return TRUE;
   }
   if(temp1->isObjStat(ITEM_RUSTY)){
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy rusty goods.");
+    keeper->doTell(ch, "I'm sorry, I don't buy rusty goods.");
     return TRUE;
   }
 
   if (shop_index[shop_nr].isOwned() && temp1->isObjStat(ITEM_NORENT)){
-    keeper->doTell(ch->getName(), "This shop is privately owned and we don't purchase non-rentable items.");
+    keeper->doTell(ch, "This shop is privately owned and we don't purchase non-rentable items.");
     return TRUE;
   }
 
@@ -744,12 +744,12 @@ bool will_not_buy(TBeing *ch, TMonster *keeper, TObj *temp1, int shop_nr)
     return FALSE;
 
   if(temp1->sellPrice(1, shop_nr, -1, ch) < 0){
-    keeper->doTell(ch->getName(), "You'd have to pay me to buy that!");
+    keeper->doTell(ch, "You'd have to pay me to buy that!");
     return TRUE;
   }
 
   if(shop_index[shop_nr].getInventoryCount() >= (int)MAX_SHOP_INVENTORY){
-    keeper->doTell(ch->getName(), "My inventory is full, I can't buy anything!");
+    keeper->doTell(ch, "My inventory is full, I can't buy anything!");
     return TRUE;
   }
 
@@ -774,14 +774,14 @@ bool TObj::sellMeCheck(TBeing *ch, TMonster *keeper, int, int defaultMax) const
   int max_num=tso.getMaxNum(ch, this, defaultMax);
 
   if(max_num == 0){
-    keeper->doTell(ch->name, "I don't wish to buy any of those right now.");
+    keeper->doTell(ch, "I don't wish to buy any of those right now.");
     return TRUE;
   }
 
   total=tso.getInventoryCount(this);
 
   if (total >= max_num && !shop_index[shop_nr].isProducing(this)) {
-    keeper->doTell(ch->name, "I already have plenty of those.");
+    keeper->doTell(ch, "I already have plenty of those.");
     return TRUE;
   }
 
@@ -801,7 +801,7 @@ void generic_num_sell(TBeing *ch, TMonster *keeper, TObj *obj, int shop_nr, int 
     return;
   }
   if (!shop_index[shop_nr].willBuy(obj)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
   if (will_not_buy(ch, keeper, obj, shop_nr)) 
@@ -833,7 +833,7 @@ void generic_sell(TBeing *ch, TMonster *keeper, TObj *obj, int shop_nr)
     return;
   }
   if (!shop_index[shop_nr].willBuy(obj)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
   if (will_not_buy(ch, keeper, obj, shop_nr)) 
@@ -860,13 +860,13 @@ int TObj::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
   float chr;
 
   if (!shop_index[shop_nr].profit_sell) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return false;
   }
   
   
   if (getValue() <= 1 || isObjStat(ITEM_NEWBIE)) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy valueless items.");
+    keeper->doTell(ch, "I'm sorry, I don't buy valueless items.");
     return false;
   }
   if (sellMeCheck(ch, keeper, num, 9))
@@ -884,21 +884,21 @@ int TObj::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
       cost /= getMaxStructPoints();
     }
     if(Config::NoDamagedItemsShop()){
-      keeper->doTell(fname(ch->name), "It's been damaged, but I guess I can buy it as scrap.");
+      keeper->doTell(ch, "It's been damaged, but I guess I can buy it as scrap.");
     }
   }
   max(cost, 1);   // at least 1 talen 
   if (keeper->getMoney() < cost) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].missing_cash1);
+    keeper->doTell(ch, shop_index[shop_nr].missing_cash1);
     return false;
   }
   if (obj_index[getItemIndex()].max_exist <= 10) {
-    keeper->doTell(ch->name, "Wow!  This is one of those limited items.");
-    keeper->doTell(ch->name, "You should really think about auctioning it.");
+    keeper->doTell(ch, "Wow!  This is one of those limited items.");
+    keeper->doTell(ch, "You should really think about auctioning it.");
   }
   act("$n sells $p.", FALSE, ch, this, 0, TO_ROOM);
 
-  keeper->doTell(ch->getName(), format(shop_index[shop_nr].message_sell)% cost);
+  keeper->doTell(ch, format(shop_index[shop_nr].message_sell)% cost);
 
   ch->sendTo(COLOR_OBJECTS, format("The shopkeeper now has %s.\n\r") % sstring(getName()).uncap());
   ch->logItem(this, CMD_SELL);
@@ -1102,7 +1102,7 @@ int shopping_sell(const char *tString, TBeing *ch, TMonster *tKeeper, int shop_n
   strcpy(argm, tString);
 
   if (!*argm) {
-    tKeeper->doTell(ch->getName(), "What do you want to sell??");
+    tKeeper->doTell(ch, "What do you want to sell??");
     return FALSE;
   }
 
@@ -1125,7 +1125,7 @@ int shopping_sell(const char *tString, TBeing *ch, TMonster *tKeeper, int shop_n
     tObjectManip = ObjectManipType(argm, tStString, tItemType);
 
     if (tObjectManip == OBJMAN_NULL) {
-        tKeeper->doTell(ch->getName(), "And what is it you want to sell??");
+        tKeeper->doTell(ch, "And what is it you want to sell??");
     }
 
     if (tObjectManip != OBJMAN_NONE)
@@ -1286,7 +1286,7 @@ int shopping_sell(const char *tString, TBeing *ch, TMonster *tKeeper, int shop_n
   TComponent *temp2 = dynamic_cast<TComponent *>(temp1);
 
   if (!temp1) {
-    tKeeper->doTell(ch->getName(), shop_index[shop_nr].no_such_item2);
+    tKeeper->doTell(ch, shop_index[shop_nr].no_such_item2);
     return FALSE;
   }
   if (temp2) {
@@ -1311,7 +1311,7 @@ void shopping_value(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
   strcpy(argm, arg);
 
   if (!*argm) {
-    keeper->doTell(ch->name, "What do you want me to evaluate??");
+    keeper->doTell(ch, "What do you want me to evaluate??");
     return;
   }
   
@@ -1355,11 +1355,11 @@ void shopping_value(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
   TThing *t_temp1 = searchLinkedListVis(ch, argm, ch->stuff);
   temp1 = dynamic_cast<TObj *>(t_temp1);
   if (!temp1) {
-    keeper->doTell(ch->name, shop_index[shop_nr].no_such_item2);
+    keeper->doTell(ch, shop_index[shop_nr].no_such_item2);
     return;
   }
   if (!(shop_index[shop_nr].willBuy(temp1))) {
-    keeper->doTell(ch->name, shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
   if (will_not_buy(ch, keeper, temp1, shop_nr)) 
@@ -1384,7 +1384,7 @@ void TObj::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
   willbuy=!sellMeCheck(ch, keeper, num, 9);
 
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
 
@@ -1396,8 +1396,8 @@ void TObj::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
   cost = sellPrice(1, shop_nr, chr, ch);
 
   if (obj_index[getItemIndex()].max_exist <= 10) {
-    keeper->doTell(ch->name, "Wow!  This is one of those limited items.");
-    keeper->doTell(ch->name, "You should really think about auctioning it.");
+    keeper->doTell(ch, "Wow!  This is one of those limited items.");
+    keeper->doTell(ch, "You should really think about auctioning it.");
   }
 
   if ((getStructPoints() != getMaxStructPoints()) &&
@@ -1407,7 +1407,7 @@ void TObj::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
     cost *= getStructPoints();
     cost /= getMaxStructPoints();
     if(Config::NoDamagedItemsShop()){
-      keeper->doTell(fname(ch->name), "It's been damaged, but I guess I can buy it as scrap.");
+      keeper->doTell(ch, "It's been damaged, but I guess I can buy it as scrap.");
     }
 
   }
@@ -1417,10 +1417,10 @@ void TObj::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
   } else {
     buf = format("Normally, I'd give you %d talens for %s!") % cost % getName();
   }
-  keeper->doTell(ch->name, buf);
+  keeper->doTell(ch, buf);
 
   if (keeper->getMoney() < cost) {
-    keeper->doTell(fname(ch->name), "Unfortunately, at the moment, I can not afford to buy that item from you.");
+    keeper->doTell(ch, "Unfortunately, at the moment, I can not afford to buy that item from you.");
     return;
   }
 }
@@ -1803,7 +1803,7 @@ void shopping_list(sstring argument, TBeing *ch, TMonster *keeper, int shop_nr)
 	   shop_nr,
 	   buf.c_str());
 
-  keeper->doTell(ch->getName(), "You can buy:");
+  keeper->doTell(ch, "You can buy:");
 
   buf="Item #     Item Name                                Info       Number     Price\n\r";
   buf+="-------------------------------------------------------------------------------\n\r";
@@ -2140,10 +2140,10 @@ void shopping_kill(const char *, TBeing *ch, TBeing *keeper, int shop_nr)
 
   switch (shop_index[shop_nr].temper2) {
     case 0:
-      keeper->doTell(ch->name, "Don't ever try that again!");
+      keeper->doTell(ch, "Don't ever try that again!");
       return;
     case 1:
-      keeper->doTell(ch->name, "Scram - midget!");
+      keeper->doTell(ch, "Scram - midget!");
       return;
 
     default:
@@ -2368,7 +2368,7 @@ int shop_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, TOb
   if ((cmd == CMD_CAST) || (cmd == CMD_RECITE) || 
       (cmd == CMD_USE) || (cmd == CMD_PRAY)) {
     if (myself->canSee(ch)) {
-      myself->doTell(ch->getNameNOC(ch), "<r>No magic here - kid!<z>");
+      myself->doTell(ch, "<r>No magic here - kid!<z>");
     } else
       act("I may not be able to see you kid, but there is no magic in here.",
           FALSE, ch, 0, myself, TO_CHAR);

--- a/code/code/misc/shopaccounting.cc
+++ b/code/code/misc/shopaccounting.cc
@@ -338,7 +338,7 @@ void TShopOwned::journalize(const sstring &customer, const sstring &name,
 void TShopOwned::giveStatements(sstring arg)
 {
   if(!hasAccess(SHOPACCESS_LOGS)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return;
   }
 

--- a/code/code/misc/shopowned.cc
+++ b/code/code/misc/shopowned.cc
@@ -323,7 +323,7 @@ void TShopOwned::setReserve(sstring arg)
   TDatabase db(DB_SNEEZY);
 
   if(!hasAccess(SHOPACCESS_OWNER)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return;
   }
 
@@ -331,14 +331,14 @@ void TShopOwned::setReserve(sstring arg)
   int max=convertTo<int>(arg.word(1));
 
   if(!(min==0 && max==0) && (min > max || (max-min) < 100000)){
-    keeper->doTell(ch->getName(), "The minimum reserve must be less than the maximum reserve.");
-    keeper->doTell(ch->getName(), "The two reserve values must be at least 100k apart.");
+    keeper->doTell(ch, "The minimum reserve must be less than the maximum reserve.");
+    keeper->doTell(ch, "The two reserve values must be at least 100k apart.");
     return;
   }
 
   db.query("update shopowned set reserve_min=%i, reserve_max=%i where shop_nr=%i", min, max, shop_nr);
 
-  keeper->doTell(ch->getName(), format("Ok, the minimum reserve is now %i and the maximum reserve is %i.") % min % max);
+  keeper->doTell(ch, format("Ok, the minimum reserve is now %i and the maximum reserve is %i.") % min % max);
 
   shoplog(shop_nr, ch, keeper, format("%i-%i") % min % max, 0, "set reserve");
   shop_index[shop_nr].clearCache();
@@ -438,20 +438,20 @@ void TShopOwned::setQuality(sstring arg)
   TDatabase db(DB_SNEEZY);
 
   if(!hasAccess(SHOPACCESS_RATES)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return;
   }
 
   double f=convertTo<double>(arg);
 
   if(f > 1.0 || f <= 0.0){
-    keeper->doTell(ch->getName(), "The quality percentage must be less than or equal to 1.0 and greater than 0.0.");
+    keeper->doTell(ch, "The quality percentage must be less than or equal to 1.0 and greater than 0.0.");
     return;
   }
 
   db.query("update shopownedrepair set quality=%f where shop_nr=%i", f, shop_nr);
 
-  keeper->doTell(ch->getName(), format("Ok, the quality percentage has been set to %f.") % f);
+  keeper->doTell(ch, format("Ok, the quality percentage has been set to %f.") % f);
 
   shoplog(shop_nr, ch, keeper, format("%f") % f, 0, "set quality");
   shop_index[shop_nr].clearCache();
@@ -464,20 +464,20 @@ void TShopOwned::setSpeed(sstring arg)
   TDatabase db(DB_SNEEZY);
 
   if(!hasAccess(SHOPACCESS_RATES)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return;
   }
 
   double f=convertTo<double>(arg);
 
   if(f > 5.0 || f <= 0.0){
-    keeper->doTell(ch->getName(), "The speed modifier must be less than or equal to 1.0 and greater than 0.0.");
+    keeper->doTell(ch, "The speed modifier must be less than or equal to 1.0 and greater than 0.0.");
     return;
   }
 
   db.query("update shopownedrepair set speed=%f where shop_nr=%i", f, shop_nr);
 
-  keeper->doTell(ch->getName(), format("Ok, the speed modifier has been set to %f.") % f);
+  keeper->doTell(ch, format("Ok, the speed modifier has been set to %f.") % f);
 
   shoplog(shop_nr, ch, keeper, format("%f") % f, 0, "set speed");
   shop_index[shop_nr].clearCache();
@@ -526,20 +526,20 @@ void TShopOwned::setDividend(sstring arg)
   TDatabase db(DB_SNEEZY);
 
   if(!hasAccess(SHOPACCESS_DIVIDEND)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return;
   }
 
   double f=convertTo<double>(arg);
 
   if(f > 1.0 || f < 0.0){
-    keeper->doTell(ch->getName(), "The dividend percentage must be less than or equal to 1.0 and greater than or equal to 0.0.");
+    keeper->doTell(ch, "The dividend percentage must be less than or equal to 1.0 and greater than or equal to 0.0.");
     return;
   }
 
   db.query("update shopowned set dividend=%f where shop_nr=%i", f, shop_nr);
 
-  keeper->doTell(ch->getName(), format("Ok, the dividend percentage has been set to %f.") % f);
+  keeper->doTell(ch, format("Ok, the dividend percentage has been set to %f.") % f);
 
   shoplog(shop_nr, ch, keeper, format("%f") % f, 0, "set dividend");
   shop_index[shop_nr].clearCache();
@@ -596,36 +596,36 @@ void TShopOwned::showInfo()
     value=convertTo<int>(db["value"]);
     count=convertTo<int>(db["count"]);
 
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("I have %i talens and %i items worth %i talens and selling for approximately %i talens.") %
 		   keeper->getMoney() % count % value %
 		   (int)(value * shop_index[shop_nr].profit_buy));
 
-    //    keeper->doTell(ch->getName(), format("My inventory takes up %i cubic inches of space.") % volume);
+    //    keeper->doTell(ch, format("My inventory takes up %i cubic inches of space.") % volume);
     
-    keeper->doTell(ch->getName(), format("That puts my total value at %i talens.") %
+    keeper->doTell(ch, format("That puts my total value at %i talens.") %
 		   (keeper->getMoney()+value));
 
     if(getDividend() > 0)
-      keeper->doTell(ch->getName(), format("My corporate dividend kickback is %f.") % getDividend());
+      keeper->doTell(ch, format("My corporate dividend kickback is %f.") % getDividend());
     if(getMinReserve() > 0 || getMaxReserve() > 0)
-      keeper->doTell(ch->getName(), format("My corporate reserve is %i-%i.") %
+      keeper->doTell(ch, format("My corporate reserve is %i-%i.") %
 		     getMinReserve() % getMaxReserve());
     if(getExpenseRatio() > 0)
-      keeper->doTell(ch->getName(), format("My expense ratio is %f.") % getExpenseRatio());
+      keeper->doTell(ch, format("My expense ratio is %f.") % getExpenseRatio());
 
   }
 
 
 
   if(!isOwned()){
-    keeper->doTell(ch->getName(), "This shop is for sale, however the King charges a sales tax and an ownership fee.");
+    keeper->doTell(ch, "This shop is for sale, however the King charges a sales tax and an ownership fee.");
     
-    keeper->doTell(ch->getName(), format("That puts the sale price at %i.") %
+    keeper->doTell(ch, format("That puts the sale price at %i.") %
 		   getPurchasePrice(keeper->getMoney(), value));
   } else if(getCorpID()){
     TCorporation corp(getCorpID());
-    keeper->doTell(ch->getName(), format("This shop is owned by %s.") %
+    keeper->doTell(ch, format("This shop is owned by %s.") %
 		   corp.getName());
   }
 
@@ -633,22 +633,22 @@ void TShopOwned::showInfo()
   db.query("select r.name as name from room r, shopowned st, shop s where r.vnum=s.in_room and s.shop_nr=st.tax_nr and st.shop_nr=%i", shop_nr);
 
   if(db.fetchRow()){
-    keeper->doTell(ch->getName(), format("This shop is taxed by %s.") % 
+    keeper->doTell(ch, format("This shop is taxed by %s.") % 
 		   db["name"]);
   } else {
-    keeper->doTell(ch->getName(), "This shop is untaxed.");
+    keeper->doTell(ch, "This shop is untaxed.");
   }
   
 
   // repair stuff
   if((getQuality() >= 0 && getQuality() != 1) ||
      (getSpeed() >= 0 && getSpeed() != 1))
-    keeper->doTell(ch->getName(), format("My quality percentage is %f and my speed modifier is %f.") % getQuality() % getSpeed());
+    keeper->doTell(ch, format("My quality percentage is %f and my speed modifier is %f.") % getQuality() % getSpeed());
 
 
   // anyone can see profit_buy, profit_sell and trading types, anytime
   if(keeper->spec==SPEC_LOAN_SHARK){
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("My defaulting penalty is %f and my interest rate is %f.") %
 		   shop_index[shop_nr].profit_buy %
 		   shop_index[shop_nr].profit_sell);
@@ -657,44 +657,44 @@ void TShopOwned::showInfo()
     db.query("select x, y, term from shopownedloanrate where shop_nr=%i",
 	     shop_nr);
     if(db.fetchRow()){
-      keeper->doTell(ch->getName(), format("My offered term is %i years.") %
+      keeper->doTell(ch, format("My offered term is %i years.") %
 		     convertTo<int>(db["term"]));
-      keeper->doTell(ch->getName(), format("My talens per level X value is %f and my max offering at level 50 is %f.") % 
+      keeper->doTell(ch, format("My talens per level X value is %f and my max offering at level 50 is %f.") % 
 		     convertTo<double>(db["x"]) % 
 		     convertTo<double>(db["y"]));
     }
   } else if(keeper->spec==SPEC_BANKER){
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("I pay out %f in yearly interest, compounded daily.") %
 		   (shop_index[shop_nr].profit_sell));
     db.query("select a.talens+b.talens as talens from (select sum(talens) as talens from shopownedbank where shop_nr=%i) a, (select sum(talens) as talens from shopownedcorpbank where shop_nr=%i) b", shop_nr, shop_nr);
     if(db.fetchRow()){
-      keeper->doTell(ch->getName(), format("My equity value is %i talens.") %
+      keeper->doTell(ch, format("My equity value is %i talens.") %
 		     (keeper->getMoney()-convertTo<int>(db["talens"])));
     }
   } else if(keeper->spec==SPEC_TAXMAN){
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("The tax rate is %f.") %
 		   (shop_index[shop_nr].profit_buy));
   } else if(keeper->spec==SPEC_CENTRAL_BANKER){
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("The reserve deposit requirement is %f.") %
 		   (shop_index[shop_nr].profit_buy));
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("The rate of new money printed is %f.") %
 		   (shop_index[shop_nr].profit_sell));
   } else {
-    keeper->doTell(ch->getName(),
+    keeper->doTell(ch,
 		   format("My profit_buy is %f and my profit_sell is %f.") %
 		   shop_index[shop_nr].profit_buy %
 		   shop_index[shop_nr].profit_sell);
-    keeper->doTell(ch->getName(),format("My maximum inventory per item is %i.") %
+    keeper->doTell(ch,format("My maximum inventory per item is %i.") %
 		   getMaxNum(NULL, NULL, 9));
   }
 
 
   if(shop_index[shop_nr].type.size()<=1){
-    keeper->doTell(ch->getName(), 
+    keeper->doTell(ch, 
 		   "I only sell things, I do not buy anything.");
   } else {
     buf = "I deal in";
@@ -703,7 +703,7 @@ void TShopOwned::showInfo()
       if(tmp != MAX_OBJ_TYPES && (int) tmp != -1)
 	buf = format("%s %s,") % buf % ItemInfo[tmp]->name;
     }
-    keeper->doTell(ch->getName(), buf);
+    keeper->doTell(ch, buf);
   }
 }
 
@@ -716,7 +716,7 @@ int TShopOwned::setRates(sstring arg)
   int max_num, argc=0;
 
   if(!hasAccess(SHOPACCESS_RATES)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return FALSE;
   }
 
@@ -733,7 +733,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("delete from shopownedratios where shop_nr=%i", shop_nr);
       db.query("delete from shopownedmatch where shop_nr=%i", shop_nr);
       db.query("delete from shopownedplayer where shop_nr=%i", shop_nr);
-      keeper->doTell(ch->getName(), "Ok, I cleared all of the individual profit ratios.");
+      keeper->doTell(ch, "Ok, I cleared all of the individual profit ratios.");
       shoplog(shop_nr, ch, keeper, "all", 0, "clear setrates");
       return TRUE;
     } else if(buf == "player"){
@@ -742,7 +742,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("delete from shopownedplayer where shop_nr=%i and player='%s'",
 	       shop_nr, buf.c_str());
       
-      keeper->doTell(ch->getName(), "Done.");
+      keeper->doTell(ch, "Done.");
       shoplog(shop_nr, ch, keeper, buf, 0, "clear setrates");
       return TRUE;
     } else if(buf == "match"){
@@ -751,7 +751,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("delete from shopownedmatch where shop_nr=%i and match_str='%s'",
 	       shop_nr, buf.c_str());
       
-      keeper->doTell(ch->getName(), "Done.");
+      keeper->doTell(ch, "Done.");
       shoplog(shop_nr, ch, keeper, format("match %s") % buf, 0, "clear setrates");
   
       return TRUE;
@@ -761,7 +761,7 @@ int TShopOwned::setRates(sstring arg)
       TThing *tt = searchLinkedListVis(ch, buf, ch->stuff);
       
       if(!tt){
-	keeper->doTell(ch->getName(), "I don't have that item.");
+	keeper->doTell(ch, "I don't have that item.");
 	return FALSE;
       }
       
@@ -770,7 +770,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("delete from shopownedratios where shop_nr=%i and obj_nr=%i",
 	       shop_nr, o->objVnum());
       
-      keeper->doTell(ch->getName(), "Done.");
+      keeper->doTell(ch, "Done.");
       shoplog(shop_nr, ch, keeper, format("item %s") % 
 	      o->getName(), 0, "clear setrates");
 
@@ -799,12 +799,12 @@ int TShopOwned::setRates(sstring arg)
      keeper->spec != SPEC_AUCTIONEER){
     if(profit_buy>5 || profit_buy<0 ||
        profit_sell>5 || profit_sell<0){
-      keeper->doTell(ch->getName(), "Due to fraud regulations, I cannot set my profit_sell or profit_buy to more than 5 or less than 0.");
+      keeper->doTell(ch, "Due to fraud regulations, I cannot set my profit_sell or profit_buy to more than 5 or less than 0.");
       return FALSE;
     }
     
     if(profit_buy < profit_sell){
-      keeper->doTell(ch->getName(), "You can't set your buy profit lower than your sell profit, you'd lose all your money!");
+      keeper->doTell(ch, "You can't set your buy profit lower than your sell profit, you'd lose all your money!");
       return FALSE;
     }
   }
@@ -813,7 +813,7 @@ int TShopOwned::setRates(sstring arg)
     db.query("select obj_nr, profit_buy, profit_sell, max_num from shopownedratios where shop_nr=%i", shop_nr);
     
     while(db.fetchRow()){
-      keeper->doTell(ch->getName(), format("%f %f %i item %s") %
+      keeper->doTell(ch, format("%f %f %i item %s") %
 		     convertTo<float>(db["profit_buy"]) % 
 		     convertTo<float>(db["profit_sell"]) % 
 		     convertTo<int>(db["max_num"]) %
@@ -823,7 +823,7 @@ int TShopOwned::setRates(sstring arg)
     db.query("select match_str, profit_buy, profit_sell, max_num from shopownedmatch where shop_nr=%i", shop_nr);
     
     while(db.fetchRow()){
-      keeper->doTell(ch->getName(),format( "%f %f %i match %s") %
+      keeper->doTell(ch,format( "%f %f %i match %s") %
 		     convertTo<float>(db["profit_buy"]) % 
 		     convertTo<float>(db["profit_sell"]) % 
 		     convertTo<int>(db["max_num"]) %
@@ -833,7 +833,7 @@ int TShopOwned::setRates(sstring arg)
     db.query("select player, profit_buy, profit_sell, max_num from shopownedplayer where shop_nr=%i", shop_nr);
     
     while(db.fetchRow()){
-      keeper->doTell(ch->getName(),format( "%f %f %i player %s") %
+      keeper->doTell(ch,format( "%f %f %i player %s") %
 		     convertTo<float>(db["profit_buy"]) % 
 		     convertTo<float>(db["profit_sell"]) % 
 		     convertTo<int>(db["max_num"]) %
@@ -842,7 +842,7 @@ int TShopOwned::setRates(sstring arg)
 
     return TRUE;
   } else if(argc<4){
-    keeper->doTell(ch->getName(), "I don't understand.");
+    keeper->doTell(ch, "I don't understand.");
     return FALSE;
   }
   
@@ -852,7 +852,7 @@ int TShopOwned::setRates(sstring arg)
     
     db.query("update shopowned set profit_buy=%f, profit_sell=%f, max_num=%i where shop_nr=%i", shop_index[shop_nr].profit_buy, shop_index[shop_nr].profit_sell, max_num, shop_nr);
     
-    keeper->doTell(ch->getName(), 
+    keeper->doTell(ch, 
 		   format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is now %i.") % 
 		   shop_index[shop_nr].profit_buy %
 		   shop_index[shop_nr].profit_sell % max_num);
@@ -874,7 +874,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("update shopownedmatch set profit_buy=%f, profit_sell=%f, max_num=%i where shop_nr=%i and match_str='%s'", profit_buy, profit_sell, max_num, shop_nr, buf.c_str());
     }
     
-    keeper->doTell(ch->getName(), format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is now %i, all for keyword %s.") %
+    keeper->doTell(ch, format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is now %i, all for keyword %s.") %
 		   profit_buy % profit_sell % max_num % buf);    
 
     shoplog(shop_nr, ch, keeper, format("match %s, %f %f %i") % 
@@ -893,7 +893,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("update shopownedplayer set profit_buy=%f, profit_sell=%f, max_num=%i where shop_nr=%i and player='%s'", profit_buy, profit_sell, max_num, shop_nr, buf.c_str());
     }
     
-    keeper->doTell(ch->getName(), format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is now %i, all for player %s.") %
+    keeper->doTell(ch, format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is now %i, all for player %s.") %
 		   profit_buy % profit_sell % max_num % buf);    
     shoplog(shop_nr, ch, keeper, format("player %s, %f %f %i") %
 	    buf % profit_buy % profit_sell % max_num, 0, "set setrates");
@@ -908,7 +908,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("update shopownedloanrate set x=%f, y=%f, term=%i where shop_nr=%i", profit_buy, profit_sell, max_num, shop_nr);
     }    
 
-    keeper->doTell(ch->getName(), 
+    keeper->doTell(ch, 
 		   format("Ok, my loanrate X value is now %f, my Y value is now %f and my max term is %i.") % profit_buy % profit_sell % max_num);
     shoplog(shop_nr, ch, keeper, format("loanrate %f %f %i") %
 	    profit_buy % profit_sell % max_num, 0, "set setrates");
@@ -923,7 +923,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("update shopownedrepair set quality=%f, speed=%f where shop_nr=%i", profit_buy, profit_sell, shop_nr);
     }    
 
-    keeper->doTell(ch->getName(), 
+    keeper->doTell(ch, 
 		   format("Ok, my quality percentage is now %f and my speed modifier is now %f.") % profit_buy % profit_sell);
 
     shoplog(shop_nr, ch, keeper, format("repair %f %f") % profit_buy % profit_sell, 0, "set setrates");
@@ -934,7 +934,7 @@ int TShopOwned::setRates(sstring arg)
     TThing *tt = searchLinkedListVis(ch, buf, keeper->stuff);
     
     if(!tt){
-      keeper->doTell(ch->getName(), "I don't have that item.");
+      keeper->doTell(ch, "I don't have that item.");
       return FALSE;
     }
     
@@ -950,7 +950,7 @@ int TShopOwned::setRates(sstring arg)
       db.query("update shopownedratios set profit_buy=%f, profit_sell=%f, max_num=%i where shop_nr=%i and obj_nr=%i", profit_buy, profit_sell, max_num, shop_nr, o->objVnum());
     }
     
-    keeper->doTell(ch->getName(), format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is %i, all for %s.") %
+    keeper->doTell(ch, format("Ok, my profit_buy is now %f, my profit_sell is now %f and my max_num is %i, all for %s.") %
 		   profit_buy % profit_sell % max_num % o->getName());
     
     shoplog(shop_nr, ch, keeper, format("item %s, %f %f %i") % 
@@ -971,7 +971,7 @@ int TShopOwned::buyShop(sstring arg){
   int corp_id=0;
 
   if(isOwned()){
-    keeper->doTell(ch->getName(), "Sorry, this shop isn't for sale.");
+    keeper->doTell(ch, "Sorry, this shop isn't for sale.");
     return TRUE;
   }
   
@@ -989,12 +989,12 @@ int TShopOwned::buyShop(sstring arg){
       corp_id=convertTo<int>(db["corp_id"]);
 
     if(db.fetchRow()){
-      keeper->doTell(ch->getName(), "You must specify the ID of the corporation you wish to buy this shop for.");
+      keeper->doTell(ch, "You must specify the ID of the corporation you wish to buy this shop for.");
       return TRUE;
     }
   } else {
     if(convertTo<int>(arg) == 0){
-      keeper->doTell(ch->getName(), "You must specify the ID of the corporation you wish to buy this shop for.");
+      keeper->doTell(ch, "You must specify the ID of the corporation you wish to buy this shop for.");
       return TRUE;
     }
 
@@ -1007,13 +1007,13 @@ int TShopOwned::buyShop(sstring arg){
   }
 
   if(!corp_id){
-      keeper->doTell(ch->getName(), "You must specify the ID of the corporation you wish to buy this shop for.");
+      keeper->doTell(ch, "You must specify the ID of the corporation you wish to buy this shop for.");
       return TRUE;
   }
 
   
   if(ch->getMoney()<value){
-    keeper->doTell(ch->getName(), format("Sorry, you can't afford this shop.  The price is %i.") % value);
+    keeper->doTell(ch, format("Sorry, you can't afford this shop.  The price is %i.") % value);
     return TRUE;
   }
   ch->setMoney(ch->getMoney()-value);
@@ -1023,7 +1023,7 @@ int TShopOwned::buyShop(sstring arg){
   
   keeper->saveItems(shop_nr);
   
-  keeper->doTell(ch->getName(), "Congratulations, you now own this shop.");
+  keeper->doTell(ch, "Congratulations, you now own this shop.");
   shop_index[shop_nr].owned=true;
 
   shoplog(shop_nr, ch, keeper, format("%i") % value, 0, "bought shop");
@@ -1039,25 +1039,25 @@ int TShopOwned::setString(sstring arg)
   s=one_argument(arg, which);
   
   if(!hasAccess(SHOPACCESS_OWNER)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return FALSE;
   }
 
 
   if(which.empty() && s.empty()){
-    keeper->doTell(ch->getName(), format("no_such_item1: %s") %
+    keeper->doTell(ch, format("no_such_item1: %s") %
 		   shop_index[shop_nr].no_such_item1);
-    keeper->doTell(ch->getName(), format("no_such_item2: %s") %
+    keeper->doTell(ch, format("no_such_item2: %s") %
 		   shop_index[shop_nr].no_such_item2);
-    keeper->doTell(ch->getName(), format("do_not_buy: %s") %
+    keeper->doTell(ch, format("do_not_buy: %s") %
 		   shop_index[shop_nr].do_not_buy);
-    keeper->doTell(ch->getName(), format("missing_cash1: %s") %
+    keeper->doTell(ch, format("missing_cash1: %s") %
 		   shop_index[shop_nr].missing_cash1);
-    keeper->doTell(ch->getName(), format("missing_cash2: %s") %
+    keeper->doTell(ch, format("missing_cash2: %s") %
 		   shop_index[shop_nr].missing_cash2);
-    keeper->doTell(ch->getName(), format("message_buy: %s") %
+    keeper->doTell(ch, format("message_buy: %s") %
 		   shop_index[shop_nr].message_buy);
-    keeper->doTell(ch->getName(), format("message_sell: %s") %
+    keeper->doTell(ch, format("message_sell: %s") %
 		   shop_index[shop_nr].message_sell);
     return TRUE;
   } 
@@ -1085,7 +1085,7 @@ int TShopOwned::setString(sstring arg)
     delete [] shop_index[shop_nr].message_sell;
     shop_index[shop_nr].message_sell=mud_str_dup(s);
   } else {
-    keeper->doTell(ch->getName(), "You need to specify a string to change.");
+    keeper->doTell(ch, "You need to specify a string to change.");
     return FALSE;
   }
 
@@ -1095,7 +1095,7 @@ int TShopOwned::setString(sstring arg)
   db.query("update shopowned set %s='%s' where shop_nr=%i", 
 	   which.c_str(), s.c_str(), shop_nr);
 
-  keeper->doTell(ch->getName(), "Alright, I changed that response.");
+  keeper->doTell(ch, "Alright, I changed that response.");
 
   shoplog(shop_nr, ch, keeper, which, 0, "set sstring");
   
@@ -1108,9 +1108,9 @@ int TShopOwned::sellShop(){
   int value=0;
 
   if(!hasAccess(SHOPACCESS_SELL)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
-    keeper->doTell(ch->getName(), "And remember, when you do sell this shop, I won't pay you for the inventory.");
-    keeper->doTell(ch->getName(), "I'll just give you the money I have on me, but nothing for the inventory.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "And remember, when you do sell this shop, I won't pay you for the inventory.");
+    keeper->doTell(ch, "I'll just give you the money I have on me, but nothing for the inventory.");
     return FALSE;
   }
   
@@ -1128,7 +1128,7 @@ int TShopOwned::sellShop(){
   shop_index[shop_nr].profit_buy=1.1;
   shop_index[shop_nr].profit_sell=0.9;
   
-  keeper->doTell(ch->getName(), "Ok, you no longer own this shop.");
+  keeper->doTell(ch, "Ok, you no longer own this shop.");
   shop_index[shop_nr].owned=false;
 
   shoplog(shop_nr, ch, keeper, format("%i") % value, 0, "sold shop");
@@ -1145,7 +1145,7 @@ int TShopOwned::giveMoney(sstring arg){
   TDatabase db(DB_SNEEZY);
 
   if(!hasAccess(SHOPACCESS_GIVE)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return FALSE;
   }
 
@@ -1155,7 +1155,7 @@ int TShopOwned::giveMoney(sstring arg){
 
   if(amount<=0){
     keeper->doAction(ch->getName(), CMD_SLAP);
-    keeper->doTell(ch->getName(), "Don't be an idiot.");
+    keeper->doTell(ch, "Don't be an idiot.");
     return FALSE;
   }  
 
@@ -1163,7 +1163,7 @@ int TShopOwned::giveMoney(sstring arg){
 
   if(db.fetchRow()){
     if((keeper->getMoney() - getMinReserve()) < amount){
-      keeper->doTell(ch->getName(), "I wouldn't have enough cash to cover the central bank reserve requirement.");
+      keeper->doTell(ch, "I wouldn't have enough cash to cover the central bank reserve requirement.");
       return FALSE;
     }
   }
@@ -1182,8 +1182,8 @@ int TShopOwned::giveMoney(sstring arg){
     act(buf, TRUE, keeper, NULL, ch, TO_VICT);
     act("$n gives some money to $N.", 1, keeper, 0, ch, TO_NOTVICT);
   } else {
-    keeper->doTell(ch->getName(), "I don't have that many talens.");
-    keeper->doTell(ch->getName(), format("I have %i talens.") % keeper->getMoney());
+    keeper->doTell(ch, "I don't have that many talens.");
+    keeper->doTell(ch, format("I have %i talens.") % keeper->getMoney());
   }
 
   return TRUE;
@@ -1196,7 +1196,7 @@ int TShopOwned::setAccess(sstring arg)
   unsigned int access;
 
   if(!hasAccess(SHOPACCESS_ACCESS)){
-    keeper->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+    keeper->doTell(ch, "Sorry, you don't have access to do that.");
     return FALSE;
   }
 
@@ -1253,7 +1253,7 @@ int TShopOwned::setAccess(sstring arg)
 	buf+=" owner";
       }
       
-      keeper->doTell(ch->getName(), buf);
+      keeper->doTell(ch, buf);
     }
   }
   
@@ -1272,7 +1272,7 @@ int TShopOwned::doLogs(sstring arg)
     if(keeper->spec == SPEC_BANKER){
       arg = ch->name;
     } else {
-      keeper->doTell(ch->getName(),"Sorry, you don't have access to do that.");
+      keeper->doTell(ch,"Sorry, you don't have access to do that.");
       return FALSE;
     }
   }

--- a/code/code/misc/talk.cc
+++ b/code/code/misc/talk.cc
@@ -739,13 +739,13 @@ TBeing *findTellTarget(TBeing *me, const sstring &name, bool visible, bool mobs)
 
 TBeing *findAccountAlternate(TBeing *me, const sstring &name, bool visible)
 {
-    TBeing *vict;
-    TDatabase db(DB_SNEEZY);
-    db.query("select p1.name as name from player p1, player p2, account a where p2.name='%s' and a.account_id=p2.account_id and p1.account_id=a.account_id", name);
-    while (db.fetchRow())
-        if ((vict=findTellTarget(me, db["name"], visible, false)))
-            return vict;
-    return nullptr;
+  TBeing *vict;
+  TDatabase db(DB_SNEEZY);
+  db.query("select p.name as name from player p join player a on p.account_id = a.account_id and a.name = '%s' where p.name <> '%s'", name, name);
+  while (db.fetchRow())
+    if ((vict=findTellTarget(me, db["name"], visible, false)))
+      return vict;
+  return nullptr;
 }
 
 

--- a/code/code/misc/talk.cc
+++ b/code/code/misc/talk.cc
@@ -869,8 +869,7 @@ int TBeing::doTell(const sstring &name, const sstring &message, bool visible)
   if(vict->isImmortal() && drunkNum>0)
     garbed=message;
 
-  rc = vict->triggerSpecialOnPerson(this, CMD_OBJ_TOLD_TO_PLAYER, 
-				    garbed.c_str());
+  rc = vict->triggerSpecialOnPerson(this, CMD_OBJ_TOLD_TO_PLAYER, garbed);
   if (IS_SET_DELETE(rc, DELETE_THIS)) {
     delete vict;
     vict = NULL;

--- a/code/code/obj/obj_arrow.cc
+++ b/code/code/obj/obj_arrow.cc
@@ -237,7 +237,7 @@ bool TArrow::engraveMe(TBeing *ch, TMonster *me, bool give)
 {
   char buf[256];
 
-  me->doTell(ch->getName(), "Engraving this would destroy its aerodynamics.");
+  me->doTell(ch, "Engraving this would destroy its aerodynamics.");
 
   if (give) {
     strcpy(buf, name.c_str());

--- a/code/code/obj/obj_bag.cc
+++ b/code/code/obj/obj_bag.cc
@@ -53,7 +53,7 @@ sstring TBag::statObjInfo() const
 bool TBag::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair bags.");
+    repair->doTell(ch, "I can't repair bags.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_base_container.cc
+++ b/code/code/obj/obj_base_container.cc
@@ -47,7 +47,7 @@ bool TBaseContainer::engraveMe(TBeing *ch, TMonster *me, bool give)
   char buf[256];
 
   // engraved bags would protect too many things
-  me->doTell(ch->getName(), "The powers that be say I can't do that anymore.");
+  me->doTell(ch, "The powers that be say I can't do that anymore.");
 
   if (give) {
     strcpy(buf, name.c_str());

--- a/code/code/obj/obj_base_cup.cc
+++ b/code/code/obj/obj_base_cup.cc
@@ -224,7 +224,7 @@ void TBaseCup::lowCheck()
 bool TBaseCup::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "you might wanna take that to the diner!");
+    repair->doTell(ch, "you might wanna take that to the diner!");
   }
   return TRUE;
 }
@@ -252,7 +252,7 @@ void TBaseCup::getFourValues(int *x1, int *x2, int *x3, int *x4) const
 
 int TBaseCup::objectSell(TBeing *ch, TMonster *keeper)
 {
-  keeper->doTell(ch->getName(), "I'm sorry, I don't purchase drink containers.");
+  keeper->doTell(ch, "I'm sorry, I don't purchase drink containers.");
   return TRUE;
 }
 

--- a/code/code/obj/obj_base_weapon.cc
+++ b/code/code/obj/obj_base_weapon.cc
@@ -292,12 +292,12 @@ int TBaseWeapon::sharpenerValueMe(const TBeing *ch, TMonster *me) const
   int cost;
 
   if (getCurSharp() == getMaxSharp()) {
-    me->doTell(ch->getName(), "This weapon is perfectly ok!");
+    me->doTell(ch, "This weapon is perfectly ok!");
     return TRUE;
   }
   cost = sharpenPrice();
 
-  me->doTell(ch->getName(), format("It will cost %d talens to totally %s your %s.") %
+  me->doTell(ch, format("It will cost %d talens to totally %s your %s.") %
 	     cost % (isBluntWeapon() ? "dull" : "sharpen") %
 	     fname(name));
   return TRUE;
@@ -310,7 +310,7 @@ int TBaseWeapon::sharpenerGiveMe(TBeing *ch, TMonster *me)
   sharp_struct *job;
 
   if (getCurSharp() == getMaxSharp()) {
-    me->doTell(ch->getName(), "That item is perfectly ok!");
+    me->doTell(ch, "That item is perfectly ok!");
     strcpy(buf, name.c_str());
     strcpy(buf, add_bars(buf).c_str());
     sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -320,7 +320,7 @@ int TBaseWeapon::sharpenerGiveMe(TBeing *ch, TMonster *me)
   cost = sharpenPrice();
 
   if (ch->getMoney() < cost) {
-    me->doTell(ch->getName(), "I have to make a living! If you don't have the talens , I don't do the work!");
+    me->doTell(ch, "I have to make a living! If you don't have the talens , I don't do the work!");
     strcpy(buf, name.c_str());
     strcpy(buf, add_bars(buf).c_str());
     sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());

--- a/code/code/obj/obj_card_deck.cc
+++ b/code/code/obj/obj_card_deck.cc
@@ -118,7 +118,7 @@ sstring TCardDeck::statObjInfo() const
 bool TCardDeck::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair that.");
+    repair->doTell(ch, "I can't repair that.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_chest.cc
+++ b/code/code/obj/obj_chest.cc
@@ -50,7 +50,7 @@ sstring TChest::statObjInfo() const
 bool TChest::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "Does this look like a locksmithery to you?");
+    repair->doTell(ch, "Does this look like a locksmithery to you?");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_commodity.cc
+++ b/code/code/obj/obj_commodity.cc
@@ -288,18 +288,18 @@ int TCommodity::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
     return -1;
   }
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return -1;
   }
   if (num > (int) (numUnits())) {
     num = (int) (numUnits());
-    keeper->doTell(ch->getName(), format("I don't have that much %s.  Here's the %d that I do have.") % fname(name) % num);
+    keeper->doTell(ch, format("I don't have that much %s.  Here's the %d that I do have.") % fname(name) % num);
   }
   price = shopPrice(num, shop_nr, -1, ch);
   vnum = objVnum();
 
   if (ch->getMoney() < price) {
-    keeper->doTell(ch->name, shop_index[shop_nr].missing_cash2);
+    keeper->doTell(ch, shop_index[shop_nr].missing_cash2);
 
     switch (shop_index[shop_nr].temper1) {
       case 0:
@@ -327,7 +327,7 @@ int TCommodity::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
     obj2->setWeight(num/10.0);
     obj2->setMaterial(getMaterial());
     *ch += *obj2;
-    keeper->doTell(ch->getName(), format("That'll be %i.  Here's %d units of %s.") %
+    keeper->doTell(ch, format("That'll be %i.  Here's %d units of %s.") %
 		   price % num % material_nums[getMaterial()].mat_name);
     act("$n buys $p.", TRUE, ch, obj2, keeper, TO_NOTVICT);
 
@@ -357,7 +357,7 @@ bool TCommodity::sellMeCheck(TBeing *ch, TMonster *keeper, int num, int total_in
     max_num=tso.getMaxNum(ch, this, shop_capacity);
 
   if(max_num == 0){
-    keeper->doTell(ch->name, "I don't wish to buy any of those right now.");
+    keeper->doTell(ch, "I don't wish to buy any of those right now.");
     return TRUE;
   }
 
@@ -365,11 +365,11 @@ bool TCommodity::sellMeCheck(TBeing *ch, TMonster *keeper, int num, int total_in
     total_inventory = tso.getInventoryCount(this);
   
   if (total_inventory >= max_num) {
-    keeper->doTell(ch->getName(), format("I already have plenty of %s.") % 
+    keeper->doTell(ch, format("I already have plenty of %s.") % 
 		   getName());
     return TRUE;
   } else if (total_inventory + num > max_num) {
-    keeper->doTell(ch->getName(), format("I'll buy no more than %d unit%s of %s.") % (max_num - total_inventory) % (max_num - total_inventory > 1 ? "s" : "") % getName());
+    keeper->doTell(ch, format("I'll buy no more than %d unit%s of %s.") % (max_num - total_inventory) % (max_num - total_inventory > 1 ? "s" : "") % getName());
     return TRUE;
   }
   
@@ -407,11 +407,11 @@ int TCommodity::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int)
     return false;
   }
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return false;
   }
   if (keeper->getMoney() < price) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].missing_cash1);
+    keeper->doTell(ch, shop_index[shop_nr].missing_cash1);
     return false;
   }
 
@@ -424,7 +424,7 @@ int TCommodity::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int)
     TShopOwned tso(shop_nr, keeper, ch);
     tso.doSellTransaction(price, getName(), TX_SELLING);
 
-    keeper->doTell(ch->getName(), format("Thanks, here's your %d talens.") % price);
+    keeper->doTell(ch, format("Thanks, here's your %d talens.") % price);
     act("$n sells $p.", TRUE, ch, this, 0, TO_ROOM);
     if (ch->isAffected(AFF_GROUP) && ch->desc &&
             IS_SET(ch->desc->autobits, AUTO_SPLIT) &&
@@ -511,14 +511,14 @@ void TCommodity::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int)
   strcpy(buf2, fname(name).c_str());*/
 
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     //delete obj2;
     return;
   }
 
   price = sellPrice(numUnits(), shop_nr, -1, ch);
 
-  keeper->doTell(ch->getName(), format("Hmm, I'd give you %d talens for your %i units of that.") % price % numUnits());
+  keeper->doTell(ch, format("Hmm, I'd give you %d talens for your %i units of that.") % price % numUnits());
 
   //delete obj2;
 }

--- a/code/code/obj/obj_component.cc
+++ b/code/code/obj/obj_component.cc
@@ -2314,7 +2314,7 @@ bool TComponent::sellMeCheck(TBeing *ch, TMonster *keeper, int num, int defaultM
   int max_num = tso.getMaxNum(ch, this, defaultMax);
 
   if(max_num == 0){
-    keeper->doTell(ch->name, "I don't wish to buy any of those right now.");
+    keeper->doTell(ch, "I don't wish to buy any of those right now.");
     return TRUE;
   }
 
@@ -2330,10 +2330,10 @@ bool TComponent::sellMeCheck(TBeing *ch, TMonster *keeper, int num, int defaultM
   }
 
   if (total >= max_num) {
-    keeper->doTell(ch->getName(), format("I already have plenty of %s.") % getName());
+    keeper->doTell(ch, format("I already have plenty of %s.") % getName());
     return TRUE;
   } else if (total + num > max_num) {
-    keeper->doTell(ch->getName(), format("I'll buy no more than %d charge%s of %s.") % (max_num - total) % (max_num - total > 1 ? "s" : "") % getName());
+    keeper->doTell(ch, format("I'll buy no more than %d charge%s of %s.") % (max_num - total) % (max_num - total > 1 ? "s" : "") % getName());
     return FALSE;
   }
 
@@ -2608,7 +2608,7 @@ sstring TComponent::statObjInfo() const
 bool TComponent::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->getName()), "You might wanna take that to the magic shop!");
+    repair->doTell(ch, "You might wanna take that to the magic shop!");
   }
   return TRUE;
 }
@@ -3024,7 +3024,7 @@ int TComponent::buyMe(TBeing *ch, TMonster *tKeeper, int tNum, int tShop)
   tCost  = (int) shopPrice(tNum, tShop, tChr, ch);
 
   if ((ch->getMoney() < tCost) && !ch->hasWizPower(POWER_GOD)) {
-    tKeeper->doTell(ch->name, shop_index[tShop].missing_cash2);
+    tKeeper->doTell(ch, shop_index[tShop].missing_cash2);
 
     switch (shop_index[tShop].temper1) {
       case 0:
@@ -3042,7 +3042,7 @@ int TComponent::buyMe(TBeing *ch, TMonster *tKeeper, int tNum, int tShop)
   int charges = getComponentCharges();
   
   if (tNum > charges) {
-    tKeeper->doTell(ch->getName(), format("I don't have %d charges of %s.  Here %s the %d I do have.") % tNum % getName() % ((charges > 2) ? "are" : "is") % charges);
+    tKeeper->doTell(ch, format("I don't have %d charges of %s.  Here %s the %d I do have.") % tNum % getName() % ((charges > 2) ? "are" : "is") % charges);
     tNum  = charges;
     tCost = shopPrice(tNum, tShop, tChr, ch);
   }
@@ -3070,7 +3070,7 @@ int TComponent::buyMe(TBeing *ch, TMonster *tKeeper, int tNum, int tShop)
   }
   
   tObj->purchaseMe(ch, tKeeper, tCost, tShop);
-  tKeeper->doTell(ch->name, format(shop_index[tShop].message_buy) % tCost);
+  tKeeper->doTell(ch, format(shop_index[tShop].message_buy) % tCost);
   
   ch->sendTo(COLOR_OBJECTS, format("You now have %s (*%d charges).\n\r") %
 	     sstring(getName()).uncap() % tNum);
@@ -3104,12 +3104,12 @@ int TComponent::sellMe(TBeing *ch, TMonster *tKeeper, int tShop, int num)
   TShopOwned tso(tShop, tKeeper, ch);
 
   if (!shop_index[tShop].profit_sell) {
-    tKeeper->doTell(ch->getName(), shop_index[tShop].do_not_buy);
+    tKeeper->doTell(ch, shop_index[tShop].do_not_buy);
     return false;
   }
 
   if (obj_flags.cost <= 1 || isObjStat(ITEM_NEWBIE)) {
-    tKeeper->doTell(ch->getName(), "I'm sorry, I don't buy valueless items.");
+    tKeeper->doTell(ch, "I'm sorry, I don't buy valueless items.");
     return false;
   }
 
@@ -3122,13 +3122,13 @@ int TComponent::sellMe(TBeing *ch, TMonster *tKeeper, int tShop, int num)
   // bypass sellMeCheck, since we already have the val0 we can save a DB op
   int max_num = tso.getMaxNum(ch, this, 50);
   if (max_num == 0){
-    tKeeper->doTell(ch->name, "I don't wish to buy any of those right now.");
+    tKeeper->doTell(ch, "I don't wish to buy any of those right now.");
     return false;
   } else if (charges >= max_num) {
-    tKeeper->doTell(ch->getName(), format("I already have plenty of %s.") % getName());
+    tKeeper->doTell(ch, format("I already have plenty of %s.") % getName());
     return false;
   } else if (charges + num > max_num) {
-    tKeeper->doTell(ch->getName(), format("I'll buy no more than %d charge%s of %s.") % (max_num - charges) % (max_num - charges > 1 ? "s" : "") % getName());
+    tKeeper->doTell(ch, format("I'll buy no more than %d charge%s of %s.") % (max_num - charges) % (max_num - charges > 1 ? "s" : "") % getName());
     return false;
   }
 
@@ -3153,17 +3153,17 @@ int TComponent::sellMe(TBeing *ch, TMonster *tKeeper, int tShop, int num)
   tCost  = max(1, sellPrice(num, tShop, tChr, ch));
 
   if (tKeeper->getMoney() < tCost) {
-    tKeeper->doTell(ch->name, shop_index[tShop].missing_cash1);
+    tKeeper->doTell(ch, shop_index[tShop].missing_cash1);
     return false;
   }
 
   if (obj_index[getItemIndex()].max_exist <= 10) {
-    tKeeper->doTell(ch->getName(), "Wow!  This is one of those limited items.");
-    tKeeper->doTell(ch->getName(), "You should really think about auctioning it.");
+    tKeeper->doTell(ch, "Wow!  This is one of those limited items.");
+    tKeeper->doTell(ch, "You should really think about auctioning it.");
   }
 
   act("$n sells $p.", FALSE, ch, this, 0, TO_ROOM);
-  tKeeper->doTell(ch->getName(), format(shop_index[tShop].message_sell) % tCost);
+  tKeeper->doTell(ch, format(shop_index[tShop].message_sell) % tCost);
   ch->sendTo(COLOR_OBJECTS, format("The shopkeeper now has %s.\n\r") % sstring(getName()).uncap());
   ch->logItem(this, CMD_SELL);
 
@@ -3255,7 +3255,7 @@ void TComponent::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num)
   price = sellPrice(num, shop_nr, -1, ch);
 
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
 
@@ -3264,5 +3264,5 @@ void TComponent::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num)
   } else {
     buf = format("Normally, I'd give you %d talens for %s!") % price % getName();
   }
-  keeper->doTell(ch->getName(), buf);
+  keeper->doTell(ch, buf);
 }

--- a/code/code/obj/obj_cookware.cc
+++ b/code/code/obj/obj_cookware.cc
@@ -55,7 +55,7 @@ sstring TCookware::statObjInfo() const
 bool TCookware::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "Does this look like a cookware repair shop to you?");
+    repair->doTell(ch, "Does this look like a cookware repair shop to you?");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_drug.cc
+++ b/code/code/obj/obj_drug.cc
@@ -172,7 +172,7 @@ int TDrug::objectSell(TBeing *ch, TMonster *keeper)
 {
   return false;
 
-  //  keeper->doTell(ch->getName(), "I'm sorry, I don't buy back drugs.");
+  //  keeper->doTell(ch, "I'm sorry, I don't buy back drugs.");
   //  return TRUE;
 }
 

--- a/code/code/obj/obj_food.cc
+++ b/code/code/obj/obj_food.cc
@@ -1136,14 +1136,14 @@ sstring TFood::statObjInfo() const
 
 int TFood::objectSell(TBeing *ch, TMonster *keeper)
 {
-  keeper->doTell(ch->getName(), "I'm sorry, I don't purchase food.");
+  keeper->doTell(ch, "I'm sorry, I don't purchase food.");
   return TRUE;
 }
 
 bool TFood::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "you might wanna take that to the diner!");
+    repair->doTell(ch, "you might wanna take that to the diner!");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_fuel.cc
+++ b/code/code/obj/obj_fuel.cc
@@ -146,7 +146,7 @@ void TFuel::lowCheck()
 
 int TFuel::objectSell(TBeing *ch, TMonster *keeper)
 {
-  keeper->doTell(ch->getName(), "I'm sorry, I don't buy back fuel.");
+  keeper->doTell(ch, "I'm sorry, I don't buy back fuel.");
   return TRUE;
 }
 

--- a/code/code/obj/obj_key.cc
+++ b/code/code/obj/obj_key.cc
@@ -68,7 +68,7 @@ bool TKey::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
 
-    repair->doTell(fname(ch->name), "Does this look like a locksmithery to you?");
+    repair->doTell(ch, "Does this look like a locksmithery to you?");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_keyring.cc
+++ b/code/code/obj/obj_keyring.cc
@@ -50,7 +50,7 @@ sstring TKeyring::statObjInfo() const
 bool TKeyring::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair keyrings.");
+    repair->doTell(ch, "I can't repair keyrings.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_magic_item.cc
+++ b/code/code/obj/obj_magic_item.cc
@@ -77,7 +77,7 @@ sstring TMagicItem::displayFourValues()
 int TMagicItem::objectSell(TBeing *ch, TMonster *keeper)
 {
   if (getMagicLearnedness() < MAX_SKILL_LEARNEDNESS) {
-    keeper->doTell(ch->getName(), format("I'm sorry, that %s is of sub-standard quality.") % fname(name));
+    keeper->doTell(ch, format("I'm sorry, that %s is of sub-standard quality.") % fname(name));
     return TRUE;
   }
 

--- a/code/code/obj/obj_moneypouch.cc
+++ b/code/code/obj/obj_moneypouch.cc
@@ -89,7 +89,7 @@ sstring TMoneypouch::statObjInfo() const
 bool TMoneypouch::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair moneypouches.");
+    repair->doTell(ch, "I can't repair moneypouches.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_note.cc
+++ b/code/code/obj/obj_note.cc
@@ -116,7 +116,7 @@ sstring TNote::statObjInfo() const
 
 int TNote::objectSell(TBeing *ch, TMonster *keeper)
 {
-  keeper->doTell(ch->getName(), "I'm sorry, I don't buy back notes.");
+  keeper->doTell(ch, "I'm sorry, I don't buy back notes.");
   return TRUE;
 }
 

--- a/code/code/obj/obj_opal.cc
+++ b/code/code/obj/obj_opal.cc
@@ -110,7 +110,7 @@ void TOpal::getFourValues(int *x1, int *x2, int *x3, int *x4) const
 
 int TOpal::objectSell(TBeing *ch, TMonster *keeper)
 {
-  keeper->doTell(ch->getName(), "I'm sorry, I don't buy back opal powerstones.");
+  keeper->doTell(ch, "I'm sorry, I don't buy back opal powerstones.");
   return TRUE;
 }
 

--- a/code/code/obj/obj_organic.cc
+++ b/code/code/obj/obj_organic.cc
@@ -178,7 +178,7 @@ int TOrganic::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
   }
   // Make sure it's an item we buy.
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return -1;
   }
   nocName = getNameNOC(ch);
@@ -186,14 +186,14 @@ int TOrganic::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
   if (getUnits() > 0) {
     if (num > getUnits()) {
       num = getUnits();
-      keeper->doTell(ch->getName(), format("I don't have that much of %s.  Here's the %d that I do have.") % nocName % num);
+      keeper->doTell(ch, format("I don't have that much of %s.  Here's the %d that I do have.") % nocName % num);
     }
   }
   // cost_per = pricePerUnit();
   price = shopPrice(num, shop_nr, -1, ch);
   vnum = objVnum();
   if (ch->getMoney() < price) {
-    keeper->doTell(ch->name, shop_index[shop_nr].missing_cash2);
+    keeper->doTell(ch, shop_index[shop_nr].missing_cash2);
 
     switch (shop_index[shop_nr].temper1) {
       case 0:
@@ -237,12 +237,12 @@ int TOrganic::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
       obj2->setWeight(nWeight);
       obj2->obj_flags.cost = nCost;
       *ch += *obj2;
-      keeper->doTell(ch->getName(), format("Here ya go.  That's %d unit%s of %s for %d talen%s.") % num % (num > 1 ? "s" : "") % nocName % price % (price > 1 ? "s" : ""));
+      keeper->doTell(ch, format("Here ya go.  That's %d unit%s of %s for %d talen%s.") % num % (num > 1 ? "s" : "") % nocName % price % (price > 1 ? "s" : ""));
       act("$n buys $p.", TRUE, ch, obj2, keeper, TO_NOTVICT);
     } else {
       // Must not have been a unit item, just give them the item in question.
       *ch += *this;
-      keeper->doTell(ch->getName(), "Here ya go.  Thanks for shopping with us.");
+      keeper->doTell(ch, "Here ya go.  Thanks for shopping with us.");
       act("$n buys $p.", TRUE, ch, this, keeper, TO_NOTVICT);
     }
 
@@ -289,9 +289,9 @@ static void sellReducePrice(const TBeing *ch, TBeing *keeper, const TOrganic *ob
 {
   if (obj2 && obj2->getUnits() >= 100) {
     int bnCost = max(1, (int) (price/4));
-    keeper->doTell(ch->getName(), "Well it would seem I have a surplus of that hide...");
+    keeper->doTell(ch, "Well it would seem I have a surplus of that hide...");
     if (bnCost != price) {
-      keeper->doTell(ch->getName(), "Afraid I can not pay you full price for it.");
+      keeper->doTell(ch, "Afraid I can not pay you full price for it.");
       price = bnCost;
     }
   }
@@ -327,11 +327,11 @@ int TOrganic::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
   if (will_not_buy(ch, keeper, this, shop_nr))
     return false;
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return false;
   }
   if (keeper->getMoney() < price) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].missing_cash1);
+    keeper->doTell(ch, shop_index[shop_nr].missing_cash1);
     return false;
   }
   // See if the shop keeper already has one of these items.
@@ -348,7 +348,7 @@ int TOrganic::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
     }
   }
   if (found >= 20) {
-    keeper->doTell(ch->getName(), "I'm afraid I already have too many of those, sorry.");
+    keeper->doTell(ch, "I'm afraid I already have too many of those, sorry.");
     return false;
   }
   if (getUnits() > 0) {
@@ -395,7 +395,7 @@ int TOrganic::sellMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
 
     keeper->giveMoney(ch, price, GOLD_COMM);
 
-    keeper->doTell(ch->getName(), format("Thanks, here's your %d talen%s.") %
+    keeper->doTell(ch, format("Thanks, here's your %d talen%s.") %
 		   price % (price > 1 ? "s" : ""));
     act("$n sells $p.", TRUE, ch, this, 0, TO_ROOM);
     if (ch->isAffected(AFF_GROUP) && ch->desc &&
@@ -432,7 +432,7 @@ void TOrganic::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
     price = sellPrice(1, shop_nr, -1, ch);
 
   if (!shop_index[shop_nr].willBuy(this)) {
-    keeper->doTell(ch->getName(), shop_index[shop_nr].do_not_buy);
+    keeper->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
 
@@ -448,7 +448,7 @@ void TOrganic::valueMe(TBeing *ch, TMonster *keeper, int shop_nr, int num = 1)
   sellReducePrice(ch, keeper, obj2, price);
 
 
-  keeper->doTell(ch->getName(), format("Hmm, I'd give you %d talen%s for that.") %
+  keeper->doTell(ch, format("Hmm, I'd give you %d talen%s for that.") %
 		 price % (price > 1 ? "s" : ""));
 }
 

--- a/code/code/obj/obj_poison.cc
+++ b/code/code/obj/obj_poison.cc
@@ -71,7 +71,7 @@ int TPoison::objectSell(TBeing *ch, TMonster *keeper)
   sstring buf;
 
   if(!liquidInfo[getDrinkType()]->poison){
-    keeper->doTell(ch->getName(), "Hey, that's not poison!.");
+    keeper->doTell(ch, "Hey, that's not poison!.");
     return TRUE;
   }
 

--- a/code/code/obj/obj_potion.cc
+++ b/code/code/obj/obj_potion.cc
@@ -87,7 +87,7 @@ int TPotion::objectSell(TBeing *ch, TMonster *keeper)
   sstring buf;
 
   if(!liquidInfo[getDrinkType()]->potion){
-    keeper->doTell(ch->getName(), "Hey, that's not a potion!.");
+    keeper->doTell(ch, "Hey, that's not a potion!.");
     return TRUE;
   }
 

--- a/code/code/obj/obj_quiver.cc
+++ b/code/code/obj/obj_quiver.cc
@@ -52,7 +52,7 @@ sstring TQuiver::statObjInfo() const
 bool TQuiver::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair quivers.");
+    repair->doTell(ch, "I can't repair quivers.");
   }
   return true;
 }

--- a/code/code/obj/obj_saddlebag.cc
+++ b/code/code/obj/obj_saddlebag.cc
@@ -50,7 +50,7 @@ sstring TSaddlebag::statObjInfo() const
 bool TSaddlebag::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair saddlebags.");
+    repair->doTell(ch, "I can't repair saddlebags.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_scroll.cc
+++ b/code/code/obj/obj_scroll.cc
@@ -148,7 +148,7 @@ void TScroll::lowCheck()
 bool TScroll::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "You might wanna take that to the magic shop!");
+    repair->doTell(ch, "You might wanna take that to the magic shop!");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_staff.cc
+++ b/code/code/obj/obj_staff.cc
@@ -137,7 +137,7 @@ sstring TStaff::statObjInfo() const
 int TStaff::objectSell(TBeing *ch, TMonster *keeper)
 {
   if (getCurCharges() != getMaxCharges()) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy back expended staves.");
+    keeper->doTell(ch, "I'm sorry, I don't buy back expended staves.");
     return TRUE;
   }
 
@@ -187,7 +187,7 @@ void TStaff::lowCheck()
 bool TStaff::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "You might wanna take that to the magic shop!");
+    repair->doTell(ch, "You might wanna take that to the magic shop!");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_suitcase.cc
+++ b/code/code/obj/obj_suitcase.cc
@@ -50,7 +50,7 @@ sstring TSuitcase::statObjInfo() const
 bool TSuitcase::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair suitcases.");
+    repair->doTell(ch, "I can't repair suitcases.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_symbol.cc
+++ b/code/code/obj/obj_symbol.cc
@@ -93,12 +93,12 @@ int TSymbol::objectSell(TBeing *ch, TMonster *keeper)
   int attuneCode = 1;
 
   if ((getSymbolCurStrength() != getSymbolMaxStrength())) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy back used symbols.");
+    keeper->doTell(ch, "I'm sorry, I don't buy back used symbols.");
     return TRUE;
   }
 
   if ((getSymbolFaction() != FACT_UNDEFINED) && attuneCode) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy back attuned symbols.");
+    keeper->doTell(ch, "I'm sorry, I don't buy back attuned symbols.");
     return TRUE;
   }
 
@@ -178,7 +178,7 @@ void TSymbol::lowCheck()
 bool TSymbol::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "Hey, I don't get involved with religion!");
+    repair->doTell(ch, "Hey, I don't get involved with religion!");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_tool.cc
+++ b/code/code/obj/obj_tool.cc
@@ -111,7 +111,7 @@ sstring TTool::statObjInfo() const
 int TTool::objectSell(TBeing *ch, TMonster *keeper)
 {
   if ((getToolUses() != getToolMaxUses())) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy back used tools.");
+    keeper->doTell(ch, "I'm sorry, I don't buy back used tools.");
     return TRUE;
   }
   return FALSE;

--- a/code/code/obj/obj_tooth_necklace.cc
+++ b/code/code/obj/obj_tooth_necklace.cc
@@ -132,7 +132,7 @@ sstring TToothNecklace::statObjInfo() const
 bool TToothNecklace::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "I can't repair that.");
+    repair->doTell(ch, "I can't repair that.");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_trash.cc
+++ b/code/code/obj/obj_trash.cc
@@ -52,7 +52,7 @@ sstring TTrash::statObjInfo() const
 bool TTrash::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent)
-    repair->doTell(fname(ch->name), format("I'm not the trash man. Take %s to the dump!") % getName());
+    repair->doTell(ch, format("I'm not the trash man. Take %s to the dump!") % getName());
 
   return TRUE;
 }

--- a/code/code/obj/obj_trash_pile.cc
+++ b/code/code/obj/obj_trash_pile.cc
@@ -46,7 +46,7 @@ sstring TTrashPile::statObjInfo() const
 bool TTrashPile::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent)
-    repair->doTell(fname(ch->name), format("I'm not the trash man. Take %s to the dump!") % getName());
+    repair->doTell(ch, format("I'm not the trash man. Take %s to the dump!") % getName());
 
   return TRUE;
 }

--- a/code/code/obj/obj_vial.cc
+++ b/code/code/obj/obj_vial.cc
@@ -45,12 +45,12 @@ int TVial::objectSell(TBeing *ch, TMonster *keeper)
   sstring buf;
 
   if(getDrinkType()!=LIQ_HOLYWATER){
-    keeper->doTell(ch->getName(), "Hey, that's not holy water!");
+    keeper->doTell(ch, "Hey, that's not holy water!");
     return TRUE;
   }
 
   if(getDrinkUnits()!=getMaxDrinkUnits()){
-    keeper->doTell(ch->getName(), "I only purchase full vials.");
+    keeper->doTell(ch, "I only purchase full vials.");
     return TRUE;
   }
 
@@ -60,7 +60,7 @@ int TVial::objectSell(TBeing *ch, TMonster *keeper)
 bool TVial::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent)
-    repair->doTell(fname(ch->name), "You might wanna take that somewhere else!");
+    repair->doTell(ch, "You might wanna take that somewhere else!");
 
   return TRUE;
 }

--- a/code/code/obj/obj_wagon.cc
+++ b/code/code/obj/obj_wagon.cc
@@ -50,7 +50,7 @@ sstring TWagon::statObjInfo() const
 bool TWagon::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent) {
-    repair->doTell(fname(ch->name), "Does this look like a mechanics shop to you?");
+    repair->doTell(ch, "Does this look like a mechanics shop to you?");
   }
   return TRUE;
 }

--- a/code/code/obj/obj_wand.cc
+++ b/code/code/obj/obj_wand.cc
@@ -138,7 +138,7 @@ sstring TWand::statObjInfo() const
 int TWand::objectSell(TBeing *ch, TMonster *keeper)
 {
   if (getCurCharges() != getMaxCharges()) {
-    keeper->doTell(ch->getName(), "I'm sorry, I don't buy back expended wands.");
+    keeper->doTell(ch, "I'm sorry, I don't buy back expended wands.");
     return TRUE;
   }
 
@@ -179,7 +179,7 @@ void TWand::lowCheck()
 bool TWand::objectRepair(TBeing *ch, TMonster *repair, silentTypeT silent)
 {
   if (!silent)
-    repair->doTell(fname(ch->name), "You might wanna take that to the magic shop!");
+    repair->doTell(ch, "You might wanna take that to the magic shop!");
 
   return TRUE;
 }

--- a/code/code/spec/spec_mobs.cc
+++ b/code/code/spec/spec_mobs.cc
@@ -383,7 +383,7 @@ int rumorMonger(TBeing *ch, cmdTypeT cmd, const char *, TMonster *myself, TObj *
       if (strlen(buf) >= 1)
         buf[strlen(buf) - 1] = '\0';
 
-      myself->doTell(fname(ch->name), buf);
+      myself->doTell(ch, buf);
       fclose(fp);
       return TRUE;
     }
@@ -437,7 +437,7 @@ int rumorMonger(TBeing *ch, cmdTypeT cmd, const char *, TMonster *myself, TObj *
     if (strlen(buf) >= 1)
       buf[strlen(buf) - 1] = '\0';
 
-    myself->doTell(fname(ch->name), buf);
+    myself->doTell(ch, buf);
     fclose(fp);
     return TRUE;
   }
@@ -536,7 +536,7 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
         ch->doWhisper(arg);
       else
         ch->doAsk(arg);
-      me->doTell(ch->getName(), "You are not a cleric or deikhan. I am not that charitable.");
+      me->doTell(ch, "You are not a cleric or deikhan. I am not that charitable.");
       return TRUE;
     } else {
       request = 2;
@@ -564,7 +564,7 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
     return FALSE;
   
   if (ch->GetMaxLevel() >= 10) {
-    me->doTell(ch->getName(), "I can no longer help you!");
+    me->doTell(ch, "I can no longer help you!");
     return TRUE;
   }
 
@@ -594,13 +594,13 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
         act("$n smiles and hands $N some equipment.", TRUE, me, NULL, ch,TO_NOTVICT);
         act("$n smiles and hands you some equipment.", TRUE, me, NULL, ch,TO_VICT);
         ch->doNewbieEqLoad(RACE_NORACE, 0, true);
-        me->doTell(ch->getName(), "May these items serve you well.  Be more careful next time!");
+        me->doTell(ch, "May these items serve you well.  Be more careful next time!");
         found = 2;
       }
       break;
     case 2:
       if (!ch->hasClass(CLASS_CLERIC) &&  !ch->hasClass(CLASS_DEIKHAN)) {
-        me->doTell(ch->getName(), "You are not a cleric or deikhan. I only give symbols to those who will use them.");
+        me->doTell(ch, "You are not a cleric or deikhan. I only give symbols to those who will use them.");
         return TRUE;
       }
       if (ch->affectedBySpell(AFFECT_NEWBIE)) {
@@ -616,7 +616,7 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
           }
         }
         if (best) {
-          me->doTell(ch->getName(), "You already have a symbol.  I only help the the totally destitute.");
+          me->doTell(ch, "You already have a symbol.  I only help the the totally destitute.");
           return TRUE;
         }
         act("$n rummages through a bin and selects an item.", TRUE, me, NULL, NULL, TO_ROOM);
@@ -631,7 +631,7 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
           act("$n smiles and hands a holy symbol to you.", TRUE, me, NULL, ch,TO_VICT);
         }
         personalize_object(NULL, ch, 500, -1);
-        me->doTell(ch->getName(), "May it serve you well. Be more careful next time!");
+        me->doTell(ch, "May it serve you well. Be more careful next time!");
         found = 2;
         if (ch->hasClass(CLASS_CLERIC))
           duration = max(1, (ch->GetMaxLevel() / 3)) * 48 * Pulse::UPDATES_PER_MUDHOUR;
@@ -639,12 +639,12 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
       break;
     case 3:
       if (ch->hasClass(CLASS_MONK)) {
-        me->doTell(ch->getName(), "You are a monk.  I only help those who directly need the help.");
+        me->doTell(ch, "You are a monk.  I only help those who directly need the help.");
         return TRUE;
       }
       for(StuffIter it=ch->stuff.begin();it!=ch->stuff.end() && (i=*it);++it) {
         if (dynamic_cast<TGenWeapon *>(i)) {
-          me->doTell(ch->getName(), "You already have a weapon.  I only help the the totally destitute.");
+          me->doTell(ch, "You already have a weapon.  I only help the the totally destitute.");
           return TRUE;
         }
       }
@@ -671,7 +671,7 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
         }
         act("$n smiles and hands $p to $N.", TRUE, me, obj, ch,TO_NOTVICT);
         act("$n smiles and hands $p to you.", TRUE, me, obj, ch,TO_VICT);
-        me->doTell(ch->getName(), "May it serve you well. Be more careful next time!");
+        me->doTell(ch, "May it serve you well. Be more careful next time!");
         found = 2;
         duration = max(1, (ch->GetMaxLevel() / 3)) * 48 * Pulse::UPDATES_PER_MUDHOUR;
       }
@@ -696,7 +696,7 @@ int newbieEquipper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj
       vlogf(LOG_MISC, format("Switched god used newbieEquip  %s by %s") %  ch->getName()  % me->getName());
     }
   } else if (found == 1) {
-    me->doTell(ch->getName(), "You just used my service.  Come back later and only if you haven't gotten other help.");
+    me->doTell(ch, "You just used my service.  Come back later and only if you haven't gotten other help.");
     return TRUE;
   } else {
     vlogf(LOG_BUG, format("Somehow something got through equipNewbie %s by %s") %  ch->getName() % me->getName());
@@ -1571,7 +1571,7 @@ int payToll(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, TObj *)
               return FALSE;
 
         if (ch->isPc())
-          myself->doTell(ch->getName(), "Hey! Your not authorized to be here!");
+          myself->doTell(ch, "Hey! Your not authorized to be here!");
 
         act("$n shoves you south out of the room!", FALSE, myself, 0, ch, TO_VICT);
         act("$n shoves $N south out of the room!", FALSE, myself, 0, ch, TO_NOTVICT);
@@ -2823,8 +2823,8 @@ int petVeterinarian(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TOb
   if(cmd == CMD_LIST){
     for(int i=1;db.fetchRow();++i){
       if(i==1){
-	me->doTell(ch->getName(), "Yeah, your pet dragged himself in here, half dead, and I fixed him up.");
-	me->doTell(ch->getName(), "You'll have to pay the bill if you want the cuddly little thing back.");
+	me->doTell(ch, "Yeah, your pet dragged himself in here, half dead, and I fixed him up.");
+	me->doTell(ch, "You'll have to pay the bill if you want the cuddly little thing back.");
       }
       
       vnum=convertTo<int>(db["vnum"]);
@@ -2837,10 +2837,10 @@ int petVeterinarian(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TOb
 	  short_desc=format("\"%s\", the %s") % db["name"].cap() % short_desc;
 	else
 	  short_desc=format("\"%s\", %s") % db["name"].cap() % short_desc;
-	me->doTell(ch->getName(), format("%i) %s - %i talens") %
+	me->doTell(ch, format("%i) %s - %i talens") %
 		   i % short_desc % petPriceL(level));
       } else {
-	me->doTell(ch->getName(), format("%i) %s - %i talens") %
+	me->doTell(ch, format("%i) %s - %i talens") %
 		   i % short_desc % petPriceL(level));
       }
     }
@@ -2884,7 +2884,7 @@ int petVeterinarian(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TOb
 	    }
 	    
 	    if(name == db["name"]){
-	      me->doTell(ch->getName(), "Hmm my mistake, I thought that guy wandered in here but looks like it wandered out again...");
+	      me->doTell(ch, "Hmm my mistake, I thought that guy wandered in here but looks like it wandered out again...");
 	      return TRUE;
 	    }
 	  }
@@ -2895,7 +2895,7 @@ int petVeterinarian(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TOb
     int price=petPriceL(level);
 
     if(ch->getMoney() < price){
-      me->doTell(ch->getName(), "You can't afford it!");
+      me->doTell(ch, "You can't afford it!");
       return TRUE;
     }
 
@@ -3012,9 +3012,9 @@ int pet_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     sstring tellBuf = "Look through the ";
     tellBuf += tw ? fname(tw->name) : "window";
     tellBuf += " to see the pets!";
-    me->doTell(fname(ch->name), tellBuf);
+    me->doTell(ch, tellBuf);
 
-    me->doTell(ch->getName(), "If you see something you'd like, VALUE <mob> and I'll tell you the price.");
+    me->doTell(ch, "If you see something you'd like, VALUE <mob> and I'll tell you the price.");
     return TRUE;
   } else if (cmd == CMD_BUY) {
     arg = one_argument(arg, buf, cElements(buf));
@@ -3028,13 +3028,13 @@ int pet_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       sstring tellBuf = "Look through the ";
       tellBuf += tw ? fname(tw->name) : "window";
       tellBuf += " again, there is no such pet!";
-      me->doTell(fname(ch->name), tellBuf);
+      me->doTell(ch, tellBuf);
 
       return TRUE;
     }
 
     if (pet->desc || pet->isPc() || pet->number < 0) {
-      me->doTell(fname(ch->name), format("%s is not for sale.") % pet->getName());
+      me->doTell(ch, format("%s is not for sale.") % pet->getName());
       return TRUE;
     }
     int petLevel = pet->GetMaxLevel();
@@ -3043,17 +3043,17 @@ int pet_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     if (ch->isImmortal()) {
     } else if (!ch->hasClass(CLASS_RANGER)) {
       if ((4 * petLevel) > (3 * pcLevel)) {
-        me->doTell(fname(ch->name), "I think I would be negligent if I sold you so powerful a pet.");
+        me->doTell(ch, "I think I would be negligent if I sold you so powerful a pet.");
         return TRUE;
       }
     } else {
       if (petLevel > pcLevel) {
-        me->doTell(fname(ch->name), "I think I would be negligent if I sold you so powerful a pet.");
+        me->doTell(ch, "I think I would be negligent if I sold you so powerful a pet.");
         return TRUE;
       }
     }
     if (ch->tooManyFollowers(pet, FOL_PET)) {
-      me->doTell(fname(ch->name), "With your charisma, it would be animal abuse for me to sell you this pet.");
+      me->doTell(ch, "With your charisma, it would be animal abuse for me to sell you this pet.");
       return TRUE;
     }
 
@@ -3061,7 +3061,7 @@ int pet_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
 		  shop_index[shop_nr].getProfitBuy(NULL, ch));
 
     if (ch->isPc() && ((ch->getMoney()) < price) && !ch->isImmortal()) {
-      me->doTell(ch->name, "You don't have enough money for that pet!");
+      me->doTell(ch, "You don't have enough money for that pet!");
       return TRUE;
     }
     if (!(pet = read_mobile(pet->number, REAL))) {
@@ -3120,7 +3120,7 @@ int pet_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
       sstring tellBuf = "Look through the ";
       tellBuf += tw ? fname(tw->name) : "window";
       tellBuf += " again, there is no such pet!";
-      me->doTell(fname(ch->name), tellBuf);
+      me->doTell(ch, tellBuf);
       return TRUE;
     }
     int petLevel = pet->GetMaxLevel();
@@ -3129,20 +3129,20 @@ int pet_keeper(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     price = (int)((float) pet->petPrice() * 
 		  shop_index[shop_nr].getProfitBuy(NULL, ch));
 
-    me->doTell(ch->name, format("A pet %s will cost %d to purchase.") % fname(pet->name) % price);
-    //    me->doTell(ch->name, format("and %d to rent.") % (pet->petPrice() / 4));
+    me->doTell(ch, format("A pet %s will cost %d to purchase.") % fname(pet->name) % price);
+    //    me->doTell(ch, format("and %d to rent.") % (pet->petPrice() / 4));
     if (ch->isImmortal()) {
     } else if (!ch->hasClass(CLASS_RANGER)) {
       if ((4 * petLevel) > (3 * pcLevel)) {
-        me->doTell(fname(ch->name), "I think I would be negligent if I sold you so powerful a pet.");
+        me->doTell(ch, "I think I would be negligent if I sold you so powerful a pet.");
       }
     } else {
       if (petLevel > pcLevel) {
-        me->doTell(fname(ch->name), "I think I would be negligent if I sold you so powerful a pet.");
+        me->doTell(ch, "I think I would be negligent if I sold you so powerful a pet.");
       }
     }
     if (ch->tooManyFollowers(pet, FOL_PET)) {
-      me->doTell(fname(ch->name), "With your charisma, it would be animal abuse for me to sell you this pet.");
+      me->doTell(ch, "With your charisma, it would be animal abuse for me to sell you this pet.");
     }
     return TRUE;
   }
@@ -3161,7 +3161,7 @@ int stable_man(TBeing *ch, cmdTypeT cmd, const char *, TMonster *me, TObj *)
     sstring tellBuf = "Look through the ";
     tellBuf += tw ? fname(tw->name) : "window";
     tellBuf += " to see the mounts!";
-    me->doTell(fname(ch->name), tellBuf);
+    me->doTell(ch, tellBuf);
 
     return TRUE;
   }
@@ -3230,7 +3230,7 @@ static void attuneStructSanityCheck(attune_struct *job)
 
 void TThing::attunerValue(TBeing *ch, TMonster *me)
 {
-  me->doTell(ch->getName(), "I can only attune symbols.");
+  me->doTell(ch, "I can only attune symbols.");
 }
 
 void TSymbol::attunerValue(TBeing *ch, TMonster *me)
@@ -3238,19 +3238,19 @@ void TSymbol::attunerValue(TBeing *ch, TMonster *me)
   int cost;
 
   if (getSymbolFaction() != FACT_UNDEFINED) {
-    me->doTell(ch->getName(), format("%s has already been attuned!") % getName());
+    me->doTell(ch, format("%s has already been attuned!") % getName());
     return;
   }
   cost = attunePrice(this, ch, find_shop_nr(me->number));
 
-  me->doTell(ch->getName(), format("I will tithe you %d talens to attune your %s.") % cost % getName());
+  me->doTell(ch, format("I will tithe you %d talens to attune your %s.") % cost % getName());
 }
 
 void TThing::attunerGiven(TBeing *ch, TMonster *me)
 {
   sstring buf;
 
-  me->doTell(ch->getName(), "I can only attune symbols!");
+  me->doTell(ch, "I can only attune symbols!");
   buf=format("%s %s") % add_bars(name) % fname(ch->name);
   me->doGive(buf, GIVE_FLAG_IGN_DEX_TEXT);
 }
@@ -3262,7 +3262,7 @@ void TSymbol::attunerGiven(TBeing *ch, TMonster *me)
   attune_struct *job;
 
   if (getSymbolFaction() != FACT_UNDEFINED) {
-    me->doTell(ch->getName(), "That symbol has already been attuned!");
+    me->doTell(ch, "That symbol has already been attuned!");
     strcpy(buf, name.c_str());
     strcpy(buf, add_bars(buf).c_str());
     sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -3272,7 +3272,7 @@ void TSymbol::attunerGiven(TBeing *ch, TMonster *me)
   cost = attunePrice(this, ch, find_shop_nr(me->number));
 
   if (ch->getMoney() < cost) {
-    me->doTell(ch->getName(), "I only attune for a reasonable tithe. I am sorry, I do not make exceptions!");
+    me->doTell(ch, "I only attune for a reasonable tithe. I am sorry, I do not make exceptions!");
     strcpy(buf, name.c_str());
     strcpy(buf, add_bars(buf).c_str());
     sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -3542,27 +3542,27 @@ int attuner(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       break;
     case CMD_VALUE:
       if (!ch->hasClass(CLASS_CLERIC) && !ch->hasClass(CLASS_DEIKHAN)) {
-        me->doTell(ch->getName(), "You are not a cleric or Deikhan.  I can not help you.");
+        me->doTell(ch, "You are not a cleric or Deikhan.  I can not help you.");
         return TRUE;
       }
       for(; *arg && isspace(*arg);arg++);
 
       if (!(t = searchLinkedListVis(ch, arg, ch->stuff))) {
-        me->doTell(ch->getName(), "You don't have that symbol.");
+        me->doTell(ch, "You don't have that symbol.");
         return TRUE;
       }
       t->attunerValue(ch, me);
       return TRUE;
     case CMD_MOB_GIVEN_ITEM:
       if (!(t = o)) {
-        me->doTell(ch->getName(), "You don't have that item!");
+        me->doTell(ch, "You don't have that item!");
         return TRUE;
       }
       if (!ch->hasClass(CLASS_CLERIC) && !ch->hasClass(CLASS_DEIKHAN)) {
         act("You do not accept $N's offer to give you $p.", TRUE, me, t, ch, TO_CHAR);
         act("$n rejects your attempt to give $s $p.", TRUE, me, t, ch, TO_VICT);
         act("$n refuses to accept $p from $N.", TRUE, me, t, ch, TO_NOTVICT); 
-        me->doTell(ch->getName(), "You are not a cleric or Deikhan.  I can not help you.");
+        me->doTell(ch, "You are not a cleric or Deikhan.  I can not help you.");
         strcpy(buf, t->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -3574,7 +3574,7 @@ int attuner(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
         act("You do not accept $N's offer to give you $p.", TRUE, me, t, ch, TO_CHAR);
         act("$n rejects your attempt to give $s $p.", TRUE, me, t, ch, TO_VICT);
         act("$n refuses to accept $p from $N.", TRUE, me, t, ch, TO_NOTVICT);
-        me->doTell(ch->getName(), "I can not help you unless you take a position of rest.");
+        me->doTell(ch, "I can not help you unless you take a position of rest.");
         strcpy(buf, t->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -3592,7 +3592,7 @@ int attuner(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 
 int TThing::sharpenerValueMe(const TBeing *ch, TMonster *me) const
 {
-  me->doTell(ch->getName(), "I can only value weapons.");
+  me->doTell(ch, "I can only value weapons.");
   return TRUE;
 }
 
@@ -3600,7 +3600,7 @@ int TThing::sharpenerGiveMe(TBeing *ch, TMonster *me)
 {
   char buf[256];
 
-  me->doTell(ch->getName(), "I can only sharpen weapons!");
+  me->doTell(ch, "I can only sharpen weapons!");
   strcpy(buf, name.c_str());
   strcpy(buf, add_bars(buf).c_str());
   sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -3761,13 +3761,13 @@ int sharpener(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       for(; *arg && isspace(*arg);arg++);
 
       if (!(valued = searchLinkedListVis(ch, arg, ch->stuff))) {
-        me->doTell(ch->getName(), "You don't have that item.");
+        me->doTell(ch, "You don't have that item.");
         return TRUE;
       }
       return valued->sharpenerValueMe(ch, me);
     case CMD_MOB_GIVEN_ITEM:
       if (!(weap = o)) {
-        me->doTell(ch->getName(), "You don't have that item!");
+        me->doTell(ch, "You don't have that item!");
         return TRUE;
       }
       me->logItem(weap, CMD_EAST);  // log the receipt of the item
@@ -4435,7 +4435,7 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       TObj *valued = NULL;
       if (!(ts = searchLinkedListVis(ch, arg, ch->stuff)) ||
           !(valued = dynamic_cast<TObj *>(ts))) {
-        me->doTell(ch->getName(), "You don't have that item.");
+        me->doTell(ch, "You don't have that item.");
         return TRUE;
       }
 
@@ -4443,35 +4443,35 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
         return TRUE;
 
       if (valued->obj_flags.cost <=  500) {
-        me->doTell(ch->getName(), "This item is too cheap to be engraved.");
+        me->doTell(ch, "This item is too cheap to be engraved.");
         return TRUE;
       }
       if (!valued->action_description.empty()) {
-        me->doTell(ch->getName(), "This item has already been engraved!");
+        me->doTell(ch, "This item has already been engraved!");
         return TRUE;
       }
       if (obj_index[valued->getItemIndex()].max_exist <= 10) {
-        me->doTell(ch->getName(), "I refuse to engrave such an artifact of beauty!");
+        me->doTell(ch, "I refuse to engrave such an artifact of beauty!");
         return TRUE;
       }
       if (valued->obj_flags.decay_time >= 0) {
-        me->doTell(ch->getName(), "Sorry, but this item won't last long enough to bother with an engraving!");
+        me->doTell(ch, "Sorry, but this item won't last long enough to bother with an engraving!");
         return TRUE;
       }
 
       cost = engraveCost(valued, ch, find_shop_nr(me->number));
 
-      me->doTell(ch->getName(), format("It will cost %d talens to engrave your %s.") % cost % fname(valued->name));
+      me->doTell(ch, format("It will cost %d talens to engrave your %s.") % cost % fname(valued->name));
       return TRUE;
       }
     case CMD_MOB_GIVEN_ITEM:
       // prohibit polys and charms from engraving 
       if (dynamic_cast<TMonster *>(ch)) {
-        me->doTell(fname(ch->name), "I don't engrave for beasts.");
+        me->doTell(ch, "I don't engrave for beasts.");
         return TRUE;
       }
       if (!(item = o)) {
-        me->doTell(ch->getName(), "You don't have that item!");
+        me->doTell(ch, "You don't have that item!");
         return TRUE;
       }
       me->logItem(item, CMD_EAST);  // log the receipt of the item
@@ -4480,7 +4480,7 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
         return TRUE;
 
       if (item->obj_flags.cost <= 500) {
-        me->doTell(ch->getName(), "That can't be engraved!");
+        me->doTell(ch, "That can't be engraved!");
         strcpy(buf, item->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -4488,7 +4488,7 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
         return TRUE;
       }
       if (!item->action_description.empty()) {
-        me->doTell(ch->getName(), "Sorry, but this item has already been engraved!");
+        me->doTell(ch, "Sorry, but this item has already been engraved!");
         strcpy(buf, item->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -4496,7 +4496,7 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
         return TRUE;
       }
       if (obj_index[item->getItemIndex()].max_exist <= 10) {
-        me->doTell(ch->getName(), "This artifact is too powerful to be engraved!");
+        me->doTell(ch, "This artifact is too powerful to be engraved!");
         strcpy(buf, item->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -4504,7 +4504,7 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
         return TRUE;
       }
       if (item->obj_flags.decay_time >= 0) {
-        me->doTell(ch->getName(), "This won't be around long enough to bother engraving it!");
+        me->doTell(ch, "This won't be around long enough to bother engraving it!");
         strcpy(buf, item->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -4515,7 +4515,7 @@ int engraver(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       cost = engraveCost(item, ch, find_shop_nr(me->number));
 
       if (ch->getMoney() < cost) {
-        me->doTell(ch->getName(), "I have to make a living! If you don't have the money, I don't do the work!");
+        me->doTell(ch, "I have to make a living! If you don't have the money, I don't do the work!");
         strcpy(buf, item->name.c_str());
         strcpy(buf, add_bars(buf).c_str());
         sprintf(buf + strlen(buf), " %s", fname(ch->name).c_str());
@@ -4592,23 +4592,23 @@ int TicketGuy(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     return FALSE;
 
   if (ch->getPosition() > POSITION_STANDING) {
-    me->doTell(fname(ch->name), "I won't sell you a ticket unless you stand on your own feet.");
+    me->doTell(ch, "I won't sell you a ticket unless you stand on your own feet.");
     return TRUE;
   }
 
   arg = one_argument(arg, obj_name, cElements(obj_name));
 
   if (!*obj_name || strcmp(obj_name,"ticket")) {
-    me->doTell(fname(ch->name), "Buy what?!?");
+    me->doTell(ch, "Buy what?!?");
     return TRUE;
   }
   // prohibit polys and charms from engraving 
   if (dynamic_cast<TMonster *>(ch)) {
-    me->doTell(fname(ch->name), "I don't sell tickets to beasts.");
+    me->doTell(ch, "I don't sell tickets to beasts.");
     return TRUE;
   }
   if (ch->getMoney() < TICKET_PRICE) {
-    me->doTell(fname(ch->name), format("Tickets cost %d talens.") % TICKET_PRICE);
+    me->doTell(ch, format("Tickets cost %d talens.") % TICKET_PRICE);
     return TRUE;
   }
   ch->addToMoney(-TICKET_PRICE, GOLD_HOSPITAL);
@@ -5568,34 +5568,34 @@ int divman(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       TObj *valued = NULL;
       if (!(ts = searchLinkedListVis(ch, arg, ch->stuff)) ||
           !(valued = dynamic_cast<TObj *>(ts))) {
-        me->doTell(ch->getName(), "You don't have that item.");
+        me->doTell(ch, "You don't have that item.");
         return TRUE;
       }
       if (valued->obj_flags.decay_time >= 0) {
-        me->doTell(ch->getName(), "Sorry, but this item won't last long and isn't worth the money spent.");
+        me->doTell(ch, "Sorry, but this item won't last long and isn't worth the money spent.");
         return TRUE;
       }
 
       cost = divCost(valued, ch, find_shop_nr(me->number));
 
-      me->doTell(ch->getName(), format("It will cost %d talens to identify your %s.") % cost % fname(valued->name));
+      me->doTell(ch, format("It will cost %d talens to identify your %s.") % cost % fname(valued->name));
       return TRUE;
       }
     case CMD_MOB_GIVEN_ITEM:
       if (!(item = o)) {
-        me->doTell(ch->getName(), "You don't have that item!");
+        me->doTell(ch, "You don't have that item!");
         return TRUE;
       }
       // prohibit polys and charms from engraving 
       if (dynamic_cast<TMonster *>(ch)) {
-        me->doTell(fname(ch->name), "I don't identify for beasts.");
+        me->doTell(ch, "I don't identify for beasts.");
         me->doGive(ch, item,GIVE_FLAG_IGN_DEX_TEXT);
         return TRUE;
       }
       me->logItem(item, CMD_EAST);  // log the receipt of the item
       cost = divCost(item, ch, find_shop_nr(me->number));
       if (ch->getMoney() < cost) {
-        me->doTell(ch->getName(), "I have to make a living! If you don't have the money, I don't do the work!");
+        me->doTell(ch, "I have to make a living! If you don't have the money, I don't do the work!");
         me->doGive(ch,item,GIVE_FLAG_IGN_DEX_TEXT);
         return TRUE;
       }
@@ -6280,35 +6280,35 @@ int commodMaker(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o
   if(cmd == CMD_VALUE){
     if (!(ts = searchLinkedListVis(ch, arg, ch->stuff)) ||
 	!(o = dynamic_cast<TObj *>(ts))) {
-      me->doTell(ch->getName(), "You don't have that item.");
+      me->doTell(ch, "You don't have that item.");
       return TRUE;
     }
 
     if(!okForCommodMaker(o, buf)){
-      me->doTell(ch->getName(), buf);
+      me->doTell(ch, buf);
       return TRUE;
     }
 
     mat_list=commodMakerValue(o, value);
 
-    me->doTell(ch->getName(), "I can turn that into:");
+    me->doTell(ch, "I can turn that into:");
     for(iter=mat_list.begin();iter!=mat_list.end();++iter){
-       me->doTell(ch->getName(), format("%i units of %s.") %
+       me->doTell(ch, format("%i units of %s.") %
 		 (*iter).second % material_nums[(*iter).first].mat_name);
     }
-    me->doTell(ch->getName(), format("My fee for this is %i talens.") %
+    me->doTell(ch, format("My fee for this is %i talens.") %
 	       (int)(shop_index[shop_nr].getProfitBuy(o, ch) * value));
 
     return TRUE;
   } else if(cmd == CMD_MOB_GIVEN_ITEM){
     if (o->isObjStat(ITEM_NEWBIE) || material_nums[o->getMaterial()].price <= 0){
-      me->doTell(ch->getName(), "That isn't a valuable commodity - I can't convert that.");
+      me->doTell(ch, "That isn't a valuable commodity - I can't convert that.");
       me->doGive(ch,o, GIVE_FLAG_DROP_ON_FAIL);
       return TRUE;
     }
 
     if(!okForCommodMaker(o,buf)){
-      me->doTell(ch->getName(), buf);
+      me->doTell(ch, buf);
       me->doGive(ch,o, GIVE_FLAG_DROP_ON_FAIL);
       return TRUE;
     }
@@ -6317,7 +6317,7 @@ int commodMaker(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o
     value = (int)(shop_index[shop_nr].getProfitBuy(o, ch) * value);
 
     if(ch->getMoney() < (int)value){
-      me->doTell(ch->getName(), "You can't afford it!");
+      me->doTell(ch, "You can't afford it!");
       me->doGive(ch,o, GIVE_FLAG_DROP_ON_FAIL);
       return TRUE;
     }
@@ -6335,7 +6335,7 @@ int commodMaker(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o
       commod->setWeight((*iter).second/10.0);
       commod->setMaterial((*iter).first);
       
-      me->doTell(ch->getName(), "Alright, here you go!");
+      me->doTell(ch, "Alright, here you go!");
       
       *me += *commod;
       me->doGive(ch,commod, GIVE_FLAG_DROP_ON_FAIL);
@@ -6647,7 +6647,7 @@ int shopWhisper(TBeing *ch, TMonster *myself, int shop_nr, const char *arg)
   } else if(!strcmp(buf, "string")){
     tso.setString(arg);
   } else {
-    myself->doTell(ch->getName(), "Read 'help shop owner' for assistance.");
+    myself->doTell(ch, "Read 'help shop owner' for assistance.");
   }
 
   return TRUE;

--- a/code/code/spec/spec_mobs_auctioneer.cc
+++ b/code/code/spec/spec_mobs_auctioneer.cc
@@ -115,7 +115,7 @@ void auctionList(TBeing *ch, TMonster *myself)
   db.query("select ticket, current_bid, days, buyout from shopownedauction where shop_nr=%i and seller=%i", shop_nr, ch->getPlayerID());
   
   if(db.fetchRow()){
-    myself->doTell(ch->getName(), "These are your auctions:");
+    myself->doTell(ch, "These are your auctions:");
   
     do {
       ticket=convertTo<int>(db["ticket"]);
@@ -140,7 +140,7 @@ void auctionList(TBeing *ch, TMonster *myself)
   db.query("select ticket, current_bid from shopownedauction where shop_nr=%i and bidder=%i and days <= 0", shop_nr, ch->getPlayerID());
   
   if(db.fetchRow()){
-    myself->doTell(ch->getName(), "These are the items you've won:");
+    myself->doTell(ch, "These are the items you've won:");
   
     do {
       ticket=convertTo<int>(db["ticket"]);
@@ -163,7 +163,7 @@ void auctionList(TBeing *ch, TMonster *myself)
   db.query("select ticket, current_bid, days, buyout from shopownedauction where shop_nr=%i and days>0", shop_nr);
   
   if(db.fetchRow()){
-    myself->doTell(ch->getName(), "This is what I have up for auction:");
+    myself->doTell(ch, "This is what I have up for auction:");
 
     do {
       ticket=convertTo<int>(db["ticket"]);
@@ -182,7 +182,7 @@ void auctionList(TBeing *ch, TMonster *myself)
     } while(db.fetchRow());
 
   } else
-    myself->doTell(ch->getName(), "I don't have anything up for auction right now");
+    myself->doTell(ch, "I don't have anything up for auction right now");
 }
 
 
@@ -202,22 +202,22 @@ void auctionSell(TBeing *ch, TMonster *myself, sstring arg)
   int buyout=convertTo<int>(arg.word(3));
 
   if(min_bid <= 0 || days <= 0 || (buyout && buyout < min_bid)){
-    myself->doTell(ch->getName(), "Usage: sell <item> <minimum bid> <mud days to run auction> <buyout bid>");
-    myself->doTell(ch->getName(), "");
-    myself->doTell(ch->getName(), format("There is a listing fee of %i talens per mud day, as well as a fee of %f percent of the final sale price, if the item sells.") %
+    myself->doTell(ch, "Usage: sell <item> <minimum bid> <mud days to run auction> <buyout bid>");
+    myself->doTell(ch, "");
+    myself->doTell(ch, format("There is a listing fee of %i talens per mud day, as well as a fee of %f percent of the final sale price, if the item sells.") %
 		   (int)shop_index[shop_nr].getProfitBuy(NULL, ch) %
 		   (shop_index[shop_nr].getProfitSell(NULL, ch) * 100));
-    myself->doTell(ch->getName(), "The proceeds will be automatically deposited to your bank account when the buyer pays for the item.");
+    myself->doTell(ch, "The proceeds will be automatically deposited to your bank account when the buyer pays for the item.");
     return;
   }
 
   // find the object
   if(!(obj=generic_find_obj(name, FIND_OBJ_INV, ch))){
-    myself->doTell(ch->getName(), "You don't have that!");
+    myself->doTell(ch, "You don't have that!");
     return;
   }
   if (!(shop_index[shop_nr].willBuy(obj))) {
-    myself->doTell(ch->name, shop_index[shop_nr].do_not_buy);
+    myself->doTell(ch, shop_index[shop_nr].do_not_buy);
     return;
   }
   if (will_not_buy(ch, myself, obj, shop_nr)) 
@@ -230,7 +230,7 @@ void auctionSell(TBeing *ch, TMonster *myself, sstring arg)
 
   if(!db.fetchRow()){
     TRoom *tr=real_roomp(shop_index[corp.getBank()].in_room);
-    myself->doTell(ch->getName(), format("You need to have a bank account at %s in order to sell items here.") % tr->getName());
+    myself->doTell(ch, format("You need to have a bank account at %s in order to sell items here.") % tr->getName());
     return;
   }
 
@@ -260,7 +260,7 @@ void auctionSell(TBeing *ch, TMonster *myself, sstring arg)
 
   delete obj;
   
-  myself->doTell(ch->getName(), "Your item has been placed on the auction block.");
+  myself->doTell(ch, "Your item has been placed on the auction block.");
 }
 
 void auctionBuy(TBeing *ch, TMonster *myself, sstring arg)
@@ -273,14 +273,14 @@ void auctionBuy(TBeing *ch, TMonster *myself, sstring arg)
   TCorporation corp(tso.getCorpID());
 
   if(!ticket){
-    myself->doTell(ch->getName(), "That isn't a valid item number.");
+    myself->doTell(ch, "That isn't a valid item number.");
     return;
   }
 
   db.query("select current_bid, bidder, days from shopownedauction where shop_nr=%i and ticket=%i", shop_nr, ticket);
   
   if(!db.fetchRow()){
-    myself->doTell(ch->getName(), "That isn't a valid item number.");
+    myself->doTell(ch, "That isn't a valid item number.");
     return;
   }
   
@@ -290,11 +290,11 @@ void auctionBuy(TBeing *ch, TMonster *myself, sstring arg)
   fee=(int)((float)bid * shop_index[shop_nr].getProfitSell(NULL, ch));
 
   if(days > 0){
-    myself->doTell(ch->getName(), "That auction isn't over yet.");
+    myself->doTell(ch, "That auction isn't over yet.");
   } else if(bidder != ch->getPlayerID()){
-    myself->doTell(ch->getName(), "You didn't win that auction.");
+    myself->doTell(ch, "You didn't win that auction.");
   } else if(ch->getMoney() < bid){
-    myself->doTell(ch->getName(), "You can't afford to pay for that item.");
+    myself->doTell(ch, "You can't afford to pay for that item.");
   } else {
     ItemLoad il;
 
@@ -312,7 +312,7 @@ void auctionBuy(TBeing *ch, TMonster *myself, sstring arg)
     
 
     *ch += *obj;
-    myself->doTell(ch->getName(), format("That'll be %i talens.") % bid);
+    myself->doTell(ch, format("That'll be %i talens.") % bid);
     ch->sendTo(COLOR_BASIC, format("You now have %s.") % obj->getName());
     
     db.query("delete from shopownedauction where ticket=%i", ticket);
@@ -329,14 +329,14 @@ void auctionBid(TBeing *ch, TMonster *myself, sstring arg)
   int shop_nr=find_shop_nr(myself->number);
 
   if(!ticket){
-    myself->doTell(ch->getName(), "Make a bid on what item?");
+    myself->doTell(ch, "Make a bid on what item?");
     return;
   }
 
   db.query("select seller, bidder, current_bid, max_bid, buyout from shopownedauction where ticket=%i", ticket);
 
   if(!db.fetchRow()){
-    myself->doTell(ch->getName(), "I don't have that item.");
+    myself->doTell(ch, "I don't have that item.");
     return;
   }
 
@@ -347,36 +347,36 @@ void auctionBid(TBeing *ch, TMonster *myself, sstring arg)
   seller=convertTo<int>(db["seller"]);
 
   if(my_bid >= buyout){
-    myself->doTell(ch->getName(), "Congratulations, you've won the auction.");
+    myself->doTell(ch, "Congratulations, you've won the auction.");
     db.query("update shopownedauction set days=0, current_bid=%i, bidder=%i where ticket=%i",
 	     my_bid, ch->getPlayerID(), ticket);
     shoplog(shop_nr, ch, myself, format("ticket %i, bid %i") % ticket % my_bid, 
 	    0, "buyout");
     endAuction(ticket, ch->getPlayerID(), seller);
   } else  if((bidder == ch->getPlayerID()) && my_bid < max_bid){
-    myself->doTell(ch->getName(), "You're already the high bidder!");
-    myself->doTell(ch->getName(), "Your bid must be greater than your previous max bid if you want to increase it.");
+    myself->doTell(ch, "You're already the high bidder!");
+    myself->doTell(ch, "Your bid must be greater than your previous max bid if you want to increase it.");
   } else if(bidder == ch->getPlayerID()){
-    myself->doTell(ch->getName(), "You're already the high bidder!");
-    myself->doTell(ch->getName(), "Your max bid has been increased.");
+    myself->doTell(ch, "You're already the high bidder!");
+    myself->doTell(ch, "Your max bid has been increased.");
     db.query("update shopownedauction set max_bid=%i where ticket=%i",
 	     my_bid, ticket);
     shoplog(shop_nr, ch, myself, "max bid increased", 0, format("%i talens") % 
 	    my_bid);
   } else if(my_bid <= current_bid){
-    myself->doTell(ch->getName(), "That bid is less than the current bid!");
+    myself->doTell(ch, "That bid is less than the current bid!");
   } else if(my_bid == max_bid){
-    myself->doTell(ch->getName(), "You've been outbidded.");
+    myself->doTell(ch, "You've been outbidded.");
     db.query("update shopownedauction set current_bid=%i where ticket=%i", 
 	     my_bid, ticket);
     shoplog(shop_nr, ch,myself, "outbidded", 0, format("%i talens") % my_bid);
   } else if(my_bid < max_bid){
-    myself->doTell(ch->getName(), "You've been outbidded.");
+    myself->doTell(ch, "You've been outbidded.");
     db.query("update shopownedauction set current_bid=%i where ticket=%i", 
 	     my_bid+1, ticket);
     shoplog(shop_nr, ch,myself, "outbidded", 0, format("%i talens") % (my_bid+1));
   } else {
-    myself->doTell(ch->getName(), "Congratulations, you're the high bidder.");
+    myself->doTell(ch, "Congratulations, you're the high bidder.");
     db.query("update shopownedauction set current_bid=%i, bidder=%i, max_bid=%i where ticket=%i", (max_bid+1), ch->getPlayerID(), my_bid, ticket);
     shoplog(shop_nr, ch, myself, "made bid", 0, format("%i talens") % (max_bid+1));
   }

--- a/code/code/spec/spec_mobs_banker.cc
+++ b/code/code/spec/spec_mobs_banker.cc
@@ -102,32 +102,32 @@ int bankWithdraw(TBeing *ch, TMonster *myself, TMonster *teller, int shop_nr, in
   int bankmoney;
 
   if (!ch->isPc() || dynamic_cast<TMonster *>(ch)) {
-    teller->doTell(ch->getName(), "Stupid monster can't bank here!");
+    teller->doTell(ch, "Stupid monster can't bank here!");
     return TRUE;
   }
 
   db.query("select talens from shopownedbank where shop_nr=%i and player_id=%i", shop_nr, ch->getPlayerID());
 
   if(!db.fetchRow()){
-    teller->doTell(ch->getName(), "You don't have an account here.");
-    teller->doTell(ch->getName(), "To open an account, type 'buy account'.");
-    teller->doTell(ch->getName(), "The new account fee is 100 talens.");
+    teller->doTell(ch, "You don't have an account here.");
+    teller->doTell(ch, "To open an account, type 'buy account'.");
+    teller->doTell(ch, "The new account fee is 100 talens.");
     return FALSE;
   } else
     bankmoney = convertTo<int>(db["talens"]);
   
   if (money > bankmoney) {
-    teller->doTell(ch->getName(), "You don't have enough in the bank for that!");
+    teller->doTell(ch, "You don't have enough in the bank for that!");
     return TRUE;
   } else if(myself->getMoney() < money){
-    teller->doTell(ch->getName(), "The bank doesn't have your funds available right now!");
+    teller->doTell(ch, "The bank doesn't have your funds available right now!");
     return TRUE;
   } else if (money <= 0) {
-    teller->doTell(ch->getName(), "Go away, you bother me.");
+    teller->doTell(ch, "Go away, you bother me.");
     return TRUE;
   }
 
-  teller->doTell(ch->getName(), "Thank you.");
+  teller->doTell(ch, "Thank you.");
 
   TShopOwned tso(shop_nr, myself, ch);
   tso.doSellTransaction(money, "talens", TX_WITHDRAWAL);
@@ -144,28 +144,28 @@ int bankDeposit(TBeing *ch, TMonster *myself, TMonster *teller, int shop_nr, int
   int bankmoney;
 
   if (!ch->isPc() || dynamic_cast<TMonster *>(ch)) {
-    teller->doTell(ch->getName(), "Stupid monster can't bank here!");
+    teller->doTell(ch, "Stupid monster can't bank here!");
     return TRUE;
   }
 
   db.query("select talens from shopownedbank where shop_nr=%i and player_id=%i", shop_nr, ch->getPlayerID());
 
   if(!db.fetchRow()){
-    teller->doTell(ch->getName(), "You don't have an account here.");
-    teller->doTell(ch->getName(), "To open an account, type 'buy account'.");
-    teller->doTell(ch->getName(), "The new account fee is 100 talens.");
+    teller->doTell(ch, "You don't have an account here.");
+    teller->doTell(ch, "To open an account, type 'buy account'.");
+    teller->doTell(ch, "The new account fee is 100 talens.");
     return TRUE;
   }
   
   if (money <= 0) {
-    teller->doTell(ch->getName(), "Go away, you bother me.");
+    teller->doTell(ch, "Go away, you bother me.");
     return TRUE;
   } else if (money > ch->getMoney()) {
-    teller->doTell(ch->getName(), "You don't have enough for that!");
+    teller->doTell(ch, "You don't have enough for that!");
     return TRUE;
   }
   
-  teller->doTell(ch->getName(), "Thank you.");
+  teller->doTell(ch, "Thank you.");
 
   TShopOwned tso(shop_nr, myself, ch);
   tso.doBuyTransaction(money, "talens", TX_DEPOSIT);
@@ -176,14 +176,14 @@ int bankDeposit(TBeing *ch, TMonster *myself, TMonster *teller, int shop_nr, int
   db.query("select talens from shopownedbank where shop_nr=%i and player_id=%i", shop_nr, ch->getPlayerID());
 
   if (!db.fetchRow()) {
-    teller->doTell(ch->getName(), "You really should not see me, this is an error...");
+    teller->doTell(ch, "You really should not see me, this is an error...");
     vlogf(LOG_BUG, format("Banking error, was unable to retrieve balance after a deposit: %s") % ch->getName());
 
     return TRUE;
   } else
     bankmoney = convertTo<int>(db["talens"]);
 
-  teller->doTell(ch->getName(), format("...Your new balance is %i") % bankmoney);
+  teller->doTell(ch, format("...Your new balance is %i") % bankmoney);
 
   return TRUE;
 }
@@ -197,14 +197,14 @@ int bankBalance(TBeing *ch, TMonster *myself, TMonster *teller, int shop_nr)
 
 
   if(!db.fetchRow()){
-    teller->doTell(ch->getName(), "You don't have an account here.");
-    teller->doTell(ch->getName(), "To open an account, type 'buy account'.");
-    teller->doTell(ch->getName(), "The new account fee is 100 talens.");
+    teller->doTell(ch, "You don't have an account here.");
+    teller->doTell(ch, "To open an account, type 'buy account'.");
+    teller->doTell(ch, "The new account fee is 100 talens.");
     return TRUE;
   } else
     bankmoney = convertTo<int>(db["talens"]);
 
-  teller->doTell(ch->getName(), format("Your balance is %i.") % bankmoney);
+  teller->doTell(ch, format("Your balance is %i.") % bankmoney);
 
   return TRUE;
 }
@@ -214,14 +214,14 @@ int bankBuyAccount(TBeing *ch, TMonster *myself, TMonster *teller, int shop_nr, 
   TDatabase db(DB_SNEEZY);
   
   if(ch->getMoney() < 100){
-    teller->doTell(ch->getName(), "You don't have enough money to open an account.");
+    teller->doTell(ch, "You don't have enough money to open an account.");
     return TRUE;
   }
   
   db.query("select talens from shopownedbank where player_id=%i and shop_nr=%i", ch->getPlayerID(), shop_nr);
   
   if(db.fetchRow()){
-    teller->doTell(ch->getName(), "You already have an account.");
+    teller->doTell(ch, "You already have an account.");
     return TRUE;
   }
   
@@ -230,7 +230,7 @@ int bankBuyAccount(TBeing *ch, TMonster *myself, TMonster *teller, int shop_nr, 
   shoplog(shop_nr, ch, myself, "talens", 100, "new account");
   myself->saveItems(shop_nr);
   
-  teller->doTell(ch->getName(), "Your account is now open and ready for use.");
+  teller->doTell(ch, "Your account is now open and ready for use.");
   
   return TRUE;
 }
@@ -297,7 +297,7 @@ int banker(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, TObj *)
     TShopOwned tso(shop_nr, myself, ch);
 
     if(!tso.hasAccess(SHOPACCESS_LOGS)){
-      myself->doTell(ch->getName(), "Sorry, you don't have access to do that.");
+      myself->doTell(ch, "Sorry, you don't have access to do that.");
       return FALSE;
     }
 

--- a/code/code/spec/spec_mobs_corporate_assistant.cc
+++ b/code/code/spec/spec_mobs_corporate_assistant.cc
@@ -23,7 +23,7 @@ void corpListing(TBeing *ch, TMonster *me)
 			       talenDisplay(corp_list[i].assets)));
   }
 
-  me->doTell(ch->getName(), "I know about the following corporations:");
+  me->doTell(ch, "I know about the following corporations:");
 
   sstring buf;
   for(it=m.begin();it!=m.end();++it)
@@ -49,12 +49,12 @@ void corpLogs(TBeing *ch, TMonster *me, sstring arg, sstring corp_arg)
 	corp_id=convertTo<int>(db["corp_id"]);
 
       if(db.fetchRow()){
-	me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to deposit the money for.");
+	me->doTell(ch, "You must specify the ID of the corporation you wish to deposit the money for.");
 	return;
       }
     } else {
       if(convertTo<int>(corp_arg) == 0){
-	me->doTell(ch->getName(), "You must specify the ID of the corporation you wish look at the logs of.");
+	me->doTell(ch, "You must specify the ID of the corporation you wish look at the logs of.");
 	return;
       }
 
@@ -67,7 +67,7 @@ void corpLogs(TBeing *ch, TMonster *me, sstring arg, sstring corp_arg)
     }
 
     if(!corp_id){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to deposit the money for.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to deposit the money for.");
       return;
     }
   }
@@ -121,7 +121,7 @@ void corpSummary(TBeing *ch, TMonster *me, int corp_id)
 
 
   if(!corp_id){
-    me->doTell(ch->getName(), "I don't have any information for that corporation.");
+    me->doTell(ch, "I don't have any information for that corporation.");
     return;
   }
   
@@ -142,12 +142,12 @@ void corpSummary(TBeing *ch, TMonster *me, int corp_id)
     db.query("select c.name, 0 as gold, b.talens as banktalens, 0 as shops, bank, sob.corp_id as bankowner from shopowned sob, corporation c left outer join shopownedcorpbank b on(c.corp_id=b.corp_id) where sob.shop_nr=c.bank and c.corp_id=%i group by c.corp_id, c.name, b.talens, c.bank, sob.corp_id order by c.corp_id", corp_id);
 
     if(!db.fetchRow()){
-      me->doTell(ch->getName(), "I don't have any information for that corporation.");
+      me->doTell(ch, "I don't have any information for that corporation.");
       return;
     }
   }
 
-  me->doTell(ch->getName(), "This is what I know about that corporation:");
+  me->doTell(ch, "This is what I know about that corporation:");
   
   ch->sendTo(COLOR_BASIC, format("%-3i| <r>%s<1>\n\r") % corp_id % db["name"]);
 
@@ -219,12 +219,12 @@ void corpDeposit(TBeing *ch, TMonster *me, int gold, sstring arg)
       corp_id=convertTo<int>(db["corp_id"]);
 
     if(db.fetchRow()){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to deposit the money for.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to deposit the money for.");
       return;
     }
   } else {
     if(convertTo<int>(arg) == 0){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to deposit the money for.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to deposit the money for.");
       return;
     }
 
@@ -237,14 +237,14 @@ void corpDeposit(TBeing *ch, TMonster *me, int gold, sstring arg)
   }
 
   if(!corp_id){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to deposit the money for.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to deposit the money for.");
       return;
   }
   
   TCorporation corp(corp_id);
 
   if(ch->getMoney() < gold){
-    me->doTell(ch->getName(), "You don't have that many talens.");
+    me->doTell(ch, "You don't have that many talens.");
     return;
   }
 
@@ -257,17 +257,17 @@ void corpDeposit(TBeing *ch, TMonster *me, int gold, sstring arg)
 
   if(!banker){
     vlogf(LOG_BUG, format("couldn't find banker for shop %i!") % shop_nr);
-    me->doTell(ch->getName(), "I couldn't find the bank!  Tell a god!");
+    me->doTell(ch, "I couldn't find the bank!  Tell a god!");
     return;
   }
 
-  me->doTell(ch->getName(), format("Ok, you are depositing %i gold.") % gold);
+  me->doTell(ch, format("Ok, you are depositing %i gold.") % gold);
 
 
   corp.setMoney(corp.getMoney() + gold);
   corp.corpLog(ch->getName(), "deposit", gold);
   
-  me->doTell(ch->getName(), format("Your balance is %i.") % corp.getMoney());
+  me->doTell(ch, format("Your balance is %i.") % corp.getMoney());
 
   TShopOwned tso(shop_nr, dynamic_cast<TMonster *>(banker), ch);
   tso.doBuyTransaction(gold, "talens", TX_DEPOSIT);
@@ -289,12 +289,12 @@ void corpWithdraw(TBeing *ch, TMonster *me, int gold, sstring arg)
       corp_id=convertTo<int>(db["corp_id"]);
 
     if(db.fetchRow()){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to withdraw the money from.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to withdraw the money from.");
       return;
     }
   } else {
     if(convertTo<int>(arg) == 0){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to withdraw the money from.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to withdraw the money from.");
       return;
     }
 
@@ -307,7 +307,7 @@ void corpWithdraw(TBeing *ch, TMonster *me, int gold, sstring arg)
   }
 
   if(!corp_id){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to withdraw the money from.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to withdraw the money from.");
       return;
   }
 
@@ -316,7 +316,7 @@ void corpWithdraw(TBeing *ch, TMonster *me, int gold, sstring arg)
   int tmp=corp.getMoney();
 
   if(tmp < gold){
-    me->doTell(ch->getName(), format("Your corporation only has %i talens.") % 
+    me->doTell(ch, format("Your corporation only has %i talens.") % 
 	       tmp);
     return;
   }
@@ -330,22 +330,22 @@ void corpWithdraw(TBeing *ch, TMonster *me, int gold, sstring arg)
   
   if(!banker){
     vlogf(LOG_BUG, format("couldn't find banker for shop_nr=%i!") % shop_nr);
-    me->doTell(ch->getName(), "I couldn't find the bank, tell a god!");
+    me->doTell(ch, "I couldn't find the bank, tell a god!");
     return;
   }
   
   bank_amt=banker->getMoney();
 
   if(bank_amt < gold){
-    me->doTell(ch->getName(), "I'm afraid your bank has overextended itself, and doesn't have your cash available right now.");
+    me->doTell(ch, "I'm afraid your bank has overextended itself, and doesn't have your cash available right now.");
     return;
   }
 
   corp.setMoney(corp.getMoney() - gold);
   corp.corpLog(ch->getName(), "withdrawal", -gold);
 
-  me->doTell(ch->getName(), format("Ok, here is %i talens.") % gold);
-  me->doTell(ch->getName(), format("Your balance is %i.") % (tmp-gold));
+  me->doTell(ch, format("Ok, here is %i talens.") % gold);
+  me->doTell(ch, format("Your balance is %i.") % (tmp-gold));
 
   TShopOwned tso(shop_nr, dynamic_cast<TMonster *>(banker), ch);
   tso.doSellTransaction(gold, "talens", TX_WITHDRAWAL);
@@ -365,12 +365,12 @@ void corpBalance(TBeing *ch, TMonster *me, sstring arg)
       corp_id=convertTo<int>(db["corp_id"]);
 
     if(db.fetchRow()){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to withdraw the money from.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to withdraw the money from.");
       return;
     }
   } else {
     if(convertTo<int>(arg) == 0){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to withdraw the money from.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to withdraw the money from.");
       return;
     }
 
@@ -383,13 +383,13 @@ void corpBalance(TBeing *ch, TMonster *me, sstring arg)
   }
 
   if(!corp_id){
-      me->doTell(ch->getName(), "You must specify the ID of the corporation you wish to withdraw the money from.");
+      me->doTell(ch, "You must specify the ID of the corporation you wish to withdraw the money from.");
       return;
   }
 
   TCorporation corp(corp_id);
 
-  me->doTell(ch->getName(), format("Your balance is %i.") % corp.getMoney());
+  me->doTell(ch, format("Your balance is %i.") % corp.getMoney());
 
 
 }

--- a/code/code/spec/spec_mobs_herofaeries.cc
+++ b/code/code/spec/spec_mobs_herofaeries.cc
@@ -42,10 +42,8 @@ void uniqueTrophyIntro(TBeing *faerie, TBeing *targ)
     vlogf(LOG_BUG, "uniqueTrophyIntro entered with null faerie");
     return;
   }
-  faerie->doTell(targ->getName(),
-    "You are greatly respected amongst my people for the breadth of your travels.");
-  faerie->doTell(targ->getName(),
-    "I have been sent to help you in your endeavors!");
+  faerie->doTell(targ, "You are greatly respected amongst my people for the breadth of your travels.");
+  faerie->doTell(targ, "I have been sent to help you in your endeavors!");
 }
 
 // feral wrath, but only the stat part (no AC penalty), stat part is halved
@@ -147,10 +145,8 @@ void permaDeathIntro(TBeing *faerie, TBeing *targ)
     vlogf(LOG_BUG, "permaDeathIntro entered with null targ");
     return;
   }
-  faerie->doTell(targ->getName(),
-    "You are greatly respected amongst my people for your great bravery.");
-  faerie->doTell(targ->getName(),
-    "I have been sent to help you in your endeavors!");
+  faerie->doTell(targ, "You are greatly respected amongst my people for your great bravery.");
+  faerie->doTell(targ, "I have been sent to help you in your endeavors!");
 }
 
 // barkskin

--- a/code/code/spec/spec_mobs_loan_manager.cc
+++ b/code/code/spec/spec_mobs_loan_manager.cc
@@ -24,7 +24,7 @@ void loanBuy(TBeing *ch, TMonster *myself, sstring arg)
   TCorporation corp(tso.getCorpID());
   
   if(!loan_id){
-    myself->doTell(ch->getName(), "That isn't a valid loan number");
+    myself->doTell(ch, "That isn't a valid loan number");
     return;
   }
 
@@ -32,7 +32,7 @@ void loanBuy(TBeing *ch, TMonster *myself, sstring arg)
 	   loan_id);
   
   if(!db.fetchRow()){
-    myself->doTell(ch->getName(), "That isn't a valid loan number.");
+    myself->doTell(ch, "That isn't a valid loan number.");
     return;
   }
 
@@ -40,7 +40,7 @@ void loanBuy(TBeing *ch, TMonster *myself, sstring arg)
   int amt=convertTo<int>(db["amt"]);
   
   if(ch->getMoney() < amt){
-    myself->doTell(ch->getName(), "You don't have enough money.");
+    myself->doTell(ch, "You don't have enough money.");
     return;
   }
   
@@ -51,7 +51,7 @@ void loanBuy(TBeing *ch, TMonster *myself, sstring arg)
   if(!db.fetchRow()){
     TRoom *tr=real_roomp(shop_index[corp.getBank()].in_room);
 
-    myself->doTell(ch->getName(), format("You need to have a bank account at %s in order to finance loans.") % tr->getName());
+    myself->doTell(ch, format("You need to have a bank account at %s in order to finance loans.") % tr->getName());
     return;
   }
 

--- a/code/code/spec/spec_mobs_loanshark.cc
+++ b/code/code/spec/spec_mobs_loanshark.cc
@@ -134,7 +134,7 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 	   shop_nr);
   if(!db.fetchRow()){
     vlogf(LOG_DB, format("couldn't find loanrate table for shop %i") % shop_nr);
-    me->doTell(ch->getName(), "Hm, I can't seem to find my paperwork!");
+    me->doTell(ch, "Hm, I can't seem to find my paperwork!");
     return false;
   }
 
@@ -159,29 +159,29 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 			 convertTo<float>(db["rate"]),
 			 convertTo<float>(db["default_charge"]));
 
-	me->doTell(ch->getName(), 
+	me->doTell(ch, 
 		   format("%s for %i talens at %.2f%c due %s of %s, %d P.S") %
 		   db["name"] % convertTo<int>(db["amt"]) % 
 		   (convertTo<float>(db["rate"]) * 100) % '%' %
 		   numberAsString(due.day) % month_name[due.month] %
 		   due.year);
-	me->doTell(ch->getName(),
+	me->doTell(ch,
 		   format("%s currently owes %i talens.") %
 		   db["name"] % amt);
       }
     } else if(sstring(arg)=="repo" && tso.hasAccess(SHOPACCESS_INFO)){
-      me->doTell(ch->getName(), 
+      me->doTell(ch, 
 		 "I have the following options for collecting on loans.");
-      me->doTell(ch->getName(), format("1.[1%c]) I can do a direct transfer from the debtors bank account.") % '%');
-      me->doTell(ch->getName(), format("2.[1%c]) I can do a direct transfer from the debtors corporate account.") % '%');
-      me->doTell(ch->getName(), format("3.[3%c]) I can do a direct transfer from the debtors shops.") % '%');
-      me->doTell(ch->getName(), format("4.[5%c]) I can repossess items from the debtors shops and give them to you.") % '%');
-      me->doTell(ch->getName(), format("5.[7%c]) I can repossess entire shops if need be.") % '%');
-      me->doTell(ch->getName(), format("6.[9%c]) I can send out a collection agent to collect the debt by force.") % '%');
-      me->doTell(ch->getName(), "The cost of the collection method is a percent of the debt, as listed.");
-      me->doTell(ch->getName(), "You will be charged even if the collection isn't successful.");
-      me->doTell(ch->getName(), "Shops won't be repossessed unless the debt exceeds the value of the shop.");
-      me->doTell(ch->getName(), "To use one of these collection methods, do 'buy repo <number> <playername>");
+      me->doTell(ch, format("1.[1%c]) I can do a direct transfer from the debtors bank account.") % '%');
+      me->doTell(ch, format("2.[1%c]) I can do a direct transfer from the debtors corporate account.") % '%');
+      me->doTell(ch, format("3.[3%c]) I can do a direct transfer from the debtors shops.") % '%');
+      me->doTell(ch, format("4.[5%c]) I can repossess items from the debtors shops and give them to you.") % '%');
+      me->doTell(ch, format("5.[7%c]) I can repossess entire shops if need be.") % '%');
+      me->doTell(ch, format("6.[9%c]) I can send out a collection agent to collect the debt by force.") % '%');
+      me->doTell(ch, "The cost of the collection method is a percent of the debt, as listed.");
+      me->doTell(ch, "You will be charged even if the collection isn't successful.");
+      me->doTell(ch, "Shops won't be repossessed unless the debt exceeds the value of the shop.");
+      me->doTell(ch, "To use one of these collection methods, do 'buy repo <number> <playername>");
     } else {
       db.query("select amt, granted_time, term, rate, default_charge from shopownedloans where player_id=%i", ch->getPlayerID());
       
@@ -189,7 +189,7 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 	amt=convertTo<int>(db["amt"]);
 	due=whenDue(convertTo<int>(db["granted_time"]), convertTo<int>(db["term"]));
 	
-	me->doTell(ch->getName(), format("You have a loan for %i talens, due on the %s day of %s, Year %d P.S.") %
+	me->doTell(ch, format("You have a loan for %i talens, due on the %s day of %s, Year %d P.S.") %
 		   amt %
 		   numberAsString(due.day) % 
 		   month_name[due.month] %
@@ -200,16 +200,16 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 			 convertTo<float>(db["default_charge"]));
 	
 	
-	me->doTell(ch->getName(), format("With interest, you owe %i talens.") % amt);
+	me->doTell(ch, format("With interest, you owe %i talens.") % amt);
       } else {
-	me->doTell(ch->getName(), format("I can extend you a loan for %i talens.") % amt);
-	me->doTell(ch->getName(), format("A yearly cumulative interest rate of %.2f%c will apply.") % 
+	me->doTell(ch, format("I can extend you a loan for %i talens.") % amt);
+	me->doTell(ch, format("A yearly cumulative interest rate of %.2f%c will apply.") % 
 		   (getRate(shop_nr, ch->getName()) * 100) % '%');
-	me->doTell(ch->getName(), format("The term length I can offer is %i years.") % term);
-	me->doTell(ch->getName(), "One mud year is about 2 weeks in real time.");
-	me->doTell(ch->getName(), format("If you default on the loan, you will be charged an additional %.2f%c.") %
+	me->doTell(ch, format("The term length I can offer is %i years.") % term);
+	me->doTell(ch, "One mud year is about 2 weeks in real time.");
+	me->doTell(ch, format("If you default on the loan, you will be charged an additional %.2f%c.") %
 		   (getPenalty(shop_nr, ch->getName()) * 100) % '%');
-	me->doTell(ch->getName(), "Do \"buy loan <amt>\" to take out the loan.");
+	me->doTell(ch, "Do \"buy loan <amt>\" to take out the loan.");
       }
     }
     return true;
@@ -223,7 +223,7 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       db.query("select amt, granted_time, term, rate, default_charge from shopownedloans, player where player_id=id and lower(name)=lower('%s')", sstring(arg).word(2).c_str());
       
       if(!db.fetchRow()){
-	      me->doTell(ch->getName(), "I can't find a loan for that player.");
+	      me->doTell(ch, "I can't find a loan for that player.");
 	      return true;
       }
 
@@ -235,21 +235,21 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       db.query("select 1 from shopownedloans where player_id=%i", 
 	       ch->getPlayerID());
       if(db.fetchRow()){
-	      me->doTell(ch->getName(), "You already have a loan!");
+	      me->doTell(ch, "You already have a loan!");
 	      return true;
       }
 
       int loanamt=convertTo<int>(sstring(arg).word(1));
     
       if(loanamt > amt || loanamt <= 0){
-	      me->doTell(ch->getName(), format("You can't take out a loan for that much.  The most I can give you is %i.") % amt);
+	      me->doTell(ch, format("You can't take out a loan for that much.  The most I can give you is %i.") % amt);
 	      return true;
       }
 
       amt=loanamt;
 
       if(amt > me->getMoney()){
-	      me->doTell(ch->getName(), "At the moment, I don't have the necessary capital to extend a loan to you.");
+	      me->doTell(ch, "At the moment, I don't have the necessary capital to extend a loan to you.");
 	      return true;
       }
 
@@ -263,13 +263,13 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
       me->saveItems(shop_nr);
 
 
-      me->doTell(ch->getName(), format("There you go.  Remember, I need the money back, plus interest, within %i years.") % term);
-      me->doTell(ch->getName(), "Do 'list' again at anytime to see how much you owe with interest included.");
-      me->doTell(ch->getName(), "You can give me talens at any time to make a payment on your loan.");
+      me->doTell(ch, format("There you go.  Remember, I need the money back, plus interest, within %i years.") % term);
+      me->doTell(ch, "Do 'list' again at anytime to see how much you owe with interest included.");
+      me->doTell(ch, "You can give me talens at any time to make a payment on your loan.");
     
       shoplog(shop_nr, ch, me, "talens", -amt, "loaning");
     } else {
-      me->doTell(ch->getName(), "If you want to take out the loan, do \"buy loan <amount>\".");
+      me->doTell(ch, "If you want to take out the loan, do \"buy loan <amount>\".");
     }
   }
 
@@ -288,7 +288,7 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 		       convertTo<float>(db["default_charge"]));
 
       if(coins>=amt){
-	      me->doTell(ch->getName(), "Alright, everything appears to be in order here.  Consider your loan paid off!");
+	      me->doTell(ch, "Alright, everything appears to be in order here.  Consider your loan paid off!");
 	      db.query("delete from shopownedloans where player_id=%i", ch->getPlayerID());
 	      shoplog(shop_nr, ch, me, "talens", coins, "giving");
       } else {
@@ -299,12 +299,12 @@ int loanShark(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *o)
 	      db.query("update shopownedloans set amt=%i where player_id=%i",
 		       principle, ch->getPlayerID());
 
-	      me->doTell(ch->getName(), format("Thanks for the payment.  You paid down the principle by %i talens, the rest went to interest.") % (int)(perc*coins));
+	      me->doTell(ch, format("Thanks for the payment.  You paid down the principle by %i talens, the rest went to interest.") % (int)(perc*coins));
 
 	      shoplog(shop_nr, ch, me, "talens", coins, "giving");
       }
     } else {
-      me->doTell(ch->getName(), "Uhh... thanks!");
+      me->doTell(ch, "Uhh... thanks!");
     }
   }
 

--- a/code/code/spec/spec_mobs_property_clerk.cc
+++ b/code/code/spec/spec_mobs_property_clerk.cc
@@ -11,27 +11,27 @@ int propertyClerk(TBeing *ch, cmdTypeT cmd, const char *argument, TMonster *me, 
 
   if(cmd==CMD_BUY){
     if(arg.empty()){
-      me->doTell(ch->getName(), "Which property do you want to buy a replacement key for?");
+      me->doTell(ch, "Which property do you want to buy a replacement key for?");
     } else {
       db.query("select p.owner as owner_id, p.key_vnum as key_vnum from property p, obj o where p.key_vnum=o.vnum and p.id=%s", arg.word(0).c_str());
 
       db.fetchRow();
 
       if(ch->getPlayerID() != convertTo<int>(db["owner_id"])){
-	me->doTell(ch->getName(), "Hey, you don't own that property!");
+	me->doTell(ch, "Hey, you don't own that property!");
 	return true;
       } else {
 	if(ch->getMoney() < 25000){
-	  me->doTell(ch->getName(), "It costs 25000 talens to mint a new high security key.  You don't have enough!");
+	  me->doTell(ch, "It costs 25000 talens to mint a new high security key.  You don't have enough!");
 	  return true;
 	} else {
-	  me->doTell(ch->getName(), "That will be 25000 talens to mint a new high security key.");
+	  me->doTell(ch, "That will be 25000 talens to mint a new high security key.");
 	  ch->addToMoney(-25000, GOLD_SHOP);
 	}
 
 	TObj *key=read_object(convertTo<int>(db["key_vnum"]), VIRTUAL);
 	*ch += *key;
-	me->doTell(ch->getName(), "Here you go!");
+	me->doTell(ch, "Here you go!");
 	act("$n gives you $p.", 0, me, key, ch, TO_VICT);
       }
     }
@@ -43,7 +43,7 @@ int propertyClerk(TBeing *ch, cmdTypeT cmd, const char *argument, TMonster *me, 
       db.query("select id, name from property order by id");
       
       while(db.fetchRow()){
-	me->doTell(ch->getName(), format("%-2i| %s") % 
+	me->doTell(ch, format("%-2i| %s") % 
 		   convertTo<int>(db["id"]) % db["name"]);
       }
     } else {
@@ -51,20 +51,20 @@ int propertyClerk(TBeing *ch, cmdTypeT cmd, const char *argument, TMonster *me, 
       
       while(db.fetchRow()){
 	if(ch->isImmortal()){
-	  me->doTell(ch->getName(), format("%-2i| %s") % 
+	  me->doTell(ch, format("%-2i| %s") % 
 		     convertTo<int>(db["id"]) % db["name"]);
-	  me->doTell(ch->getName(), format("Owned by: %s (%i)") % 
+	  me->doTell(ch, format("Owned by: %s (%i)") % 
 		     db["owner"] % convertTo<int>(db["owner_id"]));
-	  me->doTell(ch->getName(), format("Key: %s (%i)") % 
+	  me->doTell(ch, format("Key: %s (%i)") % 
 		     db["keyname"] % convertTo<int>(db["key_vnum"]));
-	  me->doTell(ch->getName(), format("Entrance: %s (%i)") %
+	  me->doTell(ch, format("Entrance: %s (%i)") %
 		     db["entrance"] % convertTo<int>(db["entrance_id"]));
 	} else {
-	  me->doTell(ch->getName(), format("%-2i| %s") % 
+	  me->doTell(ch, format("%-2i| %s") % 
 		     convertTo<int>(db["id"]) % db["name"]);
-	  me->doTell(ch->getName(), format("Owned by: %s") % 
+	  me->doTell(ch, format("Owned by: %s") % 
 		     db["owner"]);
-	  me->doTell(ch->getName(), format("Entrance: %s") %
+	  me->doTell(ch, format("Entrance: %s") %
 		     db["entrance"]);
 	}
       }

--- a/code/code/spec/spec_mobs_tattoo_artist.cc
+++ b/code/code/spec/spec_mobs_tattoo_artist.cc
@@ -31,17 +31,17 @@ int tattooArtist(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, TO
 
 
   if(cmd == CMD_LIST){
-    myself->doTell(ch->getName(), "I charge 10000 talens for a tattoo.  They are permanent.");
-    myself->doTell(ch->getName(), "You can buy the following tattoos from me:");
+    myself->doTell(ch, "I charge 10000 talens for a tattoo.  They are permanent.");
+    myself->doTell(ch, "You can buy the following tattoos from me:");
     for(i=0;i<ntattoos;++i)
-      myself->doTell(ch->getName(), format("%i) %s") % (i+1) % tattoos[i]);
+      myself->doTell(ch, format("%i) %s") % (i+1) % tattoos[i]);
 
     return TRUE;
   } else if(cmd==CMD_BUY){
     arg=one_argument(arg, buf, cElements(buf));
 
     if(!(i=convertTo<int>(buf)) || i>ntattoos){
-      myself->doTell(ch->getName(), "I don't understand, which tattoo do you want?");
+      myself->doTell(ch, "I don't understand, which tattoo do you want?");
       return FALSE;
     }
 
@@ -52,16 +52,16 @@ int tattooArtist(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, TO
     if ((slot_i = old_search_block(buf, 0, strlen(buf), bodyParts, 0)) > 0) {
       slot = wearSlotT(--slot_i);
       if (!ch->slotChance(slot)) {
-        myself->doTell(ch->getName(), "Where do you want the tattoo?");
+        myself->doTell(ch, "Where do you want the tattoo?");
         return FALSE;
       }
     } else {
-      myself->doTell(ch->getName(), "Where do you want the tattoo?");
+      myself->doTell(ch, "Where do you want the tattoo?");
       return FALSE;
     }
     if(slot==WEAR_LEG_R || slot==WEAR_LEG_L){
-      myself->doTell(ch->getName(), "Sorry, it is against my policy to tattoo legs.");
-      myself->doTell(ch->getName(), "It's not like you're gonna run around pantless to show it off anyway!");
+      myself->doTell(ch, "Sorry, it is against my policy to tattoo legs.");
+      myself->doTell(ch, "It's not like you're gonna run around pantless to show it off anyway!");
       return FALSE;
     }
     
@@ -70,13 +70,13 @@ int tattooArtist(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *myself, TO
 	     ch->getName().c_str(), slot);
 
     if(db.fetchRow()){
-      myself->doTell(ch->getName(), "You already have a tattoo there.");
+      myself->doTell(ch, "You already have a tattoo there.");
       return FALSE;
     }
 
 
     if(ch->getMoney() < 10000){
-      myself->doTell(ch->getName(), "Hey buddy, you don't even have the money!  Get out of here!");
+      myself->doTell(ch, "Hey buddy, you don't even have the money!  Get out of here!");
       return FALSE;
     }
 

--- a/code/code/spec/spec_mobs_taxman.cc
+++ b/code/code/spec/spec_mobs_taxman.cc
@@ -15,7 +15,7 @@ int taxman(TBeing *ch, cmdTypeT cmd, const char *arg, TMonster *me, TObj *)
     db.query("select s.shop_nr as shop_nr, r.name as name from shop s, shopowned st, room r where st.tax_nr=%i and st.shop_nr=s.shop_nr and r.vnum=s.in_room", shop_nr);
     
     while(db.fetchRow()){
-      me->doTell(ch->name, format("%-3s| <r>%s<1>") %
+      me->doTell(ch, format("%-3s| <r>%s<1>") %
 		 db["shop_nr"] % db["name"]);
     }
     

--- a/code/code/spec/spec_objs.cc
+++ b/code/code/spec/spec_objs.cc
@@ -148,20 +148,6 @@ TBeing *genericWeaponProcCheck(TBeing *vict, cmdTypeT cmd, TObj *o, int chance)
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 int rainbowBridge(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *)
 {
   int rc;
@@ -546,33 +532,6 @@ void invert(const char *arg1, char *arg2)
   *(arg2 + i) = '\0';
 }
 
-
-int jive_box(TBeing *ch, cmdTypeT cmd, const char *arg, TObj *, TObj **)
-{
-  char buf[255], buf2[255], tmp[255];
-
-  switch (cmd) {
-    case CMD_SAY:
-    case CMD_SAY2:
-      invert(arg, buf);
-      ch->doSay(buf);
-      return TRUE;
-      break;
-    case CMD_TELL:
-      half_chop(arg, tmp, buf);
-      invert(buf, buf2);
-      ch->doTell(tmp, buf);
-      return TRUE;
-      break;
-    case CMD_SHOUT:
-      invert(arg, buf);
-      ch->doShout(buf);
-      return TRUE;
-      break;
-    default:
-      return FALSE;
-  }
-}
 
 int statue_of_feeding(TBeing *ch, cmdTypeT cmd, const char *argum, TObj *me, TObj *)
 {


### PR DESCRIPTION
_REMINDER: it is recommended to review my PRs per-commit rather than as a big lump, I try to make each commit reflect a "unit of progress"._

Previously doTell would always loop thru the charlist looking for the target. Also, there are a lot of different ways sneezy got a "tellable" name out of a TBeing object!

Now, just tell directly to the TBeing* dest, except for the actual "tell xxx yyy" command which does it the hard way via an overload.

Also includes a tiny cleanup of some (ranger haha) quest handling code in combat.cc.