### PR TITLE
Multiclass fixes

### DIFF
--- a/code/code/cmd/cmd_score.cc
+++ b/code/code/cmd/cmd_score.cc
@@ -15,29 +15,22 @@ void TBeing::doScore()
 {
   time_info_data playing_time;
   sstring Buf, tString;
-  char part[256];
 
-  Buf = "";
-  sprintf(part, "You have %s%d%s/%s%d%s hit points, ", red(), getHit(), norm(), green(), hitLimit(), norm());  
-  Buf.append(part);
+  Buf = format("You have %s%d%s/%s%d%s hit points, ") % red() % getHit() % norm() % green() % hitLimit() % norm();
 
   if (hasClass(CLASS_DEIKHAN) || hasClass(CLASS_CLERIC)) {
-    sprintf(part, "%s%.2f%s %spiety, ", cyan(), getPiety(), "%", norm());
-    Buf.append(part);
+    Buf+=format("%s%.2f%s %spiety, ") % cyan() % getPiety() % "%" % norm();
   }
 
   if (hasClass(CLASS_SHAMAN)) {
-    sprintf(part, "%s%d %slifeforce, ", red(), getLifeforce(), norm());
-    Buf.append(part);
+    Buf+=format("%s%d %slifeforce, ") % red() % getLifeforce() % norm();
   }
 
   if (hasClass(CLASS_MAGE) || hasClass(CLASS_MONK) || hasQuestBit(TOG_PSIONICIST)) {
-    sprintf(part, "%s%d%s/%s%d%s mana, ", orange(),  getMana(), norm(), green(), manaLimit(), norm());
-    Buf.append(part);
+    Buf+=format("%s%d%s/%s%d%s mana, ") % orange() %  getMana() % norm() % green() % manaLimit() % norm();
   }
 
-  sprintf(part, "and %s%d%s/%s%d%s moves.\n\r", purple(), getMove(), norm(), green(), moveLimit(), norm());
-  Buf.append(part);
+  Buf+=format("and %s%d%s/%s%d%s moves.\n\r") % purple() % getMove() % norm() % green() % moveLimit()% norm();
   sendTo(Buf);
 
   sendTo(format("You are %s.\n\r") % DescMoves((((double) getMove()) / ((double) moveLimit()))));

--- a/code/code/cmd/cmd_score.cc
+++ b/code/code/cmd/cmd_score.cc
@@ -15,24 +15,32 @@ void TBeing::doScore()
 {
   time_info_data playing_time;
   sstring Buf, tString;
+  char part[256];
 
-  sendTo(format("You have %s%d%s/%s%d%s hit points, %s%d%s/%s%d%s moves and ") %	 red() % getHit() % norm() %
-	 green() % hitLimit() % norm() %
-	 purple() % getMove() % norm() %
-	 green() % moveLimit() % norm());
+  Buf = "";
+  sprintf(part, "You have %s%d%s/%s%d%s hit points, ", red(), getHit(), norm(), green(), hitLimit(), norm());  
+  Buf.append(part);
 
-  if (hasClass(CLASS_DEIKHAN) || hasClass(CLASS_CLERIC))
-    Buf = format("%s%.2f%c %spiety.\n\r") % cyan() % getPiety() % '%' % norm();
-  else if (hasClass(CLASS_SHAMAN))
-    Buf = format("%s%d %slifeforce.\n\r") % red() % getLifeforce() % norm();
-  else
-    Buf = format("%s%d%s/%s%d%s mana.\n\r") %
-      orange() % getMana() % norm() %
-      green() % manaLimit() % norm();
+  if (hasClass(CLASS_DEIKHAN) || hasClass(CLASS_CLERIC)) {
+    sprintf(part, "%s%.2f%s %spiety, ", cyan(), getPiety(), "%", norm());
+    Buf.append(part);
+  }
 
+  if (hasClass(CLASS_SHAMAN)) {
+    sprintf(part, "%s%d %slifeforce, ", red(), getLifeforce(), norm());
+    Buf.append(part);
+  }
+
+  if (hasClass(CLASS_MAGE) || hasClass(CLASS_MONK) || hasQuestBit(TOG_PSIONICIST)) {
+    sprintf(part, "%s%d%s/%s%d%s mana, ", orange(),  getMana(), norm(), green(), manaLimit(), norm());
+    Buf.append(part);
+  }
+
+  sprintf(part, "and %s%d%s/%s%d%s moves.\n\r", purple(), getMove(), norm(), green(), moveLimit(), norm());
+  Buf.append(part);
   sendTo(Buf);
 
-  sendTo(format("You are %s.\n\r") % DescMoves((((double) getMove()) / ((double)         moveLimit()))));
+  sendTo(format("You are %s.\n\r") % DescMoves((((double) getMove()) / ((double) moveLimit()))));
 
   tString = displayExp().comify();
 

--- a/code/code/misc/info.cc
+++ b/code/code/misc/info.cc
@@ -3855,6 +3855,8 @@ void TThing::evaluateMe(TBeing *ch) const
 void TMagicItem::evaluateMe(TBeing *ch) const
 {
   int learn = ch->getSkillValue(SKILL_EVALUATE);
+  int learn2 = learn;
+  int learn3 = learn;
 
   ch->learnFromDoingUnusual(LEARN_UNUSUAL_NORM_LEARN, SKILL_EVALUATE, 10);
 
@@ -3862,13 +3864,19 @@ void TMagicItem::evaluateMe(TBeing *ch) const
   if (ch->hasClass(CLASS_RANGER)) {
     learn *= ch->getClassLevel(CLASS_RANGER);
     learn /= 200;
-  } else if (ch->hasClass(CLASS_SHAMAN)) {
-    learn *= ch->getClassLevel(CLASS_SHAMAN);
-    learn /= 50;
-  } else {
-    learn *= ch->getSkillValue(SPELL_IDENTIFY);
-    learn /= 100;
-  }
+  } 
+  if (ch->hasClass(CLASS_SHAMAN)) {
+    learn2 *= ch->getClassLevel(CLASS_SHAMAN);
+    learn2 /= 50;
+  } 
+  learn3 *= ch->getSkillValue(SPELL_IDENTIFY);
+  learn3 /= 100;
+
+  // take the largest value 
+  learn2 = max(learn2, learn3);
+  learn = max(learn, learn2);
+
+  
 
   if (learn > 10) 
     ch->describeMagicLevel(this, learn);
@@ -5339,8 +5347,11 @@ void TBeing::doSpells(const sstring &argument)
   };
 
 
-  if (hasClass(CLASS_SHAMAN) && !isImmortal()) {
-    sendTo("Perhaps looking at rituals is what you need to do?\n\r");
+  if (!hasClass(CLASS_MAGE) && !isImmortal()) {
+    sendTo("You know nothing of casting spells.\n\r");
+    if (hasClass(CLASS_SHAMAN)) {
+      sendTo("Perhaps looking at rituals is what you need to do?\n\r");
+    }
     return;
   }
 

--- a/code/code/misc/magicutils.cc
+++ b/code/code/misc/magicutils.cc
@@ -528,6 +528,11 @@ TComponent *comp_from_object(TThing *item, spellNumT spell)
 }
 
 // This only returns components that are for spell-casting
+//
+// TODO: this is a mess and doesn't work for multiclass but
+// probably no one will notice because ritualism and wizardry
+// rise at the same rate.
+//
 TComponent *TBeing::findComponent(spellNumT spell) const
 {
   TThing *primary, *secondary, *belt, *juju, *wristpouchL, *wristpouchR;

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3426,6 +3426,7 @@ int TBeing::doMortalGoto(const sstring & argument)
     return FALSE;
   }
 
+  // Not multiclass safe but probably not a problem for anyone
   if (is_abbrev(arg, "trainer")) {
     if (hasClass(CLASS_WARRIOR)) {
       arg = "warrior_trainer";

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -2187,9 +2187,27 @@ void TBeing::blowCount(bool check, float &fx, float &fy)
   } else if (hasClass(CLASS_MONK)) {
     // Monk PCS
 
+    // TODO: this is such a clusterfuck
+    // end result here is monks who use weapons currently don't have a speed mod
+    // Multiclass monks don't get extra attacks when berserking
+
+    // Adding notes now and will fix in a single commit so we can revert if needed
+
+    // blowCountSplitter returns 1.0 if it's a weapon and 0.0 if it's not
+    // Why that is used in the monk section and non-monks use
+    //if (tobj && !tobj->isPaired() && !dynamic_cast<TBaseWeapon *>(tobj) && !check)
+    // 
+    // number of attacks for barehand monks is retrieved with getMult() and calculated in
+    // TBeing::classSpecificStuff() - Why the fuck it's not just done here I don't understand
+    // 
+
+
+    // getmult() should be 1.0 for war and a bunch for monk. unsure for others
     num = getMult();
     fx=fy=0;
 
+    // can probably just do if !prim && hasClass(CLASS_MONK)
+    // Then move speedmod into the else so it doesn't affect barehand monks
     if (!prim)
       fx += (0.60 * num);
     else {
@@ -2199,18 +2217,16 @@ void TBeing::blowCount(bool check, float &fx, float &fy)
       }
 
       if((gun=dynamic_cast<TGun *>(prim))){
-	fx = gun->getROF();
+        fx = gun->getROF();
       }
     }
-
-
 
     if (!sec)
       fy += (0.40 * num);
     else if (sec != prim) {
       fy = sec->blowCountSplitter(this, false);
       if((gun=dynamic_cast<TGun *>(sec)) && !gun->isPaired()){
-	fy = gun->getROF();
+        fy = gun->getROF();
       }
     } else
       // don't give paired weapons extra hits
@@ -2309,6 +2325,9 @@ void TBeing::blowCount(bool check, float &fx, float &fy)
 
     // non-monk PCs
   }
+
+
+
 
 
   // haste

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -2184,151 +2184,66 @@ void TBeing::blowCount(bool check, float &fx, float &fy)
     
 
     // MOBS
-  } else if (hasClass(CLASS_MONK)) {
-    // Monk PCS
+  } else {
+    // PCS
 
-    // TODO: this is such a clusterfuck
-    // end result here is monks who use weapons currently don't have a speed mod
-    // Multiclass monks don't get extra attacks when berserking
-
-    // Adding notes now and will fix in a single commit so we can revert if needed
-
-    // blowCountSplitter returns 1.0 if it's a weapon and 0.0 if it's not
-    // Why that is used in the monk section and non-monks use
-    //if (tobj && !tobj->isPaired() && !dynamic_cast<TBaseWeapon *>(tobj) && !check)
-    // 
-    // number of attacks for barehand monks is retrieved with getMult() and calculated in
-    // TBeing::classSpecificStuff() - Why the fuck it's not just done here I don't understand
-    // 
-
-
-    // getmult() should be 1.0 for war and a bunch for monk. unsure for others
+    // Get getMult returns the number of moonk barehand attacks
     num = getMult();
     fx=fy=0;
 
-    // can probably just do if !prim && hasClass(CLASS_MONK)
-    // Then move speedmod into the else so it doesn't affect barehand monks
-    if (!prim)
+    // Primary hand
+    if (!prim && hasClass(CLASS_MONK))
       fx += (0.60 * num);
     else {
+      // blowCountSplitter will return 0 if it is not a weapon and 1 if it is a weapon
       fx = prim->blowCountSplitter(this, true);
+      
+      // Guns
+      if((gun=dynamic_cast<TGun *>(prim))){
+        fx = gun->getROF();
+      }
+
+      // Check specialization after guns
       if (getPosition() >= POSITION_STANDING) {
         prim->specializationCheck(this, &fx);
       }
 
-      if((gun=dynamic_cast<TGun *>(prim))){
-        fx = gun->getROF();
-      }
+      // Now we can do the speed mod in here it won't affect monks barehand
+      if (fx > 0.0)
+        fx *= getSpeMod();
     }
 
-    if (!sec)
+    // Now do Secondary hand
+    if (!sec && hasClass(CLASS_MONK))
       fy += (0.40 * num);
     else if (sec != prim) {
       fy = sec->blowCountSplitter(this, false);
+
+      // Guns
       if((gun=dynamic_cast<TGun *>(sec)) && !gun->isPaired()){
         fy = gun->getROF();
       }
-    } else
+
+      // Speed mod
+      if (fy > 0.0)
+        fy *= getSpeMod();
+
+    } else {
       // don't give paired weapons extra hits
       fy = 0.00;
-
-#if 0
-    // kluge for barehand specialization check
-    // can't use TWeapon::SpecializationCheck for obvious reasons
-    if(!prim &&
-       getPosition() >= POSITION_STANDING &&
-       getDiscipline(DISC_BAREHAND)) {
-      num = ::number(0,99);
-      if (num < getSkillValue(SKILL_BAREHAND_SPEC) - 20 * drunkMinus())
-	fx += (float) 1.0;
-    }
-    // specialization check
-    if (prim && getPosition() >= POSITION_STANDING) {
-      prim->specializationCheck(this, &fx);
-    }
-#endif
-
-#if 0
-// speed adjusted when we setMult
-    // speed
-    // from balance note, want high speed to hit 5/4 more, and low to hit 4/5
-    // as much
-    if (fx > 0.0)
-      fx *= getSpeMod();
-    //  this is the same - note we DIVIDE instead of multiply since we want a lower number as the bonus
-    //  fx = fx * plotStat(STAT_CURRENT, STAT_SPE, 0.8, 1.25, 1.0);
-    if (fy > 0.0)
-      fy *= getSpeMod();
-    //  ditto above - dash
-    //  fy = fy * plotStat(STAT_CURRENT, STAT_SPE, 0.8, 1.25, 1.0);
-#endif
-
-    // Monk PCS
-  } else {
-    // NON-monk PCS
-
-    TObj *tobj = dynamic_cast<TObj *>(prim);
-    if (tobj && !tobj->isPaired() && !dynamic_cast<TBaseWeapon *>(tobj) && !check) 
-      // no attacks for non-weapons
-      fx = (float) 0.0;
-    else {
-      // generic 1 attack
-      fx = (float) 1.0;
     }
 
-    if((gun=dynamic_cast<TGun *>(prim))){
-      fx = gun->getROF();
-    }
 
-    tobj = dynamic_cast<TObj *>(sec);
-    if (tobj && !tobj->isPaired() && !dynamic_cast<TBaseWeapon *>(tobj) && !check) 
-      fy = (float) 0.0;
-    else if (sec && (sec == prim)) {
-     // Don't give two handed weapons two hits - Russ 122797
-      fy = (float) 0.0;
-    } else {
-      // generic 1 attack
-      fy = (float) 1.0;
-    }
-
-    if((gun=dynamic_cast<TGun *>(sec)) && !gun->isPaired()){
-      fy = gun->getROF();
-    }
-
-    // specialization check
-    if (prim && getPosition() >= POSITION_STANDING) {
-      prim->specializationCheck(this, &fx);
-    }
-
-    // berzerk
-    if (isCombatMode(ATTACK_BERSERK) && 
-        getPosition() >= POSITION_STANDING) {
+    // berzerk affects any combo
+    if (isCombatMode(ATTACK_BERSERK) && getPosition() >= POSITION_STANDING) {
       if (bSuccess(SKILL_BERSERK)) {
         if (fx > 0.0)
           fx += 0.5;
         if (fy > 0.0)
-	  fy += 0.5;
+	        fy += 0.5;
       }
     }
-
-    // speed
-    // from balance note, want high speed to hit 5/4 more, and low to hit 4/5
-    // as much
-    if (fx > 0.0)
-      fx *= getSpeMod();
-    //  this is the same - note we DIVIDE instead of multiply since we want a lower number as the bonus
-    //  fx = fx * plotStat(STAT_CURRENT, STAT_SPE, 0.8, 1.25, 1.0);
-    if (fy > 0.0)
-      fy *= getSpeMod();
-    //  ditto above - dash
-    //  fy = fy * plotStat(STAT_CURRENT, STAT_SPE, 0.8, 1.25, 1.0);
-
-    // non-monk PCs
   }
-
-
-
-
 
   // haste
   if (affectedBySpell(SPELL_HASTE) && getPosition() >= POSITION_STANDING) {

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -2187,7 +2187,7 @@ void TBeing::blowCount(bool check, float &fx, float &fy)
   } else {
     // PCS
 
-    // Get getMult returns the number of moonk barehand attacks
+    // Get getMult returns the number of monk barehand attacks
     num = getMult();
     fx=fy=0;
 

--- a/code/code/misc/other.cc
+++ b/code/code/misc/other.cc
@@ -568,9 +568,10 @@ void TBeing::doSplit(const char *argument, bool tell)
 
 void TBeing::doReport(const char *argument)
 {
-  char info[256];
-  char inter[256];
   char target[80];
+
+  sstring Buf, final;
+
   TThing *t;
   int found = 0;
   TBeing *targ = NULL;
@@ -588,21 +589,19 @@ void TBeing::doReport(const char *argument)
   }
   strncpy(target, argument, sizeof(target));
 
-  sprintf(info, "%.1f%% H, ", getPercHit());
+  Buf = format("%.1f%% H, ") % getPercHit();
+
   if (hasClass(CLASS_CLERIC) || hasClass(CLASS_DEIKHAN)) {
-    sprintf(inter, "%.2f%% P, ", getPiety());
-    strcat(info, inter);
+    Buf += format("%.2f%% P, ") % getPiety();
   }
   if (hasClass(CLASS_SHAMAN)) {
-    sprintf(inter, "%-4d LF, ", getLifeforce());
-    strcat(info, inter);
+    Buf += format("%d LF, ") % getLifeforce();
   }
   if (hasClass(CLASS_MAGE) || hasClass(CLASS_MONK) || hasQuestBit(TOG_PSIONICIST)) {
-    sprintf(inter, "%.1f%% M, ", getPercMana());
-    strcat(info, inter);
+    Buf += format("%.1f%% M, ") % getPercMana();
   }
-  sprintf(inter, "I am %s", DescMoves((((double) getMove()) / ((double) moveLimit()))));
-  strcat(info, inter);
+
+  Buf += format("I am %s") % DescMoves((((double) getMove()) / ((double) moveLimit())));
 
   for(StuffIter it=roomp->stuff.begin();it!=roomp->stuff.end();){
     t=*(it++);
@@ -624,12 +623,12 @@ void TBeing::doReport(const char *argument)
     }
     sendTo(COLOR_MOBS, format("You report your status to %s.\n\r") % targ->getName());
 
-    sprintf(inter, "<G>$n directly reports to you '%s%s%s'<1>", red(), info, norm());
-    colorAct(COLOR_COMM, inter, FALSE, this, 0, targ, TO_VICT);
+    final = format("<G>$n directly reports to you '%s%s%s'<1>") % red() % Buf % norm();
+    colorAct(COLOR_COMM, final, FALSE, this, 0, targ, TO_VICT);
     disturbMeditation(targ);
   } else {
-    sprintf(inter, "$n reports '%s%s%s'", red(), info, norm());
-    act(inter, FALSE, this, 0, 0, TO_ROOM);
+    final = format("$n reports '%s%s%s'") % red() % Buf % norm();
+    act(final, FALSE, this, 0, 0, TO_ROOM);
     sendTo("You report your status to the room.\n\r");
   }
 }

