### PR TITLE
New weapon procs: glacial and molten

### DIFF
--- a/code/code/spec/spec_objs.cc
+++ b/code/code/spec/spec_objs.cc
@@ -6783,6 +6783,8 @@ extern int ofManyPotions(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, T
 extern int shadowWeapon(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *);
 extern int livingVines(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *);
 extern int dkSword(TBeing *vict, cmdTypeT cmd, const char *, TObj *o, TObj *);
+extern int moltenWeapon(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, TObj *);
+extern int glacialWeapon(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, TObj *);
 
 
 
@@ -6951,5 +6953,7 @@ TObjSpecs objSpecials[NUM_OBJ_SPECIALS + 1] =
   {TRUE, "Living Vines", livingVines},
   {TRUE, "Piety Regen", pietyRegen},
   {TRUE, "DK Sword", dkSword},
+  {TRUE, "Molten Weapon", moltenWeapon}, 
+  {TRUE, "Glacial Weapon", glacialWeapon},
   {FALSE, "last proc", bogusObjProc}
 };

--- a/code/code/spec/spec_objs.h
+++ b/code/code/spec/spec_objs.h
@@ -37,7 +37,7 @@ const int SPEC_FACTIONSCORE_BOARD = 97;
 const int SPEC_GRAFFITI=135;
 const int SPEC_STOCK_BOARD  = 138;
 const int SPEC_BRICKQUEST = 148;
-const int NUM_OBJ_SPECIALS = 161;
+const int NUM_OBJ_SPECIALS = 163;
 
 struct TObjSpecs {
   bool assignable;

--- a/code/code/spec/spec_objs_weapons.cc
+++ b/code/code/spec/spec_objs_weapons.cc
@@ -2704,7 +2704,6 @@ int glacialWeapon(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, TObj *)
       act("The extreme cold from $p chills your flesh.", 
              0, vict, o, 0, TO_CHAR, ANSI_BLUE);
 
-
     rc = vict->reconcileDamage(vict, dam, DAMAGE_FROST);
     if (IS_SET_DELETE(rc, DELETE_VICT) || (vict->getHit() < -10))
       delete vict;
@@ -2750,8 +2749,10 @@ int glacialWeapon(TBeing *vict, cmdTypeT cmd, const char *arg, TObj *o, TObj *)
        aff.duration = Pulse::ONE_SECOND;
        aff.bitvector = AFF_STUNNED;
        vict->affectTo(&aff, -1);
+	  
        if (vict->fight())
           vict->stopFighting();
+	  
        return TRUE;
     }
   }


### PR DESCRIPTION
Molten:
   - 1d8 fire damage
   - 2% chance of bonebreak (fire-themed with wither effect)
   - fire-themed flavor text

Glacial:
   - 1d8 frost damage
   - 0.4% chance to freeze opponent (stun for 1 second)
   - ice-themed flavor text