### PR TITLE
Fix heap-use-after-free crash in casino valet proc

### DIFF
--- a/code/code/spec/spec_mobs_vehicle.cc
+++ b/code/code/spec/spec_mobs_vehicle.cc
@@ -384,8 +384,7 @@ int casinoElevatorGuard(TBeing *ch, cmdTypeT cmd, const char *, TMonster *myself
       myself->doSay("Thank you, enjoy your stay!");
       ch->doEnter("", elevator);
       (*o)--;
-      delete o;
-      return true;
+      return DELETE_ITEM;
     }
   }
 


### PR DESCRIPTION
Crash was caused by the casinoElevatorGuard function calling delete on a
pointer to an object it didn't "own", rather than returning `DELETE_ITEM`
and allowing the object to be deleted further up the stack. The object
was being dereferenced in the `doGive` function in `inventory.cc` after
delete had already been called on it.