### PR TITLE
Change weapon immunity

### DIFF
--- a/code/code/disc/disc_alchemy.cc
+++ b/code/code/disc/disc_alchemy.cc
@@ -1670,9 +1670,9 @@ int enhanceWeapon(TBeing *caster, TMagicItem *usedobj, TObj * toenhance)
 
   ret = enhanceWeapon(caster,toenhance,usedobj->getMagicLevel(),usedobj->getMagicLearnedness());
   if (IS_SET(ret, SPELL_SUCCESS)) {
-    act("$p begins to glow with a soft yellow light.", 
+    act("$p pulses with powerful magical energy.", 
           FALSE, caster, toenhance, NULL, TO_CHAR);
-    act("$p begins to glow with a soft yellow light.", 
+    act("$p pulses with powerful magical energy.", 
           FALSE, caster, toenhance, NULL, TO_ROOM);
   }
   if (IS_SET(ret, SPELL_CRIT_FAIL)) {

--- a/code/code/obj/obj_base_weapon.cc
+++ b/code/code/obj/obj_base_weapon.cc
@@ -741,9 +741,6 @@ int TBaseWeapon::enhanceMe(TBeing *caster, int level, short bKnown)
       affected[1].modifier += 1;
 
     addObjStat(ITEM_MAGIC);
-    addObjStat(ITEM_GLOW);
-
-    addGlowEffects();
 
     switch (critSuccess(caster, SPELL_ENHANCE_WEAPON)) {
       case CRIT_S_KILL:

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,8 @@
+02-16-19 : Immunity to +1/+2/+3 no longer have any effect in the game. 
+           Immunity to non-magic is still circumvented by magic weapons. Also,
+           the enhance weapon spell no longer makes weapons glow. 
+           Thieves Rejoice!
+
 11-29-18 : Class Quest rewards have been updated.
            Monk sashes, deikhan swords/shield, and Shaman masks are now much
            more worthwhile.


### PR DESCRIPTION
This implements changes discussed here: https://github.com/sneezymud/sneezymud/issues/213

was able to test by editing mobs to give them 100% immunity to non-magic and fighting 
- with magic items vs without and confirming damage is applied
- with voplat and without and confirming damage is applied

- confirmed that mobs with slash/blunt/pierce immunity still get applied

Also tested enhance weapon to be sure it still applies magic and +hit/dam but no longer adds light/glow

