### PR TITLE
Rollback old nerf smite/charge.

### DIFF
--- a/code/code/misc/skill_dam.cc
+++ b/code/code/misc/skill_dam.cc
@@ -426,14 +426,14 @@ int TBeing::getSkillDam(const TBeing *victim, spellNumT skill, int level, int ad
       break;
     case SKILL_CHARGE:
       // limited to mounted and has other penalties  (3*normal dam)
-      dam =  genericDam(victim, skill, DISC_DEIKHAN, level, adv_learn, 0.639*3, REDUCE_NO, !isPc(), TRIM_NO);
+      dam =  genericDam(victim, skill, DISC_DEIKHAN, level, adv_learn, 0.9*3, REDUCE_NO, !isPc(), TRIM_NO);
       // additionally, do faction percent modification for deikhan
       dam = (int) (dam * percModifier());
       break;
     case SKILL_SMITE:
       // this is limited to once a day, and has limits from weapon-use to
       // so lets let it do a LOT of damage (20*normal skill)
-      dam =  genericDam(victim, skill, DISC_DEIKHAN, level, adv_learn, 0.639*20, REDUCE_YES, !isPc(), TRIM_NO);
+      dam =  genericDam(victim, skill, DISC_DEIKHAN, level, adv_learn, 0.9*20, REDUCE_YES, !isPc(), TRIM_NO);
       // additionally, do faction percent modification for deikhan
       dam = (int) (dam * percModifier());
       break;


### PR DESCRIPTION
I'm not entirely sure, but I think this is where they nerfed these abilities. The original *20 and *3 damage values being given a fractional multiplier. If that looks right, lets bump that up a bit and try it on.

If that doesn't look right, kick it back.