### PR TITLE
Spell changes

### DIFF
--- a/code/code/disc/disc_afflictions.cc
+++ b/code/code/disc/disc_afflictions.cc
@@ -75,11 +75,6 @@ static void addTorment(TBeing * victim, spellNumT spell)
 
 int harm(TBeing * caster, TBeing * victim, int level, short bKnown, spellNumT spell, int adv_learn)
 {
-  level = min(level, 70);
-
-  if (caster->isNotPowerful(victim, level, spell, SILENT_NO)) {
-    return SPELL_FAIL;
-  }
 
   caster->reconcileHurt(victim, discArray[spell]->alignMod);
 
@@ -651,12 +646,6 @@ void blindness(TBeing * caster, TBeing * victim)
 
 int harmLight(TBeing * caster, TBeing * victim, int level, short bKnown, spellNumT spell, int adv_learn)
 {
-  level = min(level, 10);
-
-  if (caster->isNotPowerful(victim, level, spell, SILENT_NO)) {
-    return SPELL_FAIL;
-  }
-
   int dam = caster->getSkillDam(victim, spell, level, adv_learn);
 
   caster->reconcileHurt(victim, discArray[spell]->alignMod);
@@ -759,12 +748,6 @@ int harmLight(TBeing * caster, TBeing * victim)
 
 int harmCritical(TBeing * caster, TBeing * victim, int level, short bKnown, spellNumT spell, int adv_learn)
 {
-  if (caster->isNotPowerful(victim, level, spell, SILENT_NO)) {
-    return SPELL_FAIL;
-  }
-
-  level = min(level, 45);
-
   caster->reconcileHurt(victim, discArray[spell]->alignMod);
   int dam = caster->getSkillDam(victim, spell, level, adv_learn);
 
@@ -856,12 +839,6 @@ int harmCritical(TBeing * caster, TBeing * victim)
 
 int harmSerious(TBeing * caster, TBeing * victim, int level, short bKnown, spellNumT spell, int adv_learn)
 {
-  if (caster->isNotPowerful(victim, level, spell, SILENT_NO)) {
-    return SPELL_FAIL;
-  }
-
-  level = min(level, 25);
-
   int dam = caster->getSkillDam(victim, spell, level, adv_learn);
 
   caster->reconcileHurt(victim, discArray[spell]->alignMod);

--- a/code/code/disc/disc_afflictions.cc
+++ b/code/code/disc/disc_afflictions.cc
@@ -92,11 +92,6 @@ int harm(TBeing * caster, TBeing * victim, int level, short bKnown, spellNumT sp
         break;
     }
 
-    if (victim->isLucky(caster->spellLuckModifier(spell))) {
-      SV(spell);
-      dam /= 2;
-    }
-
     act("$N buckles from the pain!", FALSE, caster, NULL, victim, TO_NOTVICT);
     act("$N buckles from the pain!", FALSE, caster, NULL, victim, TO_CHAR);
     act("You buckle from the pain!  You could swear you're about to die!", FALSE, caster, NULL, victim, TO_VICT);

--- a/code/code/disc/disc_air.cc
+++ b/code/code/disc/disc_air.cc
@@ -29,8 +29,6 @@ int gust(TBeing * caster, TBeing * victim, int level, short bKnown, int adv_lear
     return SPELL_FAIL;
   }
 
-  level = min(level, 10);
-
   int dam = caster->getSkillDam(victim, SPELL_GUST, level, adv_learn);
 
   caster->reconcileHurt(victim,discArray[SPELL_GUST]->alignMod); 
@@ -495,7 +493,6 @@ int dustStorm(TBeing * caster, int level, short bKnown, int adv_learn)
     caster->nothingHappens(SILENT_YES);
     return SPELL_FAIL;
   }
-  level = min(level, 15);
 
   int dam = caster->getSkillDam(NULL, SPELL_DUST_STORM, level, adv_learn);
 
@@ -593,7 +590,6 @@ int tornado(TBeing * caster, int level, short bKnown, int adv_learn)
   TThing *t, *ch;
   TBeing *tb;
   int rc;
-  level = min(level, 33);
 
   int dam = caster->getSkillDam(NULL, SPELL_TORNADO, level, adv_learn);
 

--- a/code/code/disc/disc_earth.cc
+++ b/code/code/disc/disc_earth.cc
@@ -17,9 +17,6 @@
 
 int slingShot(TBeing * caster, TBeing * victim, int level, short bKnown, int adv_learn)
 {
-
-  level = min(level, 10);
-
   int dam = caster->getSkillDam(victim, SPELL_SLING_SHOT, level, adv_learn);
   caster->reconcileHurt(victim,discArray[SPELL_SLING_SHOT]->alignMod);
 
@@ -112,8 +109,6 @@ int castSlingShot(TBeing * caster, TBeing * victim)
 
 int graniteFists(TBeing * caster, TBeing * victim, int level, short bKnown, int adv_learn)
 {
-  level = min(level, 25);
-
   int dam = caster->getSkillDam(victim, SPELL_GRANITE_FISTS, level, adv_learn);
 
   caster->reconcileHurt(victim,discArray[SPELL_GRANITE_FISTS]->alignMod);
@@ -209,9 +204,7 @@ int pebbleSpray(TBeing * caster, int level, short bKnown, int adv_learn)
 {
   TThing *t;
   TBeing *vict = NULL;
-
-  level = min(level, 15);
-
+  
   int dam = caster->getSkillDam(NULL, SPELL_PEBBLE_SPRAY, level, adv_learn);
 
   if (caster->bSuccess(bKnown, SPELL_PEBBLE_SPRAY)) {

--- a/code/code/disc/disc_fire.cc
+++ b/code/code/disc/disc_fire.cc
@@ -38,7 +38,6 @@ int handsOfFlame(TBeing *caster, TBeing *victim, int level, short bKnown, int *d
     return SPELL_FALSE;
   }
 // Second Calculate Damage
-  level = min(level, 10);
   *damage = caster->getSkillDam(victim, SPELL_HANDS_OF_FLAME, level, adv_learn);
 
 //  ToBe coded
@@ -564,8 +563,6 @@ int flamingSword(TBeing *caster, TBeing *victim, int level, short bKnown, int ad
 {
   int ret = 0;
 
-  level = min(level, 25);
-
   int dam = caster->getSkillDam(victim, SPELL_FLAMING_SWORD, level, adv_learn);
 
   caster->reconcileHurt(victim,discArray[SPELL_FLAMING_SWORD]->alignMod);
@@ -866,8 +863,6 @@ int hellfire(TBeing *caster, int level, short bKnown, int adv_learn)
   TThing * t;
   TBeing *vict;
 
-  level = min(level, 33);
-
   vict = NULL;
   dam = caster->getSkillDam(NULL, SPELL_HELLFIRE, level, adv_learn);
 
@@ -997,8 +992,6 @@ int fireball(TBeing *caster, int level, short bKnown, int adv_learn)
     caster->sendTo("The water completely dissolves your fireball!\n\r");
     return SPELL_FAIL;
   } 
-
-  level = min(level, 15);
 
   int damage = caster->getSkillDam(NULL, SPELL_FIREBALL, level, adv_learn);
 

--- a/code/code/disc/disc_shaman.cc
+++ b/code/code/disc/disc_shaman.cc
@@ -1787,7 +1787,6 @@ int embalm(TBeing *caster, TObj *o, int level, short bKnown)
 
 int squish(TBeing * caster, TBeing * victim, int level, short bKnown, int adv_learn)
 {
-  level = min(level, 25);
 
   int dam = caster->getSkillDam(victim, SPELL_SQUISH, level, adv_learn);
 
@@ -1890,9 +1889,6 @@ int distort(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_lea
 {
   char buf[256];
   sstring bBuf;
-
-
-  level = min(level, 15);
 
   int dam = caster->getSkillDam(victim, SPELL_DISTORT, level, adv_learn);
   int beams = (dam / 3) + ::number(0, (caster->GetMaxLevel() / 10));
@@ -2066,8 +2062,6 @@ int soulTwist(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_l
     act("$n's ritual fails because of your immunity!", FALSE, caster, NULL, victim, TO_VICT);
     return SPELL_FAIL;
   }
-
-  level = min(level, 30);
 
   int dam = caster->getSkillDam(victim, SPELL_SOUL_TWIST, level, adv_learn);
   caster->reconcileHurt(victim, discArray[SPELL_SOUL_TWIST]->alignMod);
@@ -2554,8 +2548,6 @@ int flatulence(TBeing * caster, int level, short bKnown, int adv_learn)
 {
   TThing *t;
   TBeing *vict = NULL;
-
-  level = min(level, 20);
 
   int dam = caster->getSkillDam(NULL, SPELL_FLATULENCE, level, adv_learn);
 

--- a/code/code/disc/disc_shaman_frog.cc
+++ b/code/code/disc/disc_shaman_frog.cc
@@ -428,8 +428,6 @@ int aquaticBlast(TBeing * caster, TBeing * victim, int level, short bKnown, int 
   int rc;
   TThing *t;
 
-  level = min(level, 50);
-
   int dam = caster->getSkillDam(victim, SPELL_AQUATIC_BLAST, level, adv_learn);
 
   if (victim->getImmunity(IMMUNE_WATER) >= 100) {
@@ -961,8 +959,6 @@ int deathWave(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_l
 {
   char buf[256];
   sstring bBuf;
-
-  level = min(level, 75);
 
   int dam = caster->getSkillDam(victim, SPELL_DEATHWAVE, level, adv_learn);
   int beams = (dam / 3) + ::number(0, (caster->GetMaxLevel() / 10));

--- a/code/code/disc/disc_shaman_skunk.cc
+++ b/code/code/disc/disc_shaman_skunk.cc
@@ -366,8 +366,6 @@ int cardiacStress(TBeing *caster, TBeing *victim, int level, short bKnown, int a
     return SPELL_FAIL;
   }
 
-  level = std::min(level, 80);
-
   int dam = caster->getSkillDam(victim, SPELL_CARDIAC_STRESS, level, adv_learn);
 
   caster->reconcileHurt(victim, discArray[SPELL_CARDIAC_STRESS]->alignMod);
@@ -488,7 +486,6 @@ int bloodBoil(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_l
     caster->nothingHappens(SILENT_YES);
     return SPELL_FAIL;
   }
-  level = std::min(level, 45);
 
   int dam = caster->getSkillDam(victim, SPELL_BLOOD_BOIL, level, adv_learn);
 

--- a/code/code/disc/disc_shaman_spider.cc
+++ b/code/code/disc/disc_shaman_spider.cc
@@ -968,8 +968,6 @@ int raze(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_learn)
     return SPELL_FAIL;
   }
 
-  level = min(level, 90);
-
   int dam = caster->getSkillDam(victim, SPELL_RAZE, level, adv_learn);
 
   caster->reconcileHurt(victim, discArray[SPELL_RAZE]->alignMod);

--- a/code/code/disc/disc_sorcery.cc
+++ b/code/code/disc/disc_sorcery.cc
@@ -25,10 +25,6 @@ int mysticDarts(TBeing *caster, TBeing *victim, int level, short bKnown, int adv
 {
   char buf[256];
   sstring misBuf;
-
-  if (caster->isNotPowerful(victim, level, SPELL_MYSTIC_DARTS, SILENT_NO))
-    return SPELL_FAIL;
-
   level = min(level, 10);
 
   int dam = caster->getSkillDam(victim, SPELL_MYSTIC_DARTS, level, adv_learn);

--- a/code/code/disc/disc_sorcery.cc
+++ b/code/code/disc/disc_sorcery.cc
@@ -25,7 +25,6 @@ int mysticDarts(TBeing *caster, TBeing *victim, int level, short bKnown, int adv
 {
   char buf[256];
   sstring misBuf;
-  level = min(level, 10);
 
   int dam = caster->getSkillDam(victim, SPELL_MYSTIC_DARTS, level, adv_learn);
   // Lets make the missiles at least partly dependant on damage.
@@ -193,8 +192,6 @@ int stunningArrow(TBeing *caster, TBeing *victim, int level, short bKnown, int a
     return SPELL_FAIL;
   }
 
-  level = min(level, 25);
-
   int dam = caster->getSkillDam(victim, SPELL_STUNNING_ARROW, level, adv_learn);
   caster->reconcileHurt(victim, discArray[SPELL_STUNNING_ARROW]->alignMod);
 
@@ -324,7 +321,6 @@ int blastOfFury(TBeing *caster, TBeing *victim, int level, short bKnown, int adv
     caster->nothingHappens(SILENT_YES);
     return SPELL_FAIL;
   }
-  level = min(level, 45);
 
   int dam = caster->getSkillDam(victim, SPELL_BLAST_OF_FURY, level, adv_learn);
 
@@ -443,8 +439,6 @@ int colorSpray(TBeing *caster, int level, short bKnown, int adv_learn)
 {
   TBeing *tmp_victim = NULL;
   TThing *t;
-
-  level = min(level, 15);
 
   int orig_dam = caster->getSkillDam(NULL, SPELL_COLOR_SPRAY, level, adv_learn);
 
@@ -711,8 +705,6 @@ int acidBlast(TBeing *caster, int level, short bKnown, int adv_learn)
   TThing *t;
   TBeing *b = NULL;
 
-  level = min(level, 33);
-
   int orig_dam = caster->getSkillDam(NULL, SPELL_ACID_BLAST, level, adv_learn);
 
   if (caster->bSuccess(bKnown,SPELL_ACID_BLAST)) {
@@ -834,8 +826,6 @@ int atomize(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_lea
     caster->nothingHappens(SILENT_YES);
     return SPELL_FAIL;
   }
-
-  level = min(level, 75);
 
   int dam = caster->getSkillDam(victim, SPELL_ATOMIZE, level, adv_learn);
 

--- a/code/code/disc/disc_water.cc
+++ b/code/code/disc/disc_water.cc
@@ -114,8 +114,6 @@ int icyGrip(TBeing * caster, TBeing * victim, int level, short bKnown, int adv_l
     return SPELL_FAIL;
   }
 
-  level = min(level, 25);
-
   int damage = caster->getSkillDam(victim, SPELL_ICY_GRIP, level, adv_learn);
 
   if (caster->bSuccess(bKnown, SPELL_ICY_GRIP)) {
@@ -261,8 +259,6 @@ int wateryGrave(TBeing * caster, TBeing * victim, int level, short bKnown, int)
     return SPELL_FAIL;
   }
 
-  level = min(level, 60);
-
   aff.type = AFFECT_DISEASE;
   aff.level = level/2;
   aff.duration = caster->durationModify(SPELL_WATERY_GRAVE, aff.level/2);
@@ -339,8 +335,6 @@ int arcticBlast(TBeing * caster, int level, short bKnown, int adv_learn)
   int rc = 0;
   TBeing *tmp_victim = NULL;
   TThing *t;
-
-  level = min(level, 15);
 
   int damage = caster->getSkillDam(NULL, SPELL_ARCTIC_BLAST, level, adv_learn);
 
@@ -482,8 +476,6 @@ int iceStorm(TBeing * caster, int level, short bKnown, int adv_learn)
   TBeing *tmp_victim = NULL;
   TThing *t;
 
-  level = min(level, 33);
-
   int orig_damage = caster->getSkillDam(NULL, SPELL_ICE_STORM, level, adv_learn);
 
   if (caster->bSuccess(bKnown, SPELL_ICE_STORM)) {
@@ -622,8 +614,6 @@ int tsunami(TBeing * caster, int level, short bKnown, int adv_learn)
 {
   TBeing *tmp_victim = NULL;
   TThing *t;
-
-  level = min(level, 60);
 
   int orig_damage = caster->getSkillDam(NULL, SPELL_TSUNAMI, level, adv_learn);
 
@@ -1133,8 +1123,6 @@ int gusher(TBeing * caster, TBeing * victim, int level, short bKnown, int adv_le
 {
   int rc;
   TThing *t;
-
-  level = min(level, 10);
 
   int dam = caster->getSkillDam(victim, SPELL_GUSHER, level, adv_learn);
 

--- a/code/code/disc/disc_wrath.cc
+++ b/code/code/disc/disc_wrath.cc
@@ -198,8 +198,6 @@ int pillarOfSalt(TBeing * caster, TBeing * victim, int level, short bKnown, int 
     return FALSE;
   }
 
-  level = min(level, 50);
-
   caster->reconcileHurt(victim, discArray[SPELL_PILLAR_SALT]->alignMod);
 
   int dam = caster->getSkillDam(victim, SPELL_PILLAR_SALT, level, adv_learn);
@@ -339,7 +337,6 @@ int pillarOfSalt(TBeing * caster, TBeing * victim)
 
 int rainBrimstone(TBeing * caster, TBeing * victim, int level, short bKnown, spellNumT spell, int adv_learn)
 {
-  level = min(level, 10);
 
   caster->reconcileHurt(victim, discArray[spell]->alignMod);
 
@@ -586,8 +583,6 @@ int earthquake(TBeing *caster, int level, short bKnown, spellNumT spell, int adv
     return SPELL_FAIL;
   }
 
-  level = min(level, 50);
-
   int dam = caster->getSkillDam(NULL, spell, level, adv_learn);
 
   if (caster->bSuccess(bKnown, caster->getPerc(), spell)) {
@@ -732,8 +727,6 @@ int callLightning(TBeing *caster, TBeing *victim, int level, short bKnown, spell
     return SPELL_FAIL;
   }
 
-  level = min(level, 50);
-
   caster->reconcileHurt(victim, discArray[spell]->alignMod);
 
   int dam = caster->getSkillDam(victim, spell, level, adv_learn);
@@ -832,8 +825,6 @@ int spontaneousCombust(TBeing *caster, TBeing *victim, int level, short bKnown, 
           FALSE, caster, NULL, NULL, TO_ROOM);
     return SPELL_FALSE;
   }
-
-  level = min(level, 60);
 
   caster->reconcileHurt(victim, discArray[SPELL_SPONTANEOUS_COMBUST]->alignMod);
 
@@ -983,8 +974,6 @@ int spontaneousCombust(TBeing *caster, TBeing *victim)
 int flamestrike(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_learn)
 {
   int ret = 0;
-
-  level = min(level, 30);
 
   int dam = caster->getSkillDam(victim, SPELL_FLAMESTRIKE, level, adv_learn);
 

--- a/code/code/disc/disc_wrath.cc
+++ b/code/code/disc/disc_wrath.cc
@@ -254,8 +254,7 @@ int pillarOfSalt(TBeing * caster, TBeing * victim, int level, short bKnown, int 
     }
 
     if (victim->awake()) {
-      if ((victim->isLucky(caster->spellLuckModifier(SPELL_PILLAR_SALT))) ||
-          (caster->isNotPowerful(victim, (level+8), SPELL_PILLAR_SALT, SILENT_YES))) {
+      if (victim->isLucky(caster->spellLuckModifier(SPELL_PILLAR_SALT))) {
         SV(SPELL_PILLAR_SALT);
         act("$N manages to avoid some of the pelting salt particles!", FALSE, caster, NULL, victim, TO_NOTVICT);
         act("$N manages to avoid some of the salt particles!", FALSE, caster, NULL, victim, TO_CHAR);
@@ -721,10 +720,6 @@ int callLightning(TBeing *caster, TBeing *victim, int level, short bKnown, spell
 {
   int rc;
 
-  //if (caster->isNotPowerful(victim, level, spell, SILENT_NO)) {
-  //  return SPELL_FAIL;
-  //}
-
   if (!((Weather::getWeather(*victim->roomp) == Weather::RAINY) ||
       (Weather::getWeather(*victim->roomp) == Weather::LIGHTNING))) {
     caster->sendTo("You fail to call upon the lightning from the sky!\n\r");
@@ -830,10 +825,6 @@ int callLightning(TBeing *caster, TBeing *victim)
 int spontaneousCombust(TBeing *caster, TBeing *victim, int level, short bKnown, int adv_learn)
 {
   int rc;
-
-  //  if (caster->isNotPowerful(victim, level, SPELL_SPONTANEOUS_COMBUST, SILENT_NO)) {
-  //    return SPELL_FAIL;
-  //  }
 
   if (victim->roomp->isUnderwaterSector()) {
     caster->sendTo("Your attempt fizzels and sputters in the water!\n\r");
@@ -1020,9 +1011,6 @@ int flamestrike(TBeing *caster, TBeing *victim, int level, short bKnown, int adv
       case CRIT_S_NONE:
         ret=SPELL_SUCCESS;
         break;
-    }
-    if (victim->isNotPowerful(victim, level + 5, SPELL_FLAMESTRIKE, SILENT_YES)) {
-      dam /=2;
     }
     if (victim->isLucky(caster->spellLuckModifier(SPELL_FLAMESTRIKE))) {
       dam /= 2;


### PR DESCRIPTION
**1. remove isnotpowerful checks from damage spells**
We decided that damage spells should have a reduction in damage based on level diff between caster and victim and possibly a save. isnotpowerful should only be used for non-damage spells like blind etc.

**2. remove artificial level caps passed from spells to getSkillDam**
In order for genericDam to calculate damage reduction accurately we should always pass in the real level of the caster or obj

**3. remove save from harm to be consistent with the rest of the line**
also it doesn't list  saving throw in the damage calc: https://github.com/sneezymud/sneezymud/blob/master/code/code/misc/skill_dam.cc#L321

