### PR TITLE
List account upgrade

### DIFF
--- a/code/code/cmd/cmd_who.cc
+++ b/code/code/cmd/cmd_who.cc
@@ -116,8 +116,7 @@ static const sstring getWhoLevel(const TBeing *ch, TBeing *p)
     if(p->isPlayerAction(PLR_ANONYMOUS) && !ch->isImmortal()){
       tmpstring = "Anonymous";
     } else {
-      tempbuf=format("%-5s Lev %2d") % 
-	p->getProfAbbrevName() % p->GetMaxLevel();
+      tempbuf=format("%-5s Lev %2d") % TBeing::getProfAbbrevName(p->player.Class) % p->GetMaxLevel();
       tmpstring += tempbuf;
     }
 

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -476,7 +476,7 @@ class TBeing : public TThing {
   unsigned short GetMaxLevel() const;
   void setMaxLevel(unsigned short num);
   sstring const getProfName() const;
-  std::string getProfAbbrevName() const;
+  static sstring getProfAbbrevName(unsigned short code);
   void deityIgnore(silentTypeT = SILENT_NO) const;
   void nothingHappens(silentTypeT = SILENT_NO) const;
   float percModifier() const;

--- a/code/code/misc/multiclass.cc
+++ b/code/code/misc/multiclass.cc
@@ -347,68 +347,42 @@ sstring const TBeing::getProfName() const
   return buf;
 }
 
