### PR TITLE
[Multiclass fix] move charge stave command from charge to recharge

### DIFF
--- a/code/code/cmd/cmd_charge.cc
+++ b/code/code/cmd/cmd_charge.cc
@@ -254,11 +254,6 @@ int TBeing::doCharge(const char *arg, TBeing *victim)
   int       rc        = 0;
   dirTypeT  Direction = DIR_NONE;
 
-  if (doesKnowSkill(SKILL_STAVECHARGE)) {
-    doChargeStave(arg);
-    return FALSE;
-  }
-
   if (checkBusy()) {
     return FALSE;
   }

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -1786,6 +1786,9 @@ int TBeing::doCommand(cmdTypeT cmd, const sstring &argument, TThing *vict, bool 
         case CMD_RUN:
           doRun(argument);
           break;
+        case CMD_RECHARGE:
+          doChargeStave(newarg.c_str());
+          break;
 
           break;
         case MAX_CMD_LIST:
@@ -2984,6 +2987,7 @@ void buildCommandArray(void)
   commandArray[CMD_REMEMBER] = new commandInfo("remember", POSITION_DEAD, 0);
   commandArray[CMD_REMEMBERPLAYER] = new commandInfo("rememberplayer", POSITION_DEAD, 0);
   commandArray[CMD_RETRIEVE] = new commandInfo("retrieve", POSITION_DEAD, 0);
+  commandArray[CMD_RECHARGE] = new commandInfo("recharge", POSITION_STANDING, 0);
 }
 
 bool _parse_name_safe(const char *arg, char *name, unsigned int nameLen)

--- a/code/code/misc/parse.h
+++ b/code/code/misc/parse.h
@@ -590,6 +590,7 @@ enum cmdTypeT {
      CMD_REMEMBER,
      CMD_REMEMBERPLAYER,
      CMD_RETRIEVE,
+     CMD_RECHARGE,
      MAX_CMD_LIST,  // Keep this as last command in regular list
        CMD_RESP_TOGGLE,
        CMD_RESP_UNTOGGLE,

--- a/lib/help/_skills/charge stave
+++ b/lib/help/_skills/charge stave
@@ -1,5 +1,5 @@
-Syntax: charge
-Syntax: charge <spell>
+Syntax: recharge
+Syntax: recharge <spell>
 
   With a greater understanding of a spell, a lot of the component and an
 applicable staff it is possible for a mage to charge the various staves of The


### PR DESCRIPTION
Deikhan/Mage combinations can't learn charge stave or they won't be able to charge (mount) ever.

This seemed like a "good enough" fix. 