### PR TITLE
Preventing weapon dislodge into stunned targets

### DIFF
--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -5311,7 +5311,11 @@ int TBeing::dislodgeWeapon(TBeing *v, TThing *weapon, wearSlotT part)
 {           
   char buf[160];
   int rc;
-
+  
+  // Quality of life tweak - there's no sense in weapons getting stuck in opponents that can't even move
+  if (v->isAffected(AFF_STUNNED))
+    return FALSE;
+	
   mud_assert(v->slotChance(part), "No slotChance in dislodgeWeapon");
 
   if (weapon && !v->getStuckIn(part)) {


### PR DESCRIPTION
Currently pierce weapons very frequently get stuck into stunned targets, and this is a bit silly (and annoying).  I think a v2.0 of this change would be to add skill checks to weapon retention/strength/telekinesis/etc. so that you can dislodge the weapon yourself (with bonus damage) from non-stunned targets, but this is a quick and easy quality of life change for now.