### PR TITLE
Aion elite cityguard armor/weapon update

### DIFF
--- a/lib/objdata/suitsets
+++ b/lib/objdata/suitsets
@@ -31,6 +31,21 @@
 :shield   = 
 :back     = 
 // Paste below this line.
+:Set #157
+#elite leather
+$human
+head     = 750
+neck     = 751
+body     = 752
+back     = 753
+arm      = 754
+wrist    = 755
+hand     = 756
+finger   = 757
+waist    = 758
+leg      = 760
+foot     = 761
+shield   = 762 
 :Set #156
 #grizzled
 $ogre

--- a/lib/zonefiles/250
+++ b/lib/zonefiles/250
@@ -20,7 +20,7 @@ Y 0 8 2                 chance of studded
 A 0 250 296
 M 0 102 1 -99        Elite guard
 ? 0 4 0 E
-E 1 300 100 19          chance of long sword
-Y 0 8 4                 chance of studded
+E 1 762 100 19          chance of steel sword
+Y 0 157 5                 chance of elite leather
 
 S


### PR DESCRIPTION
Created new armor/weapon set for elite cityguards. Lvl 34 guards loading lvl 25 gear. All equipment matches new standards. 