### PR TITLE
Adding diamond/ruby weapons to arch vampire

### DIFF
--- a/lib/zonefiles/28865
+++ b/lib/zonefiles/28865
@@ -16,6 +16,10 @@ E 1 28803 5 11                   ruby gauntlet
 E 1 28801 5 7                  ruby legging   
 ? 0 3 0 E 
 E 1 1191 5 14                   cloak power (diamond)
+? 0 2 0 E
+E 1 1193 10 19              ruby longsword
+? 0 1 0 E
+E 1 1192 10 18              diamond longsword
 Y 0 14 4                       Diamond Set
 
 M 0 28806 1 28899        Giant Octopus


### PR DESCRIPTION
Adding matching suitset weapons to the arch vampire. I believe the new zonefile commands will work, since mobs no longer equip weapons and the danger of him dual wielding death upon players is null. 

According to zonefile documentation there shouldn't be a conflict. Nevertheless I will test for instances where the diamond sword or diamond shield never load, as they share a slot.