### PR TITLE
Fix missing param causing oedit error

### DIFF
--- a/code/code/misc/create_objs.cc
+++ b/code/code/misc/create_objs.cc
@@ -323,7 +323,7 @@ static void ObjSave(TBeing *ch, TObj *o, int vnum)
 	return;
       }
     } else {
-      if(!db.query("insert into objextra (name, description, owner, vnum) values ('%s', '', '%s')", exdes->keyword.c_str(), ch->name.c_str(), vnum)){
+      if(!db.query("insert into objextra (name, description, owner, vnum) values ('%s', '', '%s', %i)", exdes->keyword.c_str(), ch->name.c_str(), vnum)){
 	ch->sendTo("Database error!  Talk to a coder ASAP.\n\r");
 	return;
       }


### PR DESCRIPTION
Fixes error reported by Vasco when trying to save item without a description in oedit. 

Test procedure:

- Ran game using unmodified code
- `load obj moth-pendant`
- `oed save pendant 15488`
  - Received the same error reported by Vasco: `Database error!  Talk to a coder ASAP.`
- Made changes contained in this PR
- Recompiled and ran game
- Input same commands as before, and this time received: 
```Saving.```
```Unable to save object.  Make sure that an object doesn't already exist in that slot.``` 

Assuming that second message is expected when saving an object to an already existing slot, issue appears to be resolved.