### PR TITLE
Correcting object number error

### DIFF
--- a/lib/zonefiles/11800
+++ b/lib/zonefiles/11800
@@ -41,7 +41,7 @@ M 0 11803 1 11829        Vampire
 G 1 813 1                scroll recall
 M 0 11804 1 11829        Arch Nemesis
 ? 0 1 0 E
-E 1 11914 10 19            Legion Greatblade
+E 1 11814 10 19            Legion Greatblade
 Y 0 159 4                  Black Legion Set
 M 0 25506 35 11911       Skeleton
 G 1 813 1


### PR DESCRIPTION
Replacing vnum of the legion greatblade with the correct vnum.