--- a/code/code/misc/other.cc
+++ b/code/code/misc/other.cc
@@ -569,6 +569,7 @@ void TBeing::doSplit(const char *argument, bool tell)
 void TBeing::doReport(const char *argument)
 {
   char info[256];
+  char inter[256];
   char target[80];
   TThing *t;
   int found = 0;
@@ -586,22 +587,22 @@ void TBeing::doReport(const char *argument)
     return;
   }
   strncpy(target, argument, sizeof(target));
-  if (hasClass(CLASS_CLERIC) || hasClass(CLASS_DEIKHAN))
-    sprintf(info, "$n reports '%s%.1f%% H, %.2f%% P. I am %s%s'",
-           red(), getPercHit(), getPiety(),
-           DescMoves((((double) getMove()) / ((double) moveLimit()))),
-           norm());
-  else if (hasClass(CLASS_SHAMAN))
-    sprintf(info, "$n reports '%s%.1f%% H, %-4d LF. I am %s%s'",
-           red(), getPercHit(), getLifeforce(),
-           DescMoves((((double) getMove()) / ((double) moveLimit()))),
-           norm());
-  else
-    sprintf(info, "$n reports '%s%.1f%% H, %.1f%% M. I am %s%s'", 
-           red(), getPercHit(), getPercMana(), 
-           DescMoves((((double) getMove()) / ((double) moveLimit()))), 
-           norm());
 
