### PR TITLE
New weapon procs - molten + possessed

### DIFF
--- a/code/code/spec/spec_objs.cc
+++ b/code/code/spec/spec_objs.cc
@@ -6783,6 +6783,8 @@ extern int ofManyPotions(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, T
 extern int shadowWeapon(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *);
 extern int livingVines(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *);
 extern int dkSword(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *);
+extern int possessedSpear(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, TObj *);
+extern int weaponMolten(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, TObj *);
 
 
 
@@ -6951,5 +6953,7 @@ TObjSpecs objSpecials[NUM_OBJ_SPECIALS + 1] =
   {TRUE, "Living Vines", livingVines},
   {TRUE, "Piety Regen", pietyRegen},
   {TRUE, "DK Sword", dkSword},
+  {TRUE, "Possessed Spear", possessedSpear},
+  {TRUE, "Molten Weapon", weaponMolten},
   {FALSE, "last proc", bogusObjProc}
 };

--- a/code/code/spec/spec_objs.h
+++ b/code/code/spec/spec_objs.h
@@ -37,7 +37,7 @@ const int SPEC_FACTIONSCORE_BOARD = 97;
 const int SPEC_GRAFFITI=135;
 const int SPEC_STOCK_BOARD  = 138;
 const int SPEC_BRICKQUEST = 148;
-const int NUM_OBJ_SPECIALS = 161;
+const int NUM_OBJ_SPECIALS = 163;
 
 struct TObjSpecs {
   bool assignable;


### PR DESCRIPTION
Proposing a couple of thematic weapon procs for weapons I'd like to see in the game.  One is aimed at a possessed spear with damage procs based around a phantasmal warrior - chance to cause bleed and rarest one has a chance to embed an item similar to bloodspike (todo is to create a thematic item, but using spike for now).

The molten one is aimed at a fiery 2h great axe, and is largely limited to 2h weapons (most abilities don't work if the weapon is not PAIRED).  Some damage procs and a bonebreak proc that is similar to wither limb for thematic reasons.  The damage procs include some healing balanced around this being limited to 2h weapons.  There are a few thematic additions too like an enhanced damage proc if the enemy is bleeding (and it consumes the bleed), enhanced damage against undead, and so on.