-std::string TBeing::getProfAbbrevName() const
+namespace {
+  int count_set_bit(int n) {
+    int count = 0;
+    while(n != 0) {
+      count += n & 1;
+      n >>= 1;
+    }
+    return count;
+  }
+}
+
+sstring TBeing::getProfAbbrevName(unsigned short code)
 {
-  // CLASS_MAGE
-  // CLASS_CLERIC
-  // CLASS_WARRIOR
-  // CLASS_THIEF
-  // CLASS_SHAMAN
-  // CLASS_DEIKHAN
-  // CLASS_MONK
-  // CLASS_RANGER
-  // CLASS_COMMONER
+  sstring buf = "";
+  bool multiclass = false;
 
-  std::unordered_map<classIndT, char> abbr = {
-    {MAGE_LEVEL_IND, 'M'},
-    {CLERIC_LEVEL_IND, 'C'},
-    {WARRIOR_LEVEL_IND, 'W'},
-    {THIEF_LEVEL_IND, 'T'},
-    {SHAMAN_LEVEL_IND, 'S'},
-    {DEIKHAN_LEVEL_IND, 'D'},
-    {MONK_LEVEL_IND, 'K'},
-    {RANGER_LEVEL_IND, 'R'},
-    {COMMONER_LEVEL_IND, '?'},
-    {UNUSED1_LEVEL_IND, '?'},
-    {UNUSED2_LEVEL_IND, '?'}};
+  if (count_set_bit(code) > 1)
+    multiclass = true;
 
-  int numCl = howManyClasses();
-  if (numCl > 3)
-    return "Multi";
+  for (classIndT iClass = MIN_CLASS_IND; iClass < MAX_CLASSES; iClass++){
+    if (code & (1<<iClass)) {
+      if (!multiclass) {
+        if (classInfo[iClass].name == "thief"){
+          return classInfo[iClass].name.cap();
+        }
 
-  if (numCl == 1) {
-    if (hasClass(CLASS_MAGE, EXACT_YES))
-      return "Mage";
-    else if (hasClass(CLASS_CLERIC, EXACT_YES))
-      return "Cler";
-    else if (hasClass(CLASS_WARRIOR, EXACT_YES))
-      return "Warr";
-    else if (hasClass(CLASS_THIEF, EXACT_YES))
-      return "Thief";
-    else if (hasClass(CLASS_DEIKHAN, EXACT_YES))
-      return "Deik";
-    else if (hasClass(CLASS_MONK, EXACT_YES))
-      return "Monk";
-    else if (hasClass(CLASS_SHAMAN, EXACT_YES))
-      return "Sham";
-    else if (hasClass(CLASS_RANGER, EXACT_YES))
-      return "Rang";
-    return "???";
-  } else {
-    bool first = true;
-    std::string res;
-
-    for (auto cl = MAGE_LEVEL_IND; cl <= RANGER_LEVEL_IND; cl++) {
-      if (hasClass(getClassNum(cl), EXACT_NO)) {
-        if (first)
-          first = false;
-        else
-          res += "/";
-        res += abbr[cl];
+        return sstring(classInfo[iClass].name.substr(0, 4)).cap();
+      } else {
+        buf += classInfo[iClass].abbr;
+        buf += "/";
       }
     }
-    return res;
   }
+  if (multiclass)
+    buf = buf.substr(0, buf.size() - 1);
+  return buf;
 }
 
 void TBeing::setClass(unsigned short num)

--- a/code/code/misc/player_data.cc
+++ b/code/code/misc/player_data.cc
@@ -2298,7 +2298,7 @@ int listAccount(sstring name, sstring &buf)
     char * tmstr = (char *) asctime(localtime(&ct));
     *(tmstr + strlen(tmstr) - 1) = '\0';
     
-    buf += format("%d) %s (L%d) %s\n\r") % ++count % chars[iChar].c_str() % int(max_level) % tmstr;
+    buf += format("%2d) %-16s %-10s [ %-5s Lev %2d ] %s\n\r") % ++count % chars[iChar].c_str() % Races[int(st.race)]->getSingularName() % TBeing::getProfAbbrevName(st.Class) % int(max_level) % tmstr;
   }
   return count;
 }

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,6 @@
+01-05-21 : List characters in the account menu now shows the race and 
+             classes of each of the characters.
+
 01-01-21 : More Garble tweaks
            - Even easier to understand with maxed language skills
            - Group tells are now considered non-verbal communication


### PR DESCRIPTION
add race and classes to account List command

--

I reworked this to be a static method that accepts the class code so it can be usable in the account menu list function.

```
-> l
The following characters are in the test account.
--------------------------------------------------
 1) bleric           human      [ M/C   Lev 50 ] Wed Jan  6 22:08:01 2021
 2) bully            bullywug   [ Warr  Lev  1 ] Thu Jan  7 00:11:35 2021
 3) deik             human      [ Deik  Lev 50 ] Tue Jan  5 23:30:11 2021
 4) elfguy           elf        [ C/S/D Lev 50 ] Tue Jan  5 21:29:48 2021
 5) fishy            kalysian   [ Warr  Lev  1 ] Mon Dec 21 01:37:44 2020
 6) magcler          kalysian   [ M/T/D Lev  1 ] Tue Jan  5 23:49:46 2021
 7) orcguy           orc        [ Warr  Lev  1 ] Sat Dec 12 22:11:08 2020
 8) phil             human      [ S/K   Lev 50 ] Thu Dec 31 06:13:00 2020
 9) reallyreallylong troglodyte [ Warr  Lev  1 ] Wed Jan  6 01:11:35 2021
10) reyek            human      [ C/T/S Lev 50 ] Sun Dec 20 19:46:33 2020
11) smartorc         orc        [ Warr  Lev  1 ] Thu Jan  7 00:55:07 2021
12) testguy          aarakocra  [ M/C/K Lev  1 ] Wed Jan  6 01:29:22 2021
13) thief            human      [ Thief Lev 50 ] Tue Dec  8 23:11:52 2020
14) trollguy         troll      [ Warr  Lev  1 ] Mon Aug 10 07:04:22 2020
15) warlike          orc        [ Warr  Lev  1 ] Wed Jan  6 00:29:39 2021

[Press return to continue]
```

who -l still works the same

```
> who -l
Players: (Add -? for online help)
--------
Aion        Level:[ Implementor  ][creator]
Bleric      Level:[ M/C   Lev 50 ]
Smartorc    Level:[ Warr  Lev  1 ]

Total players / Link dead [3/0] ( 0%)
Number Listed: 3  Max since Reboot [3]  Avg Players : [1.0]
```