### PR TITLE
Restore skill difficulty

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -323,8 +323,6 @@ int TBeing::bashSuccess(TBeing *victim, spellNumT skill)
   // the effect here should be strictly to prevent skill-use
   // it should NOT cause loss of attacks, or do damage
   float wt = combatRound(discArray[SKILL_BASH]->lag);
-  // adjust based on bash difficulty
-  // wt = (wt * 100.0 / getSkillDiffModifier(SKILL_BASH));
 
   // Take a few moves from basher
   // since we cost some moves to perform, allow an extra 1/2 round of lag

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -324,7 +324,7 @@ int TBeing::bashSuccess(TBeing *victim, spellNumT skill)
   // it should NOT cause loss of attacks, or do damage
   float wt = combatRound(discArray[SKILL_BASH]->lag);
   // adjust based on bash difficulty
-  wt = (wt * 100.0 / getSkillDiffModifier(SKILL_BASH));
+  // wt = (wt * 100.0 / getSkillDiffModifier(SKILL_BASH));
 
   // Take a few moves from basher
   // since we cost some moves to perform, allow an extra 1/2 round of lag

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -194,8 +194,6 @@ static int bodyslamHit(TBeing *caster, TBeing *victim)
 
   // see the balance notes for details on what's going on here.
   float wt = combatRound(discArray[SKILL_BODYSLAM]->lag);
-  // adjust based on bash difficulty
-  wt = (wt * 100.0 / getSkillDiffModifier(SKILL_BODYSLAM));
 
   // since we cost some moves to perform, allow an extra 1/2 round of lag
   wt += 1.5;

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -180,9 +180,6 @@ static int spinHit(TBeing *caster, TBeing *victim)
   // see the balance notes for details on what's going on here.
   float wt = (combatRound(discArray[SKILL_SPIN]->lag) / 3);
 
-  // adjust based on bash difficulty
-  wt = (wt * 100.0 / getSkillDiffModifier(SKILL_SPIN));
-
   // since we cost some moves to perform, allow an extra 1/2 round of lag
   wt += 1.5;
 

--- a/code/code/cmd/cmd_trip.cc
+++ b/code/code/cmd/cmd_trip.cc
@@ -250,7 +250,6 @@ int TBeing::tripSuccess(TBeing *victim, spellNumT skill)
     return DELETE_THIS;
 
   float wait = combatRound(discArray[SKILL_TRIP]->lag);
-  wait = (wait * 100.0 / getSkillDiffModifier(SKILL_TRIP));
   addToMove(-5);
   wait += 0.5;
   // round up

--- a/code/code/disc/disc_air.cc
+++ b/code/code/disc/disc_air.cc
@@ -196,8 +196,7 @@ int immobilize(TBeing * caster, TBeing * victim, int level, short bKnown)
   // some command lock-out.
   // since spell is tasked, add one to the lag
   float rounds = 0.2233 * (discArray[SPELL_IMMOBILIZE]->lag + 1);
-  // adjust for difficulty
-  rounds = (rounds * 100.0 / getSkillDiffModifier(SPELL_IMMOBILIZE));
+
   // adjust for saving-throw penalty
   rounds = (rounds * 4 / 3);
 

