### PR TITLE
change spell crit

### DIFF
--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,8 @@
+11-05-20 : Reworked spell crit
+           - Increased crit range to between .1% and 10%
+           - Wisdom and to a smaller extent Karma determine the rate
+           Mobs can no longer crit skills and spells
+
 09-24-20 : Fixed a crash bug <3
 
 09-15-20 : Non-warriors should find honing defense and advanced defense


### PR DESCRIPTION
Here we add Wis and Karma into the spell crit formula as part of the effort to expand the affect for lesser used stats. After this change mages will have a use for int, wis and focus. Yay!