+  sprintf(info, "%.1f%% H, ", getPercHit());
+  if (hasClass(CLASS_CLERIC) || hasClass(CLASS_DEIKHAN)) {
+    sprintf(inter, "%.2f%% P, ", getPiety());
+    strcat(info, inter);
+  }
+  if (hasClass(CLASS_SHAMAN)) {
+    sprintf(inter, "%-4d LF, ", getLifeforce());
+    strcat(info, inter);
+  }
+  if (hasClass(CLASS_MAGE) || hasClass(CLASS_MONK) || hasQuestBit(TOG_PSIONICIST)) {
+    sprintf(inter, "%.1f%% M, ", getPercMana());
+    strcat(info, inter);
+  }
+  sprintf(inter, "I am %s", DescMoves((((double) getMove()) / ((double) moveLimit()))));
+  strcat(info, inter);
 
   for(StuffIter it=roomp->stuff.begin();it!=roomp->stuff.end();){
     t=*(it++);
@@ -622,26 +623,13 @@ void TBeing::doReport(const char *argument)
       return;
     }
     sendTo(COLOR_MOBS, format("You report your status to %s.\n\r") % targ->getName());
-    if (hasClass(CLASS_CLERIC) || hasClass(CLASS_DEIKHAN))
-      sprintf(info, "<G>$n directly reports to you  '%s%.1f%% H, %.2f%% P. I am %s%s'<1>",
-           red(), getPercHit(), getPiety(),
-           DescMoves((((double) getMove()) / ((double) moveLimit()))),
-           norm());
-    else if (hasClass(CLASS_SHAMAN))
-      sprintf(info, "<G>$n directly reports to you  '%s%.1f%% H, %-4d LF. I am %s%s'<1>",
-           red(), getPercHit(), getLifeforce(),
-           DescMoves((((double) getMove()) / ((double) moveLimit()))),
-           norm());
-    else
-      sprintf(info, "<G>$n directly reports to you '%s%.1f%% H, %.1f%% M. I am %s%s'<1>",
-           red(), getPercHit(), getPercMana(),
-           DescMoves((((double) getMove()) / ((double) moveLimit()))),
-           norm());
 