--- a/code/code/disc/disc_dueling.cc
+++ b/code/code/disc/disc_dueling.cc
@@ -226,8 +226,8 @@ int TBeing::parryWarrior(TBeing *v, TThing *weapon, int *dam, int w_type, wearSl
   // the higher amt is, the more things get blocked
   int amt = 0;
   if (trance) {
-    amt += (int)(420 * 100 / getSkillDiffModifier(SKILL_TRANCE_OF_BLADES));
-    amt += (int)(80 * 100 / getSkillDiffModifier(SKILL_PARRY_WARRIOR));
+    // 50% base parry chance
+    amt += 500;
     switch(::number(0,2)){
     case 0:
       strcpy(type, "parry");
@@ -247,7 +247,8 @@ int TBeing::parryWarrior(TBeing *v, TThing *weapon, int *dam, int w_type, wearSl
     //    amt = (int)((float) amt * v->plotStat(STAT_CURRENT, STAT_SPE, 0.80, 1.25, 1.00));
     amt = (int)((float)amt * getSpeMod() * getAgiMod()); // does the same thing - fear hobbit trancer.
   } else {  
-    amt += (int) (40 * 100 / getSkillDiffModifier(SKILL_PARRY_WARRIOR));
+    // 4% base parry chance
+    amt += 40;
     strcpy(type, "parry");
     strcpy(type2,"parries");
   }

--- a/code/code/disc/disc_monk.cc
+++ b/code/code/disc/disc_monk.cc
@@ -392,11 +392,8 @@ int TBeing::monkDodge(TBeing *v, TThing *weapon, int *dam, int w_type, wearSlotT
   // So technically, we should be blocking 12/90 = 13.3% of damage
   w_type -= TYPE_HIT;
 
-  // monks becoming better tanks than warriors, so lowering this to 10% (3-14-01)
-  // base amount, modified for difficulty
   // the higher amt is, the more things get blocked
-  //  :: Modifer was SKILL_DODGE.  Jirin was created to replace it.
-  int amt = (int) (100 * 100 / getSkillDiffModifier(SKILL_JIRIN));
+  int amt = 100;
 
   if (::number(0, 999) >= amt)
     return FALSE;

--- a/code/code/disc/disc_psionics.cc
+++ b/code/code/disc/disc_psionics.cc
@@ -775,7 +775,6 @@ int kwaveDamage(TBeing *caster, TBeing *victim) {
         return DELETE_VICT;
 
     float wt = combatRound(discArray[SKILL_KINETIC_WAVE]->lag);
-    wt = (wt * 100.0 / getSkillDiffModifier(SKILL_KINETIC_WAVE));
     wt += 1;
     victim->addToWait((int) wt);
 

--- a/code/code/disc/disc_thief.cc
+++ b/code/code/disc/disc_thief.cc
@@ -409,9 +409,8 @@ int TBeing::thiefDodge(TBeing *v, TThing *weapon, int *dam, int w_type, wearSlot
 
   w_type -= TYPE_HIT;
 
-  // base amount, modified for difficulty
-  // the higher amt is, the more things get blocked
-  int amt = (int) (45 * 100 / getSkillDiffModifier(SKILL_DODGE_THIEF));
+  // the higher amt is, the more things get dodged
+  int amt = 45;
 
   if (::number(0, 999) >= amt)
     return FALSE;

--- a/code/code/misc/damage.cc
+++ b/code/code/misc/damage.cc
@@ -22,7 +22,7 @@
 #include "configuration.h"
 
 // there is another one of these defines in combat.cc
-#define DAMAGE_DEFINE 0
+#define DAMAGE_DEBUG 0
 
 // -1 = v is dead, needs to go bye-bye
 int TBeing::reconcileDamage(TBeing *v, int dam, spellNumT how)

--- a/code/code/misc/discipline.cc
+++ b/code/code/misc/discipline.cc
@@ -1349,6 +1349,9 @@ bool TBeing::bSuccess(int ubCompetence, spellNumT spell)
   //limit *= plotStat(STAT_CURRENT, STAT_FOC, 0.80, 1.25, 1.00);
   limit *= getFocMod(); // does the same thing, just uses standard formula
 
+  // Adding in Karma (luck) as a smaller component than focus
+  limit *= plotStat(STAT_CURRENT, STAT_KAR, 0.9, 1.125, 1.0);
+
   // make other adjustments here
   // possibly have some for things like position, etc
 

--- a/code/code/misc/skill_dam.cc
+++ b/code/code/misc/skill_dam.cc
@@ -11,7 +11,6 @@
 
 double getSkillDiffModifier(spellNumT skill)
 {
-#if 0
   int amt = 0;
   switch (discArray[skill]->task) {
     case TASK_TRIVIAL:
@@ -37,12 +36,6 @@ double getSkillDiffModifier(spellNumT skill)
       break;
   }
   return amt;
-
-#else
-  // for time being, make everything "easy".
-  // too much complaining about skill failure, so screw it  - bat 2/3/00
-  return 100;
-#endif
 }
 
 void getSkillLevelRange(spellNumT skill, int &min_lev, int &max_lev, int adv_learn)
@@ -146,17 +139,11 @@ if (discArray[skill]->disc == discArray[skill]->assDisc) {
     fixed_amt *= 0.9091 / 1.75;
 
   // Obviously, we should tweak dam up/down based on how successful the
-  // skill is. 
-  fixed_amt *= (100.0 / getSkillDiffModifier(skill));
-#if 0
-// lower chance of CS/CF makes this less necessary
-  // intentionally factored in twice
+  // skill is. We increase damage for skills as the failure rate increases 
+  // to ensure those skills are worth using.
   // factoring in once evenly weights easy vs hard skills in terms of
   // resulting damage.
-  // hard skills have lower CS and more CF, so the damage ought to be raised
-  // even more to account for this.
   fixed_amt *= (100.0 / getSkillDiffModifier(skill));
-#endif
 
   // cut area effects in half
   if (IS_SET(discArray[skill]->targets, TAR_AREA)) 

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,21 @@
+07-09-20 : Important change to skill/spell difficulty and damage.
+            At some point all skills and spells were short-circuited
+            to act like they were all trvial difficulty. This affected
+            failure rate and damage. Currently it's impossible to fail
+            a skill/spell that is maxed unless you have very low focus.
+            We're going to restore this system so that it acts as documented
+            in the help files. Take some time to adjust and provide feedback
+            on failure rates.
+            Here's how this will be working now:
+            difficulty | Success | Damage
+            - trivial      100%    100%  
+            - easy          90%    111%
+            - normal        80%    125%
+            - difficult     70%    143%
+            - dangerous     60%    167%
+            Focus is the primary stat to increase success. I added Karma as
+            a smaller secondary modifier.
+
 07-07-20 : Synostodweomer tweak
             This prayer fading could potentially result in death so it's been
             tweaked to no longer give current hitpoints only max hitpoints.

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -13,8 +13,8 @@
             - normal        80%    125%
             - difficult     70%    143%
             - dangerous     60%    167%
-            Focus is the primary stat to increase success. I added Karma as
-            a smaller secondary modifier.
+            Focus is the primary stat to increase the above success percentage. 
+            I added Karma as a smaller secondary modifier.
 
 07-07-20 : Synostodweomer tweak
             This prayer fading could potentially result in death so it's been


### PR DESCRIPTION
Here's an interesting story. So I was chatting about how people feel skills used to do more damage and decided to walk through how this gets applied and I found this code that had been short circuited 19 years ago. 

getSkillDiffModifier in misc/skill_dam.cc returns a number based on the difficulty of the skill. This is primarily used in two places. 
- in determining success or failure of the skill/spell
- in determining the damage of the skill/spell

It was short circuited to just return 100 as if all skills are a trivial difficulty skill. Never fail unless the char is pretty unfocused.

The result damage wise is that most skills (normal difficulty) will do 25% more damage if this is merged. Up to "dangerous skills" that can do up to 66% more damage. Of course they will fail much more frequently too.

The reason listed to make the change was that "too much complaining about skill failure, so screw it  - bat 2/3/00".

I think we should turn merge this. I think it makes the game more interesting. We can tune the difficulty of an individual skill or global adjust skill success rates if we decide things need to be tuned.

I tested that the change compiles, that using skills/spells still worked and that with damage debug turned on I observe the expected change in damage values. I obviously didn't test how annoying increased failure rates are over the long haul. Also, there could be some abilities that need tweaking after this.

If we want to test this more somehow or if there's a specific concern I am happy to spend more time with it.

---
NOTES

Here's everywhere this function is used in the code
```
// Damage modifier in skill Damage
// Due to the change we are always multiplying dam by 1
// Some dangerous skills would get multiplied by 1.66667
./code/code//misc/skill_dam.cc:  fixed_amt *= (100.0 / getSkillDiffModifier(skill));


// bSuccess MAIN skill check for success. Everything runs through here and
// difficult skills will fail much more often if we make this change
./code/code//misc/discipline.cc:  float limit = getSkillDiffModifier(spell);


// Some skills have longer lockout imposed on the victim based on the difficulty of the skill
// This seems dumb as the difficulty of a skill never changes. Perhaps it was meant to be the
// learnedness of the skill? This has always been irrelevant since it always returned 100.
// I'm going to just remove this so as not to change the expected behavior of these skills. 
./code/code//cmd/cmd_spin.cc:  wt = (wt * 100.0 / getSkillDiffModifier(SKILL_SPIN));
./code/code//cmd/cmd_bodyslam.cc:  wt = (wt * 100.0 / getSkillDiffModifier(SKILL_BODYSLAM));
./code/code//cmd/cmd_trip.cc:  wait = (wait * 100.0 / getSkillDiffModifier(SKILL_TRIP));
./code/code//cmd/cmd_bash.cc:  wt = (wt * 100.0 / getSkillDiffModifier(SKILL_BASH));
./code/code//disc/disc_air.cc:  rounds = (rounds * 100.0 / getSkillDiffModifier(SPELL_IMMOBILIZE));
./code/code//disc/disc_psionics.cc:    wt = (wt * 100.0 / getSkillDiffModifier(SKILL_KINETIC_WAVE));


// Dodge/parry/block work better based on skill difficulty. These were added since this code has been broken. I will remove so we don't have some unexpected results.
./code/code//disc/disc_monk.cc:  int amt = (int) (100 * 100 / getSkillDiffModifier(SKILL_JIRIN));
./code/code//disc/disc_thief.cc:  int amt = (int) (45 * 100 / getSkillDiffModifier(SKILL_DODGE_THIEF));
./code/code//disc/disc_dueling.cc:    amt += (int)(420 * 100 / getSkillDiffModifier(SKILL_TRANCE_OF_BLADES));
./code/code//disc/disc_dueling.cc:    amt += (int)(80 * 100 / getSkillDiffModifier(SKILL_PARRY_WARRIOR));
./code/code//disc/disc_dueling.cc:    amt += (int) (40 * 100 / getSkillDiffModifier(SKILL_PARRY_WARRIOR));
./code/code//disc/disc_dueling.cc:  int amt = (int) (45 * 100 / getSkillDiffModifier(SKILL_PARRY_WARRIOR));
```

