### PR TITLE
Update periodic.cc

### DIFF
--- a/code/code/misc/periodic.cc
+++ b/code/code/misc/periodic.cc
@@ -1305,7 +1305,7 @@ int TBeing::updateHalfTickStuff()
   }
 
   // player is scared of flame (exempt or lessen for mobs?)
-  if(hasQuestBit(TOG_HAS_PYROPHOBIA) && (getPosition() > POSITION_SLEEPING) && !::number(0,1)){
+  if(hasQuestBit(TOG_HAS_PYROPHOBIA) && (getPosition() > POSITION_SLEEPING) && !::number(0,1) && (::number(0,100)-GetMaxLevel()*2>0)){
     TThing *fleeing = NULL;
     TBeing *tBeing = NULL;
     bool flee = roomp->getSectorType() == SECT_VOLCANO_LAVA ||


### PR DESCRIPTION
Tweaking the pyrophobia trait to scale inversely with level (0% chance at level 50, close to 100% chance of current proc rate at level 1).  My thought is simply if we have level 50 characters that will go into battle with an arch vampire, they shouldn't flee from a lamp post. :)