### PR TITLE
adjust aura duration

### DIFF
--- a/code/code/disc/disc_deikhan_auras.cc
+++ b/code/code/disc/disc_deikhan_auras.cc
@@ -59,7 +59,7 @@ spellNumT auraArray[MAX_AURA] = {SKILL_AURA_MIGHT,
     SKILL_AURA_VENGEANCE,
     SKILL_AURA_ABSOLUTION};
 
-const int AURA_DURATION = 7;
+const int AURA_DURATION = 9;
 const int PROJECTION_DURATION = 4850;
 
 // checkAura is called by various hooks in the code


### PR DESCRIPTION
I've seen auras wear off for a split second a few times on the live instance. Never saw this in testing. Maybe the pulse duration is different based not he system? any who adjusting it slightly.