### PR TITLE
Fixing compilation error in cmd_zonefile.cc

### DIFF
--- a/code/code/cmd/cmd_zonefile.cc
+++ b/code/code/cmd/cmd_zonefile.cc
@@ -83,7 +83,7 @@ namespace {
 
   void doNewZoneFile(TBeing& ch, const sstring& args)
   {
-    if (!hasWizPower(POWER_LOW)) {
+    if (!ch.hasWizPower(POWER_LOW)) {
       ch.sendTo("You need LOW powers to create new zones.\n\r");
       return;
     }


### PR DESCRIPTION
It wouldn't compile until I changed it to ch.hasWizPowers(). That seemed to be the correct usage here, so I fixed it and it compiled. I assume I did this right by branching it, pushing it, and requesting a merge.