### PR TITLE
Update SConstruct to fix clang compilation and add new sanitizers for gcc

### DIFF
--- a/code/SConstruct
+++ b/code/SConstruct
@@ -186,9 +186,10 @@ if flag_debug:
             # undefined behavior sanitizer, apple clang unsupported
             env.Append(CXXFLAGS='-fsanitize=undefined')
             env.Append(extra_libs=['ubsan']) 
-            # integer sanitizer, apple clang unsupported
-            env.Append(CXXFLAGS='-fsanitize=integer')
-        if (clang_version and clang_version >= (3, 9) or gcc_version >= (7, 0)):
+            if (clang_version):
+                # integer sanitizer, g++ and apple clang unsupported
+                env.Append(CXXFLAGS='-fsanitize=integer')
+        if (clang_version and clang_version >= (3, 9) or gcc_version and gcc_version >= (7, 0)):
             env.Append(CXXFLAGS='-fsanitize-address-use-after-scope') 
 
 env.Append(extra_libs=[opt_libs])

--- a/code/SConstruct
+++ b/code/SConstruct
@@ -72,7 +72,7 @@ need good crash debugging).
 """)
 
 
-flag_sanitize = get_bool_option('sanitize',      True)
+flag_sanitize = get_bool_option('sanitize',    True)
 flag_ccache =   get_bool_option('ccache',      False)
 flag_debug =    get_bool_option('debug',       True)
 flag_gprof =    get_bool_option('gprof',       False)
@@ -177,23 +177,26 @@ if flag_debug:
     env.Append(CXXFLAGS='-fno-optimize-sibling-calls')
     # keep the frame pointer for better debugging
     env.Append(CXXFLAGS='-fno-omit-frame-pointer')
-    # undefined behavior sanitizer, apple clang unsupported
-    if clang_version and clang_version >= (3, 9):
-        env.Append(CXXFLAGS='-fsanitize=undefined')
-        env.Append(extra_libs=['ubsan'])
-    # memory error sanitizer
-    if flag_sanitize:
+    if flag_sanitize:   
+        # memory error sanitizer
         env.Append(CXXFLAGS='-fsanitize=address')
-    # native clang doesn't need explicit asan lib
-    if (gcc_version or clang_version >= (3, 9)) and flag_sanitize:
-        env.Append(extra_libs=['asan'])
-    if (clang_version and clang_version >= (3, 9) or gcc_version >= (7, 0)) and flag_sanitize:
-        env.Append(CXXFLAGS='-fsanitize-address-use-after-scope')
-    # integer sanitizer, apple clang unsupported
-    if clang_version and clang_version >= (3, 9):
-        env.Append(CXXFLAGS='-fsanitize=integer')
+        # native clang doesn't need explicit asan lib
+        if (gcc_version or clang_version and clang_version >= (3, 9)):
+            env.Append(extra_libs=['asan'])
+            # undefined behavior sanitizer, apple clang unsupported
+            env.Append(CXXFLAGS='-fsanitize=undefined')
+            env.Append(extra_libs=['ubsan']) 
+            # integer sanitizer, apple clang unsupported
+            env.Append(CXXFLAGS='-fsanitize=integer')
+        if (clang_version and clang_version >= (3, 9) or gcc_version >= (7, 0)):
+            env.Append(CXXFLAGS='-fsanitize-address-use-after-scope') 
 
 env.Append(extra_libs=[opt_libs])
+
+# Fixes link errors when compiling with clang in Linux
+if not flag_harden and not flag_shared and clang_version:
+        # position-independent executable (shared mode already has -fPIC)
+        env.Append(CXXFLAGS='-fPIE', LINKFLAGS=['-fPIE', '-pie'])
 
 ## harden: security flags, slows runtime a bit
 if flag_harden:


### PR DESCRIPTION
Out of curiosity I started testing out compiling in Linux (Ubuntu 21.04/Hirsute) with clang instead of gcc, as I saw the SConstruct file was set up to allow either.

I had to make some changes to the file for compilation with clang to succeed. First, when sanitize=true, moving the code that appends the asan library up above where it appends the ubsan library as Address Sanitizer needs to be the first library in the list, and secondly changing the cxxflags/linkflags to remove a bunch of link errors that occur otherwise.

Clang seems to find more/different errors and warnings than gcc so it might be worth testing. It also appears that it was using extra sanitizers that gcc wasn't: an undefined behavior sanitizer and integer sanitizer. The benefit of using the undefined behavior sanitizer appears to be that it catches some runtime errors that wouldn't be apparent otherwise - these show up in the logs as the game is running. They can also lead to new and interesting seg faults!

Disclaimer: I tested these changes in Ubuntu running inside WSL 2. I haven't tested them with the Sneezy Docker image, but since that (I believe) uses Ubuntu as well it seems like the changes should be compatible.