### PR TITLE
Refactor the doFlee function to improve logic/remove redundancy

### DIFF
--- a/code/code/misc/monster.cc
+++ b/code/code/misc/monster.cc
@@ -514,12 +514,14 @@ int TMonster::getMobDamage() const
 }
 
 int TMonster::lookForEngaged() {
-  if (isPc()) return false;
+  if (isPc())
+    return false;
 
-  if (attackers > 0) return false;
+  if (attackers > 0)
+    return false;
 
   auto isEngagedOpponent = [this](TThing *thingInRoom) {
-    auto thingAsTBeing = dynamic_cast<TBeing *>(thingInRoom);
+    TBeing *thingAsTBeing = dynamic_cast<TBeing *>(thingInRoom);
     return thingAsTBeing && thingAsTBeing->fight() == this;
   };
 
@@ -529,15 +531,15 @@ int TMonster::lookForEngaged() {
   TBeing *newOpponent = found != roomp->stuff.end() ? dynamic_cast<TBeing *>(*found) : nullptr;
 
   if (newOpponent) {
-    auto rc = takeFirstHit(*newOpponent);
+    int rc = takeFirstHit(*newOpponent);
 
     if (IS_SET_DELETE(rc, DELETE_VICT)) {
       delete newOpponent;
       newOpponent = nullptr;
     }
 
-    if (IS_SET_DELETE(rc, DELETE_THIS)) 
-      return DELETE_THIS;   
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
 
     return true;
   }

--- a/code/code/misc/monster.cc
+++ b/code/code/misc/monster.cc
@@ -523,9 +523,10 @@ int TMonster::lookForEngaged() {
     return thingAsTBeing && thingAsTBeing->fight() == this;
   };
 
-  auto stuff = roomp->stuff;
-  auto found = std::find_if(stuff.begin(), stuff.end(), isEngagedOpponent);
-  auto newOpponent = found != stuff.end() ? dynamic_cast<TBeing *>(*found) : nullptr;
+  StuffList::iterator found =
+      std::find_if(roomp->stuff.begin(), roomp->stuff.end(), isEngagedOpponent);
+
+  TBeing *newOpponent = found != roomp->stuff.end() ? dynamic_cast<TBeing *>(*found) : nullptr;
 
   if (newOpponent) {
     auto rc = takeFirstHit(*newOpponent);

--- a/code/code/misc/monster.cc
+++ b/code/code/misc/monster.cc
@@ -521,12 +521,11 @@ int TMonster::lookForEngaged() {
     return false;
 
   auto isEngagedOpponent = [this](TThing *thingInRoom) {
-    TBeing *thingAsTBeing = dynamic_cast<TBeing *>(thingInRoom);
+    auto *thingAsTBeing = dynamic_cast<TBeing *>(thingInRoom);
     return thingAsTBeing && thingAsTBeing->fight() == this;
   };
 
-  StuffList::iterator found =
-      std::find_if(roomp->stuff.begin(), roomp->stuff.end(), isEngagedOpponent);
+  auto found = std::find_if(roomp->stuff.begin(), roomp->stuff.end(), isEngagedOpponent);
 
   TBeing *newOpponent = found != roomp->stuff.end() ? dynamic_cast<TBeing *>(*found) : nullptr;
 

--- a/code/code/misc/monster.h
+++ b/code/code/misc/monster.h
@@ -542,7 +542,7 @@ class TMonster : public TBeing {
     double getRealLevel() const;
     int lookForHorse();
     void balanceMakeNPCLikePC();
-    int lookForEngaged(const TBeing *);
+    int lookForEngaged();
     virtual sstring getStealLootNames() const;
     virtual bool getStolenFrom() const { return stolenFrom; }
     virtual void setStolenFrom(bool v) { stolenFrom = v; }

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -766,331 +766,282 @@ static bool canFleeThisWay(TBeing *ch, dirTypeT dir)
   return true;
 }
 
-static void fleeFail(const TBeing *ch)
-{
-#if 0
-  // can fail for lack of moves or too tall for door...
-  ch->sendTo("You try to flee but are too exhausted.\n\r");
-  act("$n tries to flee, but is too exhausted!", TRUE, ch, 0, 0, TO_ROOM);
-#else
-  ch->sendTo("You try to flee but fail.\n\r");
-  act("$n tries to flee!", TRUE, ch, 0, 0, TO_ROOM);
-#endif
-}
-
 // returns DELETE_THIS
-int TBeing::doFlee(const char *arg)
-{
-  int i, iDie, percent;
-  bool panic = FALSE;
-  int rc = FALSE;
-  TRoom *rp = roomp;
-  TThing *t;
-  TBeing *vict;
-
-  spellNumT skill = getSkillNum(SKILL_RETREAT);
-  spellNumT skill2 = getSkillNum(SKILL_RIDE);
-
+int TBeing::doFlee(const char *arg) {
   // automatic flee attempts should fail if lagging
   // remember that wait comes in as 1 naturaly i think
   if (getWait() > 1) {
-    sendTo("You can't flee while orienting yourself.\n\r");
-    return TRUE;
+    sendTo("You're too disoriented to flee.\n\r");
+    return true;
   }
-  // This is used to prevent 'insta-fleeing' on mobiles
-  if (isAffected(AFF_SHOCKED) && !isPc()) {
-    sendTo("You are still recovering from something!\n\r");
-    return FALSE;
-  } if (!isPc()) {
-    affectedData tAff;
 
-    tAff.type     = AFFECT_COMBAT;
-    tAff.duration = 1; // Short and sweet
+  // This is used to prevent 'insta-fleeing' on mobiles
+  if (!isPc()) {
+    if (isAffected(AFF_SHOCKED)) {
+      sendTo("You are still recovering from something!\n\r");
+      return false;
+    }
+    affectedData tAff;
+    tAff.type = AFFECT_COMBAT;
+    tAff.duration = 1;
     tAff.modifier = AFF_SHOCKED;
     tAff.location = APPLY_NONE;
-
     affectTo(&tAff, -1);
   }
 
   if (isAffected(AFF_PARALYSIS)) {
     sendTo("You can't flee while paralyzed.\n\r");
-    return FALSE;
+    return false;
   }
+
   if (isAffected(AFF_STUNNED)) {
     sendTo("You can't flee while stunned.\n\r");
-    return FALSE;
+    return false;
   }
-  if (getPosition() <= POSITION_STUNNED)
-    return FALSE;
+
+  if (getPosition() <= POSITION_STUNNED) return false;
 
   if (isCombatMode(ATTACK_BERSERK)) {
-    sendTo("You are berserking!  There is no way to flee!\n\r");
-    return FALSE;
+    sendTo("Flee? FLEE!? Your rage is too overwhelming!!\n\r");
+    return false;
   }
-  if (bothLegsHurt() && !isFlying()) {
-    sendTo("It is futile to try to flee without use of your legs!\n\r");
-    act("$n tries to flee, but $s legs just won't move!", TRUE, this, NULL, NULL, TO_ROOM);
-    return FALSE;
+
+  if (!isFlying()) {
+    if (bothLegsHurt()) {
+      sendTo("You try to flee, but can't due to the condition of your legs!\n\r");
+      act("$n tries to flee, but $s legs just won't move!", true, this, nullptr, nullptr, TO_ROOM);
+      return false;
+    }
+    if ((eitherLegHurt() || (!isHumanoid() && eitherArmHurt())) && ::number(0, 2)) {
+      sendTo("You try to flee, but can't due to the condition of your legs!\n\r");
+      act("$n tries to flee, but $s leg just won't move!", true, this, nullptr, nullptr, TO_ROOM);
+      return false;
+    }
   }
-  if (eitherLegHurt() && ::number(0,2) && !isFlying()) {
-    sendTo("Your injured leg makes the attempt fail!\n\r");
-    act("$n tries to flee, but $s legs just won't move!", 
-         TRUE, this, NULL, NULL, TO_ROOM);
-    return FALSE;
-  }
-  if (!isHumanoid() && eitherArmHurt() && ::number(0,2) && !isFlying()) {
-    // non-humanoid arms are considered legs
-    sendTo("Your injured leg makes the attempt fail!\n\r");
-    act("$n tries to flee, but $s legs just won't move!", 
-         TRUE, this, NULL, NULL, TO_ROOM);
-    return FALSE;
-  }
+
   if (isAffected(AFF_CHARM) && master && sameRoom(*master)) {
     if (!::number(0, 5))
-      act("$n bursts into tears.", TRUE, this, 0, 0, TO_ROOM);
-    act("You burst into tears at the thought of leaving $N.", 
-            FALSE, this, 0, master, TO_CHAR);
-    return FALSE;
+      act("$n bursts into tears at the thought of fleeing without $N!", true, this, nullptr, master,
+          TO_ROOM);
+    act("You can't bear the thought of leaving $N's side!", false, this, nullptr, master, TO_CHAR);
+    return false;
   }
+
   if (roomp->isRoomFlag(ROOM_NO_FLEE)) {
-    act("A strange power prevents $n from escaping.",
-            FALSE, this, NULL, NULL, TO_ROOM);
-    act("A strange power prevents you from escaping.",
-            FALSE, this, NULL, NULL, TO_CHAR, ANSI_RED);
-    return FALSE;
+    act("$n tries to flee but a strange power prevents $m from escaping.", false, this, nullptr,
+        nullptr, TO_ROOM);
+    act("A strange power prevents you from escaping.", false, this, nullptr, nullptr, TO_CHAR,
+        ANSI_RED);
+    return false;
   }
-  if (riding) {
-    // Let's make retreat skill have some chance of keeping you on the mount - Brutius 07/26/1999
-    if (!(doesKnowSkill(skill) && doesKnowSkill(skill2)) || 
-	!(bSuccess(skill) && bSuccess(skill2))) { 
+
+  /* 
+  Do skill checks now and use results throughout so bSuccess only gets 
+  called once per flee attempt. 
+  */
+  auto retreatSkill = getSkillNum(SKILL_RETREAT);  
+  auto doesKnowRetreat = doesKnowSkill(retreatSkill);
+  auto wasRetreatSuccessful = doesKnowRetreat && bSuccess(retreatSkill);  
+
+  auto panic = false;
+  auto rc = 0;
+  auto riderAsTBeing = dynamic_cast<TBeing *>(rider);
+
+  if (riding) {   
+    // Allow successful retreat and ride checks to avoid falling off mount
+    if (!doesKnowSkill(SKILL_RIDE) || !bSuccess(SKILL_RIDE) || !wasRetreatSuccessful) {
       sendTo("Your panic causes you to fall.\n\r");
       rc = fallOffMount(riding, POSITION_SITTING);
-      panic = TRUE;
-      if (IS_SET_DELETE(rc, DELETE_THIS)) 
-        return DELETE_THIS;
+      if (IS_SET_DELETE(rc, DELETE_THIS)) return DELETE_THIS;
+      panic = true;
     }
   } else if (getPosition() <= POSITION_SITTING) {
     addToMove(-10);
-    act("$n scrambles madly to $s feet!", TRUE, this, 0, 0, TO_ROOM);
-    act("Panic-stricken, you scramble to your feet.", TRUE, this, 0, 0, TO_CHAR);
+    // If retreat succeeded, simply being on the ground when fleeing doesn't
+    // result in panic. And you get a different message.
+    if (wasRetreatSuccessful) {
+      act("$n rolls aside and regains $s footing!", true, this, nullptr, nullptr, TO_ROOM);
+      act("You quickly roll aside and regain your footing.", true, this, nullptr, nullptr, TO_CHAR);
+    } else {
+      act("$n scrambles madly to $s feet!", true, this, nullptr, nullptr, TO_ROOM);
+      act("Panic-stricken, you scramble to your feet.", true, this, nullptr, nullptr, TO_CHAR);
+    }
+
     doStand();
-    addToWait(combatRound(1));
 
-    panic = TRUE;
-  } else if ((t = rider)) {
-    t->sendTo("Your mount panics and attempts to flee.\n\r");
-    rc = t->fallOffMount(this, POSITION_SITTING);
-    panic = TRUE;
+    // If retreat didn't succeed or char doesn't have it, add some lag
+    // and panic.
+    if (!wasRetreatSuccessful) {
+      addToWait(combatRound(1));
+      panic = true;
+    }
+    // If <this> is a mount being ridden
+  } else if (riderAsTBeing) {    
+    act("Your $O panics and attempts to flee!", true, riderAsTBeing, nullptr, this, TO_CHAR);
+
+    // Allow deikhans to pass checks and prevent getting bucked
+    if (
+      riderAsTBeing->doesKnowSkill(SKILL_CHIVALRY) &&
+      riderAsTBeing->bSuccess(SKILL_CHIVALRY) && 
+      riderAsTBeing->doesKnowSkill(SKILL_RIDE) &&
+      riderAsTBeing->bSuccess(SKILL_RIDE)) {
+        act("You manage to calm $M down before $E dismounts you.", true, riderAsTBeing, nullptr, this, TO_CHAR);
+        return true;
+      }
+    rc = riderAsTBeing->fallOffMount(this, POSITION_SITTING);
     if (IS_SET_DELETE(rc, DELETE_THIS)) {
-      TBeing *tbt = dynamic_cast<TBeing *>(t);
-      if (tbt)
-        tbt->reformGroup();
-      delete t;
-      t = NULL;
+      riderAsTBeing->reformGroup();
+      delete riderAsTBeing;
     }
+    // Don't want reference to rider anymore if they fell off
+    riderAsTBeing = nullptr;
+    panic = true;
   }
-   
-  
-  dirTypeT chosenDir = getDirFromChar(arg);
 
-  soundNumT snd = pickRandSound(SOUND_FLEE_01, SOUND_FLEE_03);
-  playsound(snd, SOUND_TYPE_COMBAT);
+  playsound(pickRandSound(SOUND_FLEE_01, SOUND_FLEE_03), SOUND_TYPE_COMBAT);
 
-  if (!(vict = fight())) {
-    for (i = 0; i < 20; i++) {
-      dirTypeT attempt = dirTypeT(::number(MIN_DIR, MAX_DIR-1));        // Select a random direction 
-      
-      // not fighting, so encourage flight to be in dir PC selected
-      if (chosenDir != DIR_NONE && !panic) {
-	attempt = chosenDir;
-      }
-      if (canFleeThisWay(this, attempt)) {
-        act("$n panics, and attempts to flee.", TRUE, this, 0, 0, TO_ROOM);
-        TBeing *tbt = dynamic_cast<TBeing *>(rider);
-        if (tbt) {
-          act("You turn tail and attempt to run away.", 
-	      TRUE, this, 0, 0, TO_CHAR);
-          loseSneak();
-          iDie = tbt->moveOne(attempt);
-          if (IS_SET_DELETE(iDie, DELETE_THIS)) {
-            tbt->reformGroup();
-            delete tbt;
-            tbt = NULL;
-            return FALSE;
-          }
-          if (iDie == TRUE) {
-            sendTo("You fled head over heels.\n\r");
-            return TRUE;
-          } else {
-            fleeFail(this);
-            return TRUE;
-          }
-        } else {
-          act("You turn tail and attempt to run away.", 
-	      TRUE, this, 0, 0, TO_CHAR);
-          loseSneak();
-          iDie = moveOne(attempt);
-          if (IS_SET_DELETE(iDie, DELETE_THIS))
-            return DELETE_THIS;
-	  
-          if (iDie == TRUE) {
-            sendTo(format("You nearly hurt yourself as you fled madly %swards.\n\r") % dirs[attempt]);
-            REMOVE_BIT(specials.affectedBy, AFF_ENGAGER);
-	    
-            return TRUE;
-          } else {
-            fleeFail(this);
-            return TRUE;
-          }
-        }
-      }
-    }
-    // No exits was found 
+  // Create vector containing all currently valid movement directions
+  std::vector<dirTypeT> validDirections;
+  for (auto direction = MIN_DIR; direction < MAX_DIR; direction++) {
+    if (canFleeThisWay(this, direction)) validDirections.push_back(direction);
+  }
+
+  // If there are no valid flee directions, simply return with the panic
+  // message.
+  if (validDirections.size() == 0) {
     sendTo("PANIC! You couldn't escape!\n\r");
-    return TRUE;
+
+    // Handle troglodyte racial perk
+    if (!::number(0, 1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
+      act("In your panic you release some musk scent to cover your tracks.", false, this, nullptr,
+          nullptr, TO_CHAR);
+      act("$n releases some musk into the room!", false, this, nullptr, nullptr, TO_ROOM);
+      dropGas(::number(1, 3), GAS_MUSK);
+      setCond(FULL, getCond(FULL) - 5);
+    }
+
+    return true;
   }
-  for (i = 0; i < 20; i++) {
-    dirTypeT attempt = dirTypeT(::number(MIN_DIR, MAX_DIR-1));        // Select a random direction 
-    
-    // fighting, so the chance of success depends on retreat skill (with at least 5% chance to fail)
-    if (chosenDir != DIR_NONE && !panic && (::number(0,99) < (45+getSkillValue(skill)/2)))
-      attempt = chosenDir;
-    
-    if (canFleeThisWay(this, attempt)) {
-      if (panic || !doesKnowSkill(skill) || 
-          !bSuccess(skill)) {
-        act("$n panics, and attempts to flee.", TRUE, this, 0, 0, TO_ROOM);
-        panic = TRUE;
-      } else {
-        act("$n skillfully retreats from battle", TRUE, this, 0, 0, TO_ROOM);
-        panic = FALSE;
-      }
+
+  // Randomly select a valid direction for use later
+  auto randomDir = validDirections[::number(0, validDirections.size() - 1)];
+  auto chosenDir = getDirFromChar(arg);
+
+  // Save reference to who <this> was fighting for later
+  auto enemy = fight();
+
+  // Save reference to room from which <this> is attempting to flee
+  auto previousRoom = roomp;
+
+  /*
+    Determine which direction to actually use. If panicked, no flee direction
+    chosen, (fighting + knows retreat + retreat failed), or (fighting + doesn't know retreat +
+    fails 50% chance) then flee in random direction. Otherwise flee in chosen direction.
+  */
+  auto dirToUse = panic || chosenDir == DIR_NONE ||
+                          (enemy && ((doesKnowRetreat && !wasRetreatSuccessful) ||
+                                     (!doesKnowRetreat && ::number(0, 1))))
+                      ? randomDir
+                      : chosenDir;
+
+  // These messages don't make sense if not fighting
+  if (enemy) {
+    if (wasRetreatSuccessful && !panic) {
+      act("$n is looking for an opening to escape!", true, this, nullptr, nullptr, TO_ROOM);
+      act("You look for an opening to escape from the fight.", true, this, nullptr, nullptr,
+          TO_CHAR);
+    } else {
+      act("$n panics and attempts to flee!", true, this, nullptr, nullptr, TO_ROOM);
+      act("You turn tail and attempt to run away.", true, this, nullptr, nullptr, TO_CHAR);
       loseSneak();
-      TBeing *tbt = dynamic_cast<TBeing *>(rider);
-      if (tbt) {
-        iDie = tbt->moveOne(attempt);
-        if (IS_SET_DELETE(iDie, DELETE_THIS)) {
-          tbt->reformGroup();
-          delete tbt;
-          tbt = NULL;
-          return FALSE;
-        }
-      } else {
-        iDie = moveOne(attempt);
-        if (IS_SET_DELETE(iDie, DELETE_THIS))
-          return DELETE_THIS;
-      }
-      if (iDie == 1) {
-        double lose;
-        if (GetMaxLevel() > 3) {
-          // IDEALLY:
-          // get agg'd by a trainer and flee = lose minimal
-          // attack super high lev and flee for xp = lose a lot
-          // flee from lower level = lose moderate
-          if (vict->GetMaxLevel() > GetMaxLevel()) {
-            if (isAffected(AFF_AGGRESSOR)) {
-              // flee from higher level that I attacked...
-              lose = 3 * mob_exp(GetMaxLevel());
-            } else {
-              // flee from higher level that attacked me...
-              lose = mob_exp(GetMaxLevel());
-              lose /= 4.0;
-            }
-          } else {
-            // flee from lower level...
-            // We'll use vict's XP so you can't lose more than mob was worth.
-            lose = mob_exp(vict->GetMaxLevel());
-          }
-           // Tone this way down, we're making a lot of changes and
-          // this is drawing complaints - Bat 12/98
-          lose /= 1000;
-        } else
-          lose = 0;
+    }
+  }
 
-        if (lose < 0)
-          lose = 1;
+  // If <this> is a mount and still has a rider, have its rider execute the move
+  auto moveResult = riderAsTBeing ? riderAsTBeing->moveOne(dirToUse) : moveOne(dirToUse);
 
-        // a crash was here somehow, i rearranged a bit but net was
-        // dynamic_cast was NULL, but !isPc occurred (tmons = 0x0 in addFeared)
-        // bizarre!! bat 09-19-98
-        TMonster *tmons = dynamic_cast<TMonster *>(this);
-        if (!isPc() && tmons)
-          tmons->addFeared(vict);
+  if (IS_SET_DELETE(moveResult, DELETE_THIS)) {
+    if (riderAsTBeing) {
+      riderAsTBeing->reformGroup();
+      delete riderAsTBeing;
+      riderAsTBeing = nullptr;
+      return false;
+    } else
+      return DELETE_THIS;
+  }
 
-        if (!(vict->isPc())) {
-          // I'm fleeing, make my opponent hunt me
-          tmons = dynamic_cast<TMonster *>(vict);
-          percent = (int) (100 *(double) tmons->getHit() /
-           (double) tmons->hitLimit());
-          if (::number(1, 101) < percent) {
-            if (tmons->Hates(this, NULL) ||
-                isOppositeFaction(tmons)) {
-              tmons->setHunting(this);
-            }
-          }
-        }
-        if (isPc() && panic) {
-          if (hasClass(CLASS_MONK) || hasClass(CLASS_WARRIOR) ||
-              hasClass(CLASS_DEIKHAN) || hasClass(CLASS_RANGER))
-            addToExp(-min(lose, getExp()));
-        }
-        if (panic) {
-          sendTo(format("Panic-stricken, you flee %s.\n\r") % dirs[attempt]);
-          if (!::number(0,1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
-            act("In your panic you release some musk scent to cover your tracks.", FALSE, this, 0, NULL, TO_CHAR);
-            act("$n releases some musk into the room!", FALSE, this, 0, NULL, TO_ROOM);
-            dropGas(::number(1,3), GAS_MUSK);
-            setCond(FULL, getCond(FULL)-5);
-          }
-        } else
-          sendTo(format("You retreat skillfully %s.\n\r") % dirs[attempt]);
+  if (moveResult == false) {
+    sendTo("Something prevents your escape!\n\r");
+    act("Something prevents $s escape!", true, this, nullptr, nullptr, TO_ROOM);
+    return true;
+  }
 
-        // do this before lookForEngaged to get attackers check to work OK
-        if (fight())
-          stopFighting();
+  if (panic) {
+    sendTo(format("Panic-stricken, you flee %s.\n\r") % dirs[dirToUse]);
 
-        for(StuffIter it=rp->stuff.begin();it!=rp->stuff.end();){
-          t=*(it++);
-          TBeing *tbt = dynamic_cast<TBeing *>(t);
-          if (!tbt)
-            continue;
-          if (tbt->fight() == this) {
-            tbt->stopFighting();
+    // Handle troglodyte racial perk
+    if (!::number(0, 1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
+      act("In your panic you release some musk scent to cover your tracks.", false, this, 0,
+          nullptr, TO_CHAR);
+      act("$n releases some musk into the room!", false, this, 0, nullptr, TO_ROOM);
+      dropGas(::number(1, 3), GAS_MUSK);
+      setCond(FULL, getCond(FULL) - 5);
+    }
+  } else if (wasRetreatSuccessful)
+    sendTo(format("You skillfully retreat %s.\n\r") % dirs[dirToUse]);
+  else
+    sendTo(format("You nearly hurt yourself as you fled madly %swards.\n\r") % dirs[dirToUse]);
 
-            TMonster *tmon = dynamic_cast<TMonster *>(tbt);
-            if (tmon) {
-              rc = tmon->lookForEngaged(this);
-              if (IS_SET_DELETE(rc, DELETE_THIS)) {
-                delete tmon;
-                tmon = NULL;
-              }
-              continue;
-            }
-          }
-        }
-        if (cantHit > 0)
-          cantHit = 0;
+  // If <this> wasn't fighting when attempting the flee, just return here
+  if (!enemy) return true;
 
-        REMOVE_BIT(specials.affectedBy, AFF_ENGAGER);
+  // Ensure <this> no longer fighting after successful flee
+  REMOVE_BIT(specials.affectedBy, AFF_ENGAGER);
+  if (fight()) stopFighting();
+  if (cantHit > 0) cantHit = 0;
 
-        return TRUE;
-      } else {
-        fleeFail(this);
-        return TRUE;
+  // Make mobs fear enemy who forced them to flee
+  auto thisAsTMonster = dynamic_cast<TMonster *>(this);
+  // Check IsPc() in case of disguised/polymorphed/otherwise transformed PC
+  if (!isPc() && thisAsTMonster) thisAsTMonster->addFeared(enemy);
+
+  // Determine if enemy begins hunting <this>
+  auto enemyAsTMonster = dynamic_cast<TMonster *>(enemy);
+  if (!(enemy->isPc()) && enemyAsTMonster) {
+   
+    auto percent =
+        (int)(100 * (double)enemyAsTMonster->getHit() / (double)enemyAsTMonster->hitLimit());
+
+    if (::number(1, 100) < percent) {
+      if (enemyAsTMonster->Hates(this, nullptr) || isOppositeFaction(enemyAsTMonster)) {
+        enemyAsTMonster->setHunting(this);
       }
     }
-  }                                // for 
-  sendTo("PANIC! You couldn't escape!\n\r");
-  if (!::number(0,1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
-    act("In your panic you release some musk scent to cover your tracks.", FALSE, this, 0, NULL, TO_CHAR);
-    act("$n releases some musk into the room!", FALSE, this, 0, NULL, TO_ROOM);
-    dropGas(::number(1,3), GAS_MUSK);
-    setCond(FULL, getCond(FULL)-5);
   }
 
-  return FALSE;
-}
+  // Make enemy attack anything else still in the room fighting them
+  for (auto thing : previousRoom->stuff) {
+    auto thingAsTBeing = dynamic_cast<TBeing *>(thing);
+    if (!thingAsTBeing) continue;
 
+    // If true, thing == enemy so stop fight on their end too
+    if (thingAsTBeing->fight() == this) {
+      thingAsTBeing->stopFighting();
+
+      auto thingAsTMonster = dynamic_cast<TMonster *>(thingAsTBeing);
+      if (!thingAsTMonster) continue;
+
+      auto rc = thingAsTMonster->lookForEngaged(this);
+      if (IS_SET_DELETE(rc, DELETE_THIS)) {
+        delete thingAsTMonster;
+        thingAsTMonster = nullptr;
+      }
+      if (rc == true) break;
+    }
+  }
+
+  return true; 
+}
 
 // return DELETE_THIS if this should die
 int TBeing::doAssist(const char *argument, TBeing *vict, bool flags)

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -846,7 +846,7 @@ int TBeing::doFlee(const char *arg) {
 
   bool panic = false;
   int rc = 0;
-  TBeing *riderAsTBeing = dynamic_cast<TBeing *>(rider);
+  auto *riderAsTBeing = dynamic_cast<TBeing *>(rider);
 
   if (riding) {
     // Allow successful retreat or ride checks to avoid falling off mount. Deikhans

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -1019,7 +1019,7 @@ int TBeing::doFlee(const char *arg) {
     return true;
 
   // Ensure <this> no longer fighting after successful flee
-  REMOVE_BIT(specials.affectedBy, AFF_ENGAGER);
+  // Removing AFF_ENGAGER is handled within stopFighting()
   if (fight())
     stopFighting();
   if (cantHit > 0)

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -849,9 +849,14 @@ int TBeing::doFlee(const char *arg) {
   TBeing *riderAsTBeing = dynamic_cast<TBeing *>(rider);
 
   if (riding) {
-    // Allow successful retreat and ride checks to avoid falling off mount
-    if (!doesKnowSkill(SKILL_RIDE) || !bSuccess(SKILL_RIDE) || !wasRetreatSuccessful) {
-      sendTo("Your panic causes you to fall.\n\r");
+    // Allow successful retreat or ride checks to avoid falling off mount. Deikhans
+    // get extra attempt to remain mounted via chivalry.
+    if ((doesKnowSkill(SKILL_RIDE) && !bSuccess(SKILL_RIDE)) ||
+        (doesKnowSkill(SKILL_CHIVALRY) && !bSuccess(SKILL_CHIVALRY)) || !wasRetreatSuccessful) {
+      act("You urge your $O to flee, causing it to panic and throw you off!", true, this,
+          nullptr, riding, TO_CHAR);
+      act("$n urges $s mount to flee, causing it to panic and throw $n off!", true, this,
+          nullptr, riding, TO_ROOM);
       rc = fallOffMount(riding, POSITION_SITTING);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
@@ -880,12 +885,15 @@ int TBeing::doFlee(const char *arg) {
     // If <this> is a mount being ridden
   } else if (riderAsTBeing) {
     act("Your $O panics and attempts to flee!", true, riderAsTBeing, nullptr, this, TO_CHAR);
+    act("$n's $O panics and attempts to flee!", true, riderAsTBeing, nullptr, this, TO_ROOM);
 
     // Allow deikhans to pass checks and prevent getting bucked
     if (riderAsTBeing->doesKnowSkill(SKILL_CHIVALRY) && riderAsTBeing->bSuccess(SKILL_CHIVALRY) &&
         riderAsTBeing->doesKnowSkill(SKILL_RIDE) && riderAsTBeing->bSuccess(SKILL_RIDE)) {
       act("You manage to calm $M down before $E dismounts you.", true, riderAsTBeing, nullptr, this,
           TO_CHAR);
+      act("With soothing words $n manages to calm $N and remain mounted.", true,
+          riderAsTBeing, nullptr, this, TO_ROOM);
       return true;
     }
     rc = riderAsTBeing->fallOffMount(this, POSITION_SITTING);
@@ -923,24 +931,12 @@ int TBeing::doFlee(const char *arg) {
       validDirections.push_back(direction);
   }
 
-  // Lambda for handling troglodyte racial, to avoid repetition
-  auto handleTrogRacial = [this]() {
-    if (!::number(0, 1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
-      act("In your panic you release some musk scent to cover your tracks.", false, this, nullptr,
-          nullptr, TO_CHAR);
-      act("$n releases some musk into the room!", false, this, nullptr, nullptr, TO_ROOM);
-      dropGas(::number(1, 3), GAS_MUSK);
-      setCond(FULL, getCond(FULL) - 5);
-    }
-  };
-
   /*
     If there are no valid flee directions (doors closed, etc), simply return with the panic
     message.
   */
   if (validDirections.size() == 0 && chosenDir == DIR_NONE) {
     sendTo("PANIC! You couldn't escape!\n\r");
-    handleTrogRacial();
     return true;
   }
 
@@ -977,6 +973,14 @@ int TBeing::doFlee(const char *arg) {
       act("$n panics and attempts to flee!", true, this, nullptr, nullptr, TO_ROOM);
       act("You turn tail and attempt to run away.", true, this, nullptr, nullptr, TO_CHAR);
       loseSneak();
+
+      if (panic && !::number(0, 1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
+        act("Your fear causes you to release some musk scent to cover your tracks.", false, this, nullptr,
+            nullptr, TO_CHAR);
+        act("$n releases some musk into the room!", false, this, nullptr, nullptr, TO_ROOM);
+        dropGas(::number(1, 3), GAS_MUSK);
+        setCond(FULL, getCond(FULL) - 5);
+      }
     }
   }
 
@@ -1003,7 +1007,6 @@ int TBeing::doFlee(const char *arg) {
 
   if (panic) {
     sendTo(format("Panic-stricken, you flee %s.\n\r") % dirs[dirToUse]);
-    handleTrogRacial();
   } else if (wasRetreatSuccessful)
     sendTo(format("You skillfully retreat %s.\n\r") % dirs[dirToUse]);
   else

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -920,14 +920,7 @@ int TBeing::doFlee(const char *arg) {
     if (canFleeThisWay(this, direction)) validDirections.push_back(direction);
   }
 
-  /*
-    If there are no valid flee directions (doors closed, etc), simply return with the panic
-    message.
-  */
-  if (validDirections.size() == 0 && chosenDir == DIR_NONE) {
-    sendTo("PANIC! You couldn't escape!\n\r");
-
-    // Handle troglodyte racial perk
+  auto handleTrogRacial = [this]() {
     if (!::number(0, 1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
       act("In your panic you release some musk scent to cover your tracks.", false, this, nullptr,
           nullptr, TO_CHAR);
@@ -935,7 +928,15 @@ int TBeing::doFlee(const char *arg) {
       dropGas(::number(1, 3), GAS_MUSK);
       setCond(FULL, getCond(FULL) - 5);
     }
+  };
 
+  /*
+    If there are no valid flee directions (doors closed, etc), simply return with the panic
+    message.
+  */
+  if (validDirections.size() == 0 && chosenDir == DIR_NONE) {
+    sendTo("PANIC! You couldn't escape!\n\r");
+    handleTrogRacial();
     return true;
   }
 
@@ -999,15 +1000,7 @@ int TBeing::doFlee(const char *arg) {
 
   if (panic) {
     sendTo(format("Panic-stricken, you flee %s.\n\r") % dirs[dirToUse]);
-
-    // Handle troglodyte racial perk
-    if (!::number(0, 1) && getMyRace()->hasTalent(TALENT_MUSK) && getCond(FULL) > 5) {
-      act("In your panic you release some musk scent to cover your tracks.", false, this, 0,
-          nullptr, TO_CHAR);
-      act("$n releases some musk into the room!", false, this, 0, nullptr, TO_ROOM);
-      dropGas(::number(1, 3), GAS_MUSK);
-      setCond(FULL, getCond(FULL) - 5);
-    }
+    handleTrogRacial();
   } else if (wasRetreatSuccessful)
     sendTo(format("You skillfully retreat %s.\n\r") % dirs[dirToUse]);
   else

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -836,66 +836,74 @@ int TBeing::doFlee(const char *arg) {
     return false;
   }
 
-  /*
-  Do skill checks now and use results throughout so bSuccess only gets
-  called once per flee attempt.
-  */
-  spellNumT retreatSkill = getSkillNum(SKILL_RETREAT);
-  bool doesKnowRetreat = doesKnowSkill(retreatSkill);
-  bool wasRetreatSuccessful = doesKnowRetreat && bSuccess(retreatSkill);
+  
+  // Do skill checks now and use results throughout so bSuccess only gets
+  // called once per flee attempt. 
+  bool wasRetreatSuccessful = bSuccess(getSkillNum(SKILL_RETREAT));
 
   bool panic = false;
   int rc = 0;
   auto *riderAsTBeing = dynamic_cast<TBeing *>(rider);
 
+  // Could be either riding an actual mount, or be on a chair/bed of some sort.
+  // Handle both possibilities. Failures here result in flee fail and return from function call.
   if (riding) {
-    // Allow successful retreat or ride checks to avoid falling off mount. Deikhans
-    // get extra attempt to remain mounted via chivalry.
-    if ((doesKnowSkill(SKILL_RIDE) && !bSuccess(SKILL_RIDE)) ||
-        (doesKnowSkill(SKILL_CHIVALRY) && !bSuccess(SKILL_CHIVALRY)) || !wasRetreatSuccessful) {
-      act("You urge your $O to flee, causing it to panic and throw you off!", true, this,
-          nullptr, riding, TO_CHAR);
-      act("$n urges $s mount to flee, causing it to panic and throw $n off!", true, this,
-          nullptr, riding, TO_ROOM);
+    // If this resolves to nullptr we know 'riding' is a TObj (furniture)
+    auto* ridingAsTBeing = dynamic_cast<TBeing*>(riding);
+
+    // Condensed logic using ternaries. Determine if <this> is riding an actual mount or simply on
+    // some furniture, then build some strings to send to act(). Avoids a bunch of nested ifs and
+    // calling act repeatedly.
+    bool shouldFallOffMount = ridingAsTBeing ? ((!bSuccess(SKILL_RIDE) || !wasRetreatSuccessful) &&
+                                                !bSuccess(ridingAsTBeing->mountSkillType()))
+                                             : !wasRetreatSuccessful;
+
+    sstring toChar =
+      ridingAsTBeing
+        ? (shouldFallOffMount ? "You urge your $O to flee, causing it to panic and throw you off!"
+                              : "")
+        : (shouldFallOffMount ? "Lurching backwards, you attempt to escape!"
+                              : "You smoothly stand up while looking for available exits.");
+
+    sstring toRoom =
+      ridingAsTBeing
+        ? (shouldFallOffMount ? "$n urges $s $O to flee, causing it to panic and throw $n off!"
+                              : "")
+        : (shouldFallOffMount ? "$n lurches backwards, attempting to escape!"
+                              : "$n stands up and conspicuously looks for an exit.");
+
+    if (!toChar.empty())
+      act(toChar, true, this, nullptr, riding, TO_CHAR);
+    if (!toRoom.empty())
+      act(toRoom, true, this, nullptr, riding, TO_ROOM);    
+
+    if (shouldFallOffMount) {
       rc = fallOffMount(riding, POSITION_SITTING);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
-      panic = true;
-    }
-  } else if (getPosition() <= POSITION_SITTING) {
-    addToMove(-10);
-    // If retreat succeeded, simply being on the ground when fleeing doesn't
-    // result in panic. And you get a different message.
-    if (wasRetreatSuccessful) {
-      act("$n rolls aside and regains $s footing!", true, this, nullptr, nullptr, TO_ROOM);
-      act("You quickly roll aside and regain your footing.", true, this, nullptr, nullptr, TO_CHAR);
-    } else {
-      act("$n scrambles madly to $s feet!", true, this, nullptr, nullptr, TO_ROOM);
-      act("Panic-stricken, you scramble to your feet.", true, this, nullptr, nullptr, TO_CHAR);
-    }
-
-    doStand();
-
-    // If retreat didn't succeed or char doesn't have it, add some lag
-    // and panic.
-    if (!wasRetreatSuccessful) {
       addToWait(combatRound(1));
-      panic = true;
+      return true;
     }
+
+    // Have to use dismount here, as just forcing a standing position via setPosition actually sets
+    // <this> to standing on top of whatever furniture they were on. Collapses chairs, etc.
+    if (!ridingAsTBeing)
+      dismount(POSITION_STANDING);
+
     // If <this> is a mount being ridden
   } else if (riderAsTBeing) {
     act("Your $O panics and attempts to flee!", true, riderAsTBeing, nullptr, this, TO_CHAR);
     act("$n's $O panics and attempts to flee!", true, riderAsTBeing, nullptr, this, TO_ROOM);
 
-    // Allow deikhans to pass checks and prevent getting bucked
-    if (riderAsTBeing->doesKnowSkill(SKILL_CHIVALRY) && riderAsTBeing->bSuccess(SKILL_CHIVALRY) &&
-        riderAsTBeing->doesKnowSkill(SKILL_RIDE) && riderAsTBeing->bSuccess(SKILL_RIDE)) {
+    // Give Deikhans a chance to prevent being bucked, with the right skills.
+    if (riderAsTBeing->bSuccess(mountSkillType()) && riderAsTBeing->bSuccess(SKILL_CALM_MOUNT)) {
       act("You manage to calm $M down before $E dismounts you.", true, riderAsTBeing, nullptr, this,
           TO_CHAR);
       act("With soothing words $n manages to calm $N and remain mounted.", true,
           riderAsTBeing, nullptr, this, TO_ROOM);
       return true;
     }
+    
     rc = riderAsTBeing->fallOffMount(this, POSITION_SITTING);
     if (IS_SET_DELETE(rc, DELETE_THIS)) {
       riderAsTBeing->reformGroup();
@@ -903,7 +911,31 @@ int TBeing::doFlee(const char *arg) {
     }
     // Don't want reference to rider anymore if they fell off
     riderAsTBeing = nullptr;
-    panic = true;
+  }
+
+  if (getPosition() <= POSITION_SITTING) {
+    addToMove(-10);   
+
+    // If retreat succeeded, simply being on the ground when fleeing doesn't
+    // result in panic. And you get a different message.
+    sstring toRoom = wasRetreatSuccessful
+                       ? "$n rolls aside and regains $s footing!"
+                       : "$n scrambles madly to $s feet!";
+    sstring toChar = wasRetreatSuccessful
+                       ? "You quickly roll aside and regain your footing!"
+                       : "You scramble madly to your feet!";
+
+    act(toRoom, true, this, nullptr, nullptr, TO_ROOM);
+    act(toChar, true, this, nullptr, nullptr, TO_CHAR);
+
+    setPosition(POSITION_STANDING);
+
+    // If retreat didn't succeed or char doesn't have it, add some lag
+    // and panic.
+    if (!wasRetreatSuccessful) {
+      addToWait(combatRound(1));
+      panic = true;
+    }
   }
 
   playsound(pickRandSound(SOUND_FLEE_01, SOUND_FLEE_03), SOUND_TYPE_COMBAT);
@@ -954,14 +986,13 @@ int TBeing::doFlee(const char *arg) {
 
   /*
     Determine which direction to actually use. If panicked, no flee direction
-    chosen, (fighting + knows retreat + retreat failed), or (fighting + doesn't know retreat +
-    fails 50% chance) then flee in random direction. Otherwise flee in chosen direction.
+    chosen, or fighting and both retreat and 50% chance fail then flee in random direction.
+    Otherwise flee in chosen direction.
   */
-  dirTypeT dirToUse = panic || chosenDir == DIR_NONE ||
-                              (enemy && ((doesKnowRetreat && !wasRetreatSuccessful) ||
-                                         (!doesKnowRetreat && ::number(0, 1))))
-                          ? randomDir
-                          : chosenDir;
+  dirTypeT dirToUse =
+    panic || chosenDir == DIR_NONE || (!wasRetreatSuccessful && enemy && ::number(0, 1))
+      ? randomDir
+      : chosenDir;
 
   // These messages don't make sense if not fighting
   if (enemy) {

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -1029,32 +1029,30 @@ int TBeing::doFlee(const char *arg) {
 
   // Make mobs fear enemy who forced them to flee
   // Check IsPc() in case of disguised/polymorphed/otherwise transformed PC
-  TMonster *thisAsTMonster = isPc() 
-      ? nullptr 
-      : dynamic_cast<TMonster *>(this);
+  if (!isPc()) {
+    auto* thisAsTMonster = dynamic_cast<TMonster*>(this);
+    if (thisAsTMonster)
+      thisAsTMonster->addFeared(enemy);
+  }
 
-  if (thisAsTMonster)
-    thisAsTMonster->addFeared(enemy);
+  // Determine if enemy begins hunting <this>, then potentially look for
+  // remaining opponents who are engaged and make enemy attack them if found
+  if (!enemy->isPc()) {
+    auto* enemyAsTMonster = dynamic_cast<TMonster*>(enemy);
+    if (enemyAsTMonster) {
+      int percent =
+        100 * enemyAsTMonster->getHit() / enemyAsTMonster->hitLimit();
 
-  /*
-    Determine if enemy begins hunting <this>, then potentially look for
-    remaining opponents who are engaged and make enemy attack them if found
-  */
-  TMonster *enemyAsTMonster = enemy->isPc() 
-      ? nullptr 
-      : dynamic_cast<TMonster *>(enemy);
-      
-  if (enemyAsTMonster) {
-    int percent = 100 * enemyAsTMonster->getHit() / enemyAsTMonster->hitLimit();
+      if (::number(1, 100) < percent &&
+          (enemyAsTMonster->Hates(this, nullptr) ||
+           isOppositeFaction(enemyAsTMonster)))
+        enemyAsTMonster->setHunting(this);
 
-    if (::number(1, 100) < percent &&
-        (enemyAsTMonster->Hates(this, nullptr) || isOppositeFaction(enemyAsTMonster)))
-      enemyAsTMonster->setHunting(this);
-  
-    if (IS_SET_DELETE(enemyAsTMonster->lookForEngaged(), DELETE_THIS)) {
-      delete enemyAsTMonster;
-      enemyAsTMonster = nullptr;
-      enemy = nullptr;
+      if (IS_SET_DELETE(enemyAsTMonster->lookForEngaged(), DELETE_THIS)) {
+        delete enemyAsTMonster;
+        enemyAsTMonster = nullptr;
+        enemy = nullptr;
+      }
     }
   }
 

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -835,19 +835,19 @@ int TBeing::doFlee(const char *arg) {
     return false;
   }
 
-  /* 
-  Do skill checks now and use results throughout so bSuccess only gets 
-  called once per flee attempt. 
+  /*
+  Do skill checks now and use results throughout so bSuccess only gets
+  called once per flee attempt.
   */
-  auto retreatSkill = getSkillNum(SKILL_RETREAT);  
+  auto retreatSkill = getSkillNum(SKILL_RETREAT);
   auto doesKnowRetreat = doesKnowSkill(retreatSkill);
-  auto wasRetreatSuccessful = doesKnowRetreat && bSuccess(retreatSkill);  
+  auto wasRetreatSuccessful = doesKnowRetreat && bSuccess(retreatSkill);
 
   auto panic = false;
   auto rc = 0;
   auto riderAsTBeing = dynamic_cast<TBeing *>(rider);
 
-  if (riding) {   
+  if (riding) {
     // Allow successful retreat and ride checks to avoid falling off mount
     if (!doesKnowSkill(SKILL_RIDE) || !bSuccess(SKILL_RIDE) || !wasRetreatSuccessful) {
       sendTo("Your panic causes you to fall.\n\r");
@@ -876,18 +876,16 @@ int TBeing::doFlee(const char *arg) {
       panic = true;
     }
     // If <this> is a mount being ridden
-  } else if (riderAsTBeing) {    
+  } else if (riderAsTBeing) {
     act("Your $O panics and attempts to flee!", true, riderAsTBeing, nullptr, this, TO_CHAR);
 
     // Allow deikhans to pass checks and prevent getting bucked
-    if (
-      riderAsTBeing->doesKnowSkill(SKILL_CHIVALRY) &&
-      riderAsTBeing->bSuccess(SKILL_CHIVALRY) && 
-      riderAsTBeing->doesKnowSkill(SKILL_RIDE) &&
-      riderAsTBeing->bSuccess(SKILL_RIDE)) {
-        act("You manage to calm $M down before $E dismounts you.", true, riderAsTBeing, nullptr, this, TO_CHAR);
-        return true;
-      }
+    if (riderAsTBeing->doesKnowSkill(SKILL_CHIVALRY) && riderAsTBeing->bSuccess(SKILL_CHIVALRY) &&
+        riderAsTBeing->doesKnowSkill(SKILL_RIDE) && riderAsTBeing->bSuccess(SKILL_RIDE)) {
+      act("You manage to calm $M down before $E dismounts you.", true, riderAsTBeing, nullptr, this,
+          TO_CHAR);
+      return true;
+    }
     rc = riderAsTBeing->fallOffMount(this, POSITION_SITTING);
     if (IS_SET_DELETE(rc, DELETE_THIS)) {
       riderAsTBeing->reformGroup();
@@ -900,15 +898,33 @@ int TBeing::doFlee(const char *arg) {
 
   playsound(pickRandSound(SOUND_FLEE_01, SOUND_FLEE_03), SOUND_TYPE_COMBAT);
 
-  // Create vector containing all currently valid movement directions
+  auto chosenDir = getDirFromChar(arg);
+
+  /*
+    Whether retreating or fleeing, if they input a direction, check if it's a valid
+    dir and return if not. If they've chosen a valid direction, actually do the
+    checks to see if they succeed in fleeing that way further down.
+  */
+  if (chosenDir != DIR_NONE && !canFleeThisWay(this, chosenDir)) {
+    act("You can't escape in that direction!", true, this, nullptr, nullptr, TO_CHAR);
+    return true;
+  }
+
+  /*
+    Create vector containing all currently valid flee directions, except for
+    the chosen direction if one was given.
+  */
   std::vector<dirTypeT> validDirections;
   for (auto direction = MIN_DIR; direction < MAX_DIR; direction++) {
+    if (direction == chosenDir) continue;
     if (canFleeThisWay(this, direction)) validDirections.push_back(direction);
   }
 
-  // If there are no valid flee directions, simply return with the panic
-  // message.
-  if (validDirections.size() == 0) {
+  /*
+    If there are no valid flee directions (doors closed, etc), simply return with the panic
+    message.
+  */
+  if (validDirections.size() == 0 && chosenDir == DIR_NONE) {
     sendTo("PANIC! You couldn't escape!\n\r");
 
     // Handle troglodyte racial perk
@@ -923,9 +939,14 @@ int TBeing::doFlee(const char *arg) {
     return true;
   }
 
-  // Randomly select a valid direction for use later
-  auto randomDir = validDirections[::number(0, validDirections.size() - 1)];
-  auto chosenDir = getDirFromChar(arg);
+  /*
+    Randomly select a valid flee direction for later use. If chosenDir is
+    the only valid flee direction, just use it as randomDir. Otherwise choose
+    any valid direction that's *not* chosenDir.
+  */
+  auto randomDir = validDirections.size() == 0
+                       ? chosenDir
+                       : validDirections[::number(0, validDirections.size() - 1)];
 
   // Save reference to who <this> was fighting for later
   auto enemy = fight();
@@ -1008,7 +1029,6 @@ int TBeing::doFlee(const char *arg) {
   // Determine if enemy begins hunting <this>
   auto enemyAsTMonster = dynamic_cast<TMonster *>(enemy);
   if (!(enemy->isPc()) && enemyAsTMonster) {
-   
     auto percent =
         (int)(100 * (double)enemyAsTMonster->getHit() / (double)enemyAsTMonster->hitLimit());
 
@@ -1040,7 +1060,7 @@ int TBeing::doFlee(const char *arg) {
     }
   }
 
-  return true; 
+  return true;
 }
 
 // return DELETE_THIS if this should die

--- a/code/code/misc/room.cc
+++ b/code/code/misc/room.cc
@@ -510,3 +510,8 @@ int TRoom::getLight()
   return ((isRoomFlag(ROOM_ALWAYS_LIT)) ? 18 : TThing::getLight());
 
 }
+
+TThing* TRoom::findInRoom(const std::function<bool(TThing*)> &predicate) {
+  auto found = std::find_if(stuff.begin(), stuff.end(), predicate);
+  return found != stuff.end() ? *found : nullptr;
+}

--- a/code/code/misc/room.h
+++ b/code/code/misc/room.h
@@ -338,6 +338,7 @@ class TRoom : public TThing {
     int brightSunlight() { return getLight() > 20; }
     int pitchBlackDark() { return getLight() <= 0; }
 
+    TThing* findInRoom(const std::function<bool(TThing*)> &);
 };
 
 const int ZONE_MAX_TIME      = 50;


### PR DESCRIPTION
This PR completely refactors the doFlee function that handles flee/retreat. It removes the gratuitous `for` loops used throughout previously and streamlines everything while using more modern syntax/features of C++.

The overall behavior of flee is pretty much identical to before. One new feature added was the ability for a Deikhan to resist falling off their mount if the mount panics and tries to flee. 

As coded this PR allows someone without retreat or who fails retreat a 50% chance to flee in the direction they choose. This can easily be adjusted if others feel 50% is too high of a chance.

I also refactored the lookForEngaged function since it's called in doFlee. The only real change there was updated syntax plus the removal of code that made unintelligent mobs not attack someone who was only engaged after the tank fled, which would leave the engaged person still "fighting" the mob but the mob not fighting them back.