### PR TITLE
Ensure the corpses directory exists

### DIFF
--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -402,6 +402,7 @@ void bootDb(void)
   bootPulse("Verifying runtime lib dirs.");
   verify_path("roomdata/saved");
   verify_path("immortals");
+  verify_path("corpses/corrupt");
   verify_path_azdir("rent");
   verify_path_azdir("account");
   verify_path_azdir("player");


### PR DESCRIPTION
This change ensures the `corpses` and `corpses/corrupt` directories exist when starting the server.

This was missing from the other directories that are checked on startup, and this should prevent a crash that can happen when someone dies when the server is started via the docker compose scripts, or the directory isn't manually created, and sneezymud fails to open `corpses/<playername>`.