### PR TITLE
Portal Buff

### DIFF
--- a/code/code/obj/obj_portal.cc
+++ b/code/code/obj/obj_portal.cc
@@ -37,10 +37,10 @@ TPortal::TPortal(const TRoom *rp) :
   buf = format("A portal going to %s is in the room.") % rp->name;
   setDescr(buf);
   obj_flags.wear_flags = 0;
-  obj_flags.decay_time = 5;
+  obj_flags.decay_time = 10;
   setWeight(0);
   obj_flags.cost = 1;
-  setPortalNumCharges(10);
+  setPortalNumCharges(20);
   setTarget(rp->number);
 }
 


### PR DESCRIPTION
Intent: Increase the timer on the 'Portal' skill from 5 minutes to 10 and a max number of uses from 10 to 20. 

If I have done so incorrectly, please push back.

Reason: I feel the nerf that took it down to this level originally was too severe and furthermore requires reconsideration in light of new multi-play rules.