### PR TITLE
tweak syno so as to not result in death on fade

### DIFF
--- a/code/code/disc/disc_deikhan.cc
+++ b/code/code/disc/disc_deikhan.cc
@@ -61,8 +61,6 @@ int synostodweomer(TBeing *caster, TBeing *v, int level, short bKnown)
     aff.location = APPLY_HIT;
     aff.bitvector = 0;
     v->affectTo(&aff, -1);
-    aff.location = APPLY_CURRENT_HIT;
-    v->affectTo(&aff, -1);
 
     v->updatePos();
     caster->updatePos();

--- a/code/code/sys/socket.cc
+++ b/code/code/sys/socket.cc
@@ -1258,8 +1258,8 @@ bool procCharRegen::run(const TPulse &pl, TBeing *tmp_ch) const
   if (tmp_ch->roomp && !tmp_ch->roomp->isRoomFlag(ROOM_NO_HEAL) && 
       tmp_ch->getHit() < tmp_ch->hitLimit() &&
       tmp_ch->getCond(FULL) && tmp_ch->getCond(THIRST) &&
-      !::number(0, 10) && (tmp_ch->getMyRace()->hasTalent(TALENT_FAST_REGEN) || tmp_ch->affectedBySpell(SPELL_SYNOSTODWEOMER)))
-  {
+      !::number(0, 10) &&
+      (tmp_ch->getMyRace()->hasTalent(TALENT_FAST_REGEN) || tmp_ch->affectedBySpell(SPELL_SYNOSTODWEOMER))) {
     // mostly for trolls
     int addAmt = (int)(tmp_ch->hitGain() / 10.0);
     if (addAmt > 0) {

--- a/code/code/sys/socket.cc
+++ b/code/code/sys/socket.cc
@@ -1256,10 +1256,10 @@ bool procCharRegen::run(const TPulse &pl, TBeing *tmp_ch) const
 {
   // this was in hit(), makes more sense here I think
   if (tmp_ch->roomp && !tmp_ch->roomp->isRoomFlag(ROOM_NO_HEAL) && 
-      tmp_ch->getMyRace()->hasTalent(TALENT_FAST_REGEN) &&
       tmp_ch->getHit() < tmp_ch->hitLimit() &&
       tmp_ch->getCond(FULL) && tmp_ch->getCond(THIRST) &&
-      !::number(0, 10)){
+      !::number(0, 10) && (tmp_ch->getMyRace()->hasTalent(TALENT_FAST_REGEN) || tmp_ch->affectedBySpell(SPELL_SYNOSTODWEOMER)))
+  {
     // mostly for trolls
     int addAmt = (int)(tmp_ch->hitGain() / 10.0);
     if (addAmt > 0) {

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,8 @@
+07-07-20 : Synostodweomer tweak
+            This prayer fading could potentially result in death so it's been
+            tweaked to no longer give current hitpoints only max hitpoints.
+            - It also provides enhanced regen now.
+
 07-06-20 : New skill in offensive abilities called Inevitability.
            - Stacking buff that procs on misses and improves hit chance
 


### PR DESCRIPTION
remove APPLY_CURRENT_HIT from syno so that when it fades it doesn't possibly result in death. Adding regen to the buff to sort of make up for it.