### PR TITLE
Retreat fix

### DIFF
--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -952,8 +952,8 @@ int TBeing::doFlee(const char *arg)
   for (i = 0; i < 20; i++) {
     dirTypeT attempt = dirTypeT(::number(MIN_DIR, MAX_DIR-1));        // Select a random direction 
     
-    // fighting, so give slight chance of letting PC direct the direction
-    if (chosenDir != DIR_NONE && !panic && !(::number(0,99) < (30+getSkillValue(skill)/2)))
+    // fighting, so the chance of success depends on retreat skill (with at least 5% chance to fail)
+    if (chosenDir != DIR_NONE && !panic && (::number(0,99) < (45+getSkillValue(skill)/2)))
       attempt = chosenDir;
     
     if (canFleeThisWay(this, attempt)) {


### PR DESCRIPTION
Pulling this out separately from the crit changes, as it didn't really belong.  This change fixes a bug (as currently retreat chances go down as your skill improves) and reworks the algorithm for determining whether retreat has failed.  With retreat skill at max, the player will have a 95% chance to flee in their specified direction.