### PR TITLE
upgrade area damage

### DIFF
--- a/code/code/misc/skill_dam.cc
+++ b/code/code/misc/skill_dam.cc
@@ -150,7 +150,7 @@ if (discArray[skill]->disc == discArray[skill]->assDisc) {
 
   // cut area effects in half
   if (IS_SET(discArray[skill]->targets, TAR_AREA)) 
-    fixed_amt /= 2.0;
+    fixed_amt *= 0.75;
 
   if (victim && reduce) {
     // physical skills typically have a hits() check in them which keeps

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,6 @@
+06-24-21 : Area Damage Upgrade
+           - Area damage spells increased by 50 percent accross the board
+
 03-12-21 : Travel updates
            - Portal should never close leaving a mount behind now
            - Cleric portals now have the same number of uses on each side


### PR DESCRIPTION
Area damage is halved. All these spells are pretty much useless as there aren't many fights that require fighting 3+ mobs at a time where this would be economical. Change area spells to be 75% damage, thus increasing their damage by 50%.

