### PR TITLE
Change max HP scaling calculation

### DIFF
--- a/code/code/misc/constants.cc
+++ b/code/code/misc/constants.cc
@@ -973,31 +973,38 @@ APP_type apply_types[MAX_APPLY_TYPES] =
 };
 
 
+/*
+   Scale HP per level of non tank classes so that they get
+   35 levels worth of HP spread out over 50. Warriors and
+   deikhans get a full 50 levels' worth of HP over 50 levels.
+   Replaces the previous method of HP scaling with defense +
+   advanced defense.
+*/
 const struct class_info classInfo[MAX_CLASSES] =
 {
   {true, MAGE_LEVEL_IND, CLASS_MAGE, "mage", 
-   DISC_MAGE, DISC_LORE, 0.43, 7.5, "M"},
+   DISC_MAGE, DISC_LORE, 0.43, 7.5 * 35.0 / 50.0, "M"},
 
   {true, CLERIC_LEVEL_IND, CLASS_CLERIC, "cleric",
-   DISC_CLERIC, DISC_THEOLOGY, 0.47, 8, "C"},
+   DISC_CLERIC, DISC_THEOLOGY, 0.47, 8.0 * 35.0 / 50.0, "C"},
 
   {true, WARRIOR_LEVEL_IND, CLASS_WARRIOR, "warrior",
    DISC_WARRIOR, DISC_NONE, 0.47, 8.5, "W"},
 
   {true, THIEF_LEVEL_IND, CLASS_THIEF, "thief",
-   DISC_THIEF, DISC_NONE, 0.41, 8, "T"},
+   DISC_THIEF, DISC_NONE, 0.41, 8.0 * 35.0 / 50.0, "T"},
 
   {true, SHAMAN_LEVEL_IND, CLASS_SHAMAN, "shaman",
-   DISC_SHAMAN, DISC_NONE, 0.39, 7.5, "S"},
+   DISC_SHAMAN, DISC_NONE, 0.39, 7.5 * 35.0 / 50.0, "S"},
 
   {true, DEIKHAN_LEVEL_IND, CLASS_DEIKHAN, "deikhan",
    DISC_DEIKHAN, DISC_THEOLOGY, 0.44, 7.5, "D"},
 
   {true, MONK_LEVEL_IND, CLASS_MONK, "monk",
-   DISC_MONK, DISC_NONE, 0.44, 7.5, "K"},
+   DISC_MONK, DISC_NONE, 0.44, 7.5 * 35.0 / 50.0, "K"},
 
   {false, RANGER_LEVEL_IND, CLASS_RANGER, "ranger",
-   DISC_RANGER, DISC_NONE, 0.46, 7, "R"},
+   DISC_RANGER, DISC_NONE, 0.46, 7.0 * 35.0 / 50.0, "R"},
 
   {false, COMMONER_LEVEL_IND, CLASS_COMMONER, "commoner",
    DISC_ADVENTURING, DISC_NONE, 0.40, 5, "O"}

--- a/code/code/misc/limits.cc
+++ b/code/code/misc/limits.cc
@@ -136,13 +136,11 @@ int affectHpBonus(const TPerson *tp){
 short int TPerson::hitLimit() const
 {
   if(isImmortal())
-    return points.maxHit;
-
-  float maxHpLevels = doesKnowSkill(SKILL_ADVANCED_DEFENSE) ? 50.0 : 35.0;
+    return points.maxHit;  
 
   float newmax=0;
   newmax += baseHp() + ageHpMod(this);
-  newmax += (classHpPerLevel(this) * (float)GetMaxLevel() * maxHpLevels) / (float)MAX_MORT;
+  newmax += classHpPerLevel(this) * (float)GetMaxLevel();
   newmax *= getConHpModifier();
   newmax += eqHpBonus(this);
   newmax += affectHpBonus(this);

--- a/code/code/misc/limits.cc
+++ b/code/code/misc/limits.cc
@@ -138,13 +138,11 @@ short int TPerson::hitLimit() const
   if(isImmortal())
     return points.maxHit;
 
-
-  float defense_amt=((35.0/100.0) * (float) getSkillValue(SKILL_DEFENSE)) +
-    ((15.0/100.0) * (float) getSkillValue(SKILL_ADVANCED_DEFENSE));
+  float maxHpLevels = doesKnowSkill(SKILL_ADVANCED_DEFENSE) ? 50.0 : 35.0;
 
   float newmax=0;
   newmax += baseHp() + ageHpMod(this);
-  newmax += (classHpPerLevel(this) * defense_amt);
+  newmax += (classHpPerLevel(this) * (float)GetMaxLevel() * maxHpLevels) / MAX_MORT;
   newmax *= getConHpModifier();
   newmax += eqHpBonus(this);
   newmax += affectHpBonus(this);

--- a/code/code/misc/limits.cc
+++ b/code/code/misc/limits.cc
@@ -142,7 +142,7 @@ short int TPerson::hitLimit() const
 
   float newmax=0;
   newmax += baseHp() + ageHpMod(this);
-  newmax += (classHpPerLevel(this) * (float)GetMaxLevel() * maxHpLevels) / MAX_MORT;
+  newmax += (classHpPerLevel(this) * (float)GetMaxLevel() * maxHpLevels) / (float)MAX_MORT;
   newmax *= getConHpModifier();
   newmax += eqHpBonus(this);
   newmax += affectHpBonus(this);


### PR DESCRIPTION
Per discussion in Discord, changes how max HP is determined. Instead of being based off max defense skill learnedness as before, it now scales based on character level.

Once a character learns the advanced defense skill (even if it's only at 1%) their HP will be able to scale a further 15 levels' worth.