-    colorAct(COLOR_COMM, info, FALSE, this, 0, targ, TO_VICT);
+    sprintf(inter, "<G>$n directly reports to you '%s%s%s'<1>", red(), info, norm());
+    colorAct(COLOR_COMM, inter, FALSE, this, 0, targ, TO_VICT);
     disturbMeditation(targ);
   } else {
-    act(info, FALSE, this, 0, 0, TO_ROOM);
+    sprintf(inter, "$n reports '%s%s%s'", red(), info, norm());
+    act(inter, FALSE, this, 0, 0, TO_ROOM);
     sendTo("You report your status to the room.\n\r");
   }
 }
@@ -1531,6 +1519,7 @@ void TPerson::doFeedback(const sstring &type, int clientCmd, const sstring &arg)
   }
 }
 
+// TODO: this needs fixing for multiclass
 void TBeing::doGroup(const char *argument, bool silent)
 {
   char namebuf[256];

--- a/code/code/misc/shop.cc
+++ b/code/code/misc/shop.cc
@@ -1852,21 +1852,21 @@ void shopping_list(sstring argument, TBeing *ch, TMonster *keeper, int shop_nr)
     // check class restriction
     extra_flags = convertTo<int>(db["extra_flags"]);
       
-    fit=true;
-    if(ch->hasClass(CLASS_MAGE) && (extra_flags & ITEM_ANTI_MAGE))
-      fit=false;
-    if(ch->hasClass(CLASS_CLERIC) && (extra_flags & ITEM_ANTI_CLERIC))
-      fit=false;
-    if(ch->hasClass(CLASS_WARRIOR) && (extra_flags & ITEM_ANTI_WARRIOR))
-      fit=false;
-    if(ch->hasClass(CLASS_THIEF) && (extra_flags & ITEM_ANTI_THIEF))
-      fit=false;
-    if(ch->hasClass(CLASS_SHAMAN) && (extra_flags & ITEM_ANTI_SHAMAN))
-      fit=false;
-    if(ch->hasClass(CLASS_DEIKHAN) && (extra_flags & ITEM_ANTI_DEIKHAN))
-      fit=false;
-    if(ch->hasClass(CLASS_MONK) && (extra_flags & ITEM_ANTI_MONK))
-      fit=false;
+    fit=false;
+    if(ch->hasClass(CLASS_MAGE) && !(extra_flags & ITEM_ANTI_MAGE))
+      fit=true;
+    if(ch->hasClass(CLASS_CLERIC) && !(extra_flags & ITEM_ANTI_CLERIC))
+      fit=true;
+    if(ch->hasClass(CLASS_WARRIOR) && !(extra_flags & ITEM_ANTI_WARRIOR))
+      fit=true;
+    if(ch->hasClass(CLASS_THIEF) && !(extra_flags & ITEM_ANTI_THIEF))
+      fit=true;
+    if(ch->hasClass(CLASS_SHAMAN) && !(extra_flags & ITEM_ANTI_SHAMAN))
+      fit=true;
+    if(ch->hasClass(CLASS_DEIKHAN) && !(extra_flags & ITEM_ANTI_DEIKHAN))
+      fit=true;
+    if(ch->hasClass(CLASS_MONK) && !(extra_flags & ITEM_ANTI_MONK))
+      fit=true;
 
     volume=convertTo<int>(db["volume"]);
     slot = slot_from_bit(convertTo<int>(db["wear_flag"]));

--- a/code/code/misc/spell_parser.cc
+++ b/code/code/misc/spell_parser.cc
@@ -1104,9 +1104,6 @@ int TBeing::preCastCheck()
     } else if (hasClass(CLASS_THIEF)) {
       sendTo("Thieves can't cast spells!\n\r");
       return FALSE;
-    } else if (hasClass(CLASS_RANGER)) {
-      sendTo("Rangers can't cast spells!\n\r");
-      return FALSE;
     } else if (hasClass(CLASS_MONK)) {
       sendTo("Monks can't cast spells!\n\r");
       return FALSE;

--- a/code/code/sys/comm.cc
+++ b/code/code/sys/comm.cc
@@ -1028,7 +1028,7 @@ void Descriptor::updateScreenVt100(unsigned int update)
   if (IS_SET(prompt_d.type, PROMPT_CLASSIC_ANSIBAR)) {
 
     // Line 1:
-
+    // This should be fixed for multiclass but I don't think anyone uses vt100
     if (update & CHANGED_HP) {
       snprintf(buf + strlen(buf), cElements(buf) - strlen(buf), VT_CURSPOS, ch->getScreen() - 2, 7);
       snprintf(buf + strlen(buf), cElements(buf) - strlen(buf), "%d", ch->getHit());

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,9 +1,17 @@
+03-28-20 : Some multiclass fixes:
+           - Evaluating magic items should use the best skill
+           - Shaman/Mage combinations can now use the spells command
+           - Report should now show all relevant resources for multiclass
+           - "list fit" at shops should now work correctly
+           - Fixed a typo in a previous news entry!
+           - Fixed score output to show all relevant resources
+
 03-25-20 : Multiclass hitpoint fixes:
            - Monks base hitpoints have been increased but they no longer 
              have access to advanced defense. Overall this should even out. If
              you have a single class monk that put points into advanced defense
              you can get that fixed up by an admin. This change paves the way 
-             for future improvements to to the skill for War/Deik.
+             for future improvements to the skill for War/Deik.
            - Fixed a bug with multiclass hitpoints where previously it chose
              the base hitpoints of the first class now it takes the average.
 

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -5,6 +5,9 @@
            - "list fit" at shops should now work correctly
            - Fixed a typo in a previous news entry!
            - Fixed score output to show all relevant resources
+           - Monks who wield weapons now have a speed modifier to number of 
+             attacks like all other classes
+           - Monk/Warrior multiclass now gets extra attacks when berserking 
 
 03-25-20 : Multiclass hitpoint fixes:
            - Monks base hitpoints have been increased but they no longer 


### PR DESCRIPTION
Went through a lot of hasClass() to see where it was misused to not be multiclass safe. 

           - Evaluating magic items should use the best skill
           - Shaman/Mage combinations can now use the spells command
           - Report should now show all relevant resources for multiclass
           - "list fit" at shops should now work correctly
           - Fixed a typo in a previous news entry!
           - Fixed score output to show all relevant resources
           - Monks who wield weapons now have a speed modifier to number of 
             attacks like all other classes
           - Monk/Warrior multiclass now gets extra attacks when berserking 

