### PR TITLE
Holy Symbol Max Structure Value

### DIFF
--- a/code/code/misc/constants.cc
+++ b/code/code/misc/constants.cc
@@ -512,8 +512,8 @@ void assign_item_info()
      "Max Strength", 100, 0,
      "", 0, 0);
   ItemInfo[ITEM_HOLY_SYM] = new itemInfo("Holy Symbol","a holy symbol",
-     "Strength of the holy symbol", 1250000, 0,
-     "Max Strength of the symbol", 1250000, 0,
+     "Strength of the holy symbol", 1800000, 0,
+     "Max Strength of the symbol", 1800000, 0,
      "Faction of the Symbol", MAX_FACTIONS, 0,
      "", 0, 0);
   ItemInfo[ITEM_QUIVER] = new itemInfo("Quiver","a quiver",


### PR DESCRIPTION
Intention: Raise structure cap for symbols to create room for new ones.

The current max value is very dated. White titanium symbols are already at 1.5m (cap 1.25m) which is level 55. No one can even build an equivalent object without using the white titanium or mithril symbol as a base. Since Lvl 60 gear exists in other aspects, it makes sense to me that it should at least be possible in this instance for consistency. Without using convoluted means.

Furthermore, the talen value of all symbols going forward should be at least 5% of the total holy structure, 10% for neck symbols. Physical damage structure value should be the level of the symbol for neck slots. 