### PR TITLE
allow longer zone reset timers

### DIFF
--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -2609,7 +2609,7 @@ void procZoneUpdate::run(const TPulse &) const
 // update zone ages, queue for reset if necessary, and dequeue when possible
   unsigned int i;
   resetQElement *update_u, *temp, *tmp2;
-  const int ZO_DEAD = 999;
+  const int ZO_DEAD = 9999;
 
   for (i = 0; i < zone_table.size(); i++) {
     if (zone_table[i].age < zone_table[i].lifespan &&


### PR DESCRIPTION
Pretty sure this works fine. Only done a little testing but it seems simple.

@Aion2501 Currently 998 minutes is the longest reset time that works. This changes it to 9998.

 I know we were experimenting with different numbers. in a few zones. After we merge this you should adjust those again to where you want it.


