### PR TITLE
Fix how immunity is applied

### DIFF
--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -141,7 +141,7 @@ class specialData {
 
 class immunityData {
   public:
-    byte immune_arr[MAX_IMMUNES];
+    short immune_arr[MAX_IMMUNES];
 
     immunityData();
     immunityData(const immunityData &a);

--- a/code/code/misc/immunity.cc
+++ b/code/code/misc/immunity.cc
@@ -178,7 +178,7 @@ void TBeing::setImmunity(immuneTypeT type, short amt)
 
 void TBeing::addToImmunity(immuneTypeT type, short amt)
 {
-  immunities.immune_arr[type] = min(max(immunities.immune_arr[type] + amt, -100), 100);
+  immunities.immune_arr[type] = immunities.immune_arr[type] + amt;
 }
 
 bool TBeing::isImmune(immuneTypeT bit, wearSlotT pos, int modifier) const


### PR DESCRIPTION
Currently immunity is buggy when dealing with values above 100 or below -100. 

This PR updates TBeing::addToImmunity to so that the accurate value is stored in immune_arr 

TBeing::getImmunity will still min/max between 100 -100. 
