### PR TITLE
WIP: fix shop_buy

### DIFF
--- a/code/code/misc/shop.cc
+++ b/code/code/misc/shop.cc
@@ -552,8 +552,6 @@ void shopping_buy(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
       rent_id=convertTo<int>(db["rent_id"]);
       temp1=keeper->loadItem(shop_nr, rent_id);
       *keeper += *temp1;
-      vlogf(LOG_BUG, format("created: %s ") % temp1->getName());
-
       objects.push_back(rent_id);
       objects_p.push_back(temp1);
       ++i;
@@ -588,20 +586,22 @@ void shopping_buy(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
     return;
   }
 
-  // sell/purchase the object, if that fails destroy all in-memory stuff
-  if (temp1->buyMe(ch, keeper, num, shop_nr) == -1) {
-    for(unsigned int i=0;i<objects_p.size();++i)
-      delete objects_p[i];
-    return;
-  } else {
+  if (temp1->buyMe(ch, keeper, num, shop_nr) != -1) {
     // We've sucessfully sold so update the DB
     for(unsigned int i=0;i<objects_p.size();++i) {
       keeper->deleteItem(shop_nr, objects[i]);
     }
   }
 
-  // We might still have loaded items on the keeper somehow maybe????
-  
+  // Ensure stuff that is on the keeper is deleted 
+  // regardless of where it came from or how it got there!
+  TThing *t;
+  for(StuffIter it=keeper->stuff.begin();it!=keeper->stuff.end();) {
+    // delete t;
+    t=*(it++);
+    --(*t);
+  }
+
 }
 
 

--- a/code/code/misc/shop.cc
+++ b/code/code/misc/shop.cc
@@ -552,6 +552,8 @@ void shopping_buy(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
       rent_id=convertTo<int>(db["rent_id"]);
       temp1=keeper->loadItem(shop_nr, rent_id);
       *keeper += *temp1;
+      vlogf(LOG_BUG, format("created: %s ") % temp1->getName());
+
       objects.push_back(rent_id);
       objects_p.push_back(temp1);
       ++i;
@@ -591,18 +593,15 @@ void shopping_buy(const char *arg, TBeing *ch, TMonster *keeper, int shop_nr)
     for(unsigned int i=0;i<objects_p.size();++i)
       delete objects_p[i];
     return;
+  } else {
+    // We've sucessfully sold so update the DB
+    for(unsigned int i=0;i<objects_p.size();++i) {
+      keeper->deleteItem(shop_nr, objects[i]);
+    }
   }
 
-  // delete objects left on keeper, remove objects sold from db
-  for(unsigned int i=0;i<objects_p.size();++i) {
-    TObj *cleanupObj = objects_p[i];
-    if (!cleanupObj)
-      continue;
-    if (cleanupObj->parent == keeper)
-      delete objects_p[i];
-    else
-      keeper->deleteItem(shop_nr, objects[i]);
-  }
+  // We might still have loaded items on the keeper somehow maybe????
+  
 }
 
 

--- a/code/code/obj/obj_commodity.cc
+++ b/code/code/obj/obj_commodity.cc
@@ -343,7 +343,7 @@ int TCommodity::buyMe(TBeing *ch, TMonster *keeper, int num, int shop_nr)
   ch->doQueueSave();
   if (numUnits() > 0)
     keeper->saveItem(shop_nr, this);
-  delete this;
+  // delete this;
   return price;
 }
 


### PR DESCRIPTION
@cizra wanted to get your take on this.

```
// delete objects left on keeper, remove objects sold from db
  for(unsigned int i=0;i<objects_p.size();++i) {
    TObj *cleanupObj = objects_p[i];
    if (!cleanupObj)
      continue;
    if (cleanupObj->parent == keeper)
      delete objects_p[i];
    else
      keeper->deleteItem(shop_nr, objects[i]);
  }
}
```
The intent of the above code looks like this:
- If we somehow at the end of this have any items left on the keeper we want to delete them
- otherwise we assume they've been sold and we call deleteItem which updates the DB.

This code moves the deleteItem and eliminates the extra delete. My test instance isn't crashing but can you think of something that might go wrong or a better way to handle this?
