### PR TITLE
Removing "exceptions" to dispel magic for items

### DIFF
--- a/code/code/disc/disc_alchemy.cc
+++ b/code/code/disc/disc_alchemy.cc
@@ -1329,7 +1329,8 @@ int dispelMagic(TBeing *caster, TObj * obj, int, short bKnown)
 
     // No point affecting objects already set to none, but legacy checks removed.
     for (i = 0; i < MAX_OBJ_AFFECT; i++) { 
-      if ((obj->affected[i].location != APPLY_NONE)) {
+      if ((obj->affected[i].location != APPLY_NONE) &&
+	  (obj->affected[i].location != APPLY_ARMOR))) {
         obj->affected[i].location = APPLY_NONE;
         obj->affected[i].modifier = 0;
         obj->affected[i].modifier2 = 0;

--- a/code/code/disc/disc_alchemy.cc
+++ b/code/code/disc/disc_alchemy.cc
@@ -1327,17 +1327,9 @@ int dispelMagic(TBeing *caster, TObj * obj, int, short bKnown)
 
   if (caster->bSuccess(bKnown, SPELL_DISPEL_MAGIC)) {
 
-    // assumes item not being used so don't have to affectFrom()
-    // this is the same list in checkObjStat for affects requiring MAGIC be set
+    // No point affecting objects already set to none, but legacy checks removed.
     for (i = 0; i < MAX_OBJ_AFFECT; i++) { 
-      if ((obj->affected[i].location != APPLY_NONE) &&
-          (obj->affected[i].location != APPLY_LIGHT) &&
-          (obj->affected[i].location != APPLY_NOISE) &&
-          (obj->affected[i].location != APPLY_HIT) &&
-          (obj->affected[i].location != APPLY_CHAR_WEIGHT) &&
-          (obj->affected[i].location != APPLY_CHAR_HEIGHT) &&
-          (obj->affected[i].location != APPLY_MOVE) &&
-          (obj->affected[i].location != APPLY_ARMOR)) {
+      if ((obj->affected[i].location != APPLY_NONE)) {
         obj->affected[i].location = APPLY_NONE;
         obj->affected[i].modifier = 0;
         obj->affected[i].modifier2 = 0;

--- a/code/code/disc/disc_alchemy.cc
+++ b/code/code/disc/disc_alchemy.cc
@@ -1330,7 +1330,7 @@ int dispelMagic(TBeing *caster, TObj * obj, int, short bKnown)
     // No point affecting objects already set to none, but legacy checks removed.
     for (i = 0; i < MAX_OBJ_AFFECT; i++) { 
       if ((obj->affected[i].location != APPLY_NONE) &&
-	  (obj->affected[i].location != APPLY_ARMOR))) {
+	  (obj->affected[i].location != APPLY_ARMOR)) {
         obj->affected[i].location = APPLY_NONE;
         obj->affected[i].modifier = 0;
         obj->affected[i].modifier2 = 0;


### PR DESCRIPTION
There are some legacy exceptions to dispel magic that I don't think make a lot of sense in the current state of the game.  This change will effectively allow all stats to be dispelled from items (previously, stats that affected moves, light, and so on were immune to dispel).  Consequently, this will allow enhance weapon to apply to all weapons.