### PR TITLE
Fix logic to prevent crash when weapon in inv

### DIFF
--- a/code/code/spec/spec_objs_thief_quest.cc
+++ b/code/code/spec/spec_objs_thief_quest.cc
@@ -5,31 +5,30 @@
 #include "extern.h"
 #include "obj_base_weapon.h"
 
-int thiefQuestWeapon(TBeing *victim, cmdTypeT command, const char *arg, TObj *object, TObj *) {
-  wearSlotT limb = WEAR_NOWHERE;
-
-  if (command != CMD_STAB && command != CMD_BACKSTAB && command != CMD_SLIT)
+int thiefQuestWeapon(TBeing *victim, cmdTypeT command, const char *arg, TObj *object, TObj *thief) {
+  // Thief will only == nullptr when proc is called on the generic command proc
+  // check. Don't want proc to execute in that instance - should only happen in
+  // response to skill use. Otherwise it'll execute twice as often as it should.
+  if ((command != CMD_STAB && command != CMD_BACKSTAB && command != CMD_SLIT) || !thief || !victim || !object)
     return false;
+
+  auto *weapon = dynamic_cast<TBaseWeapon *>(object);
+  auto *wielder = weapon ? dynamic_cast<TBeing *>(weapon->equippedBy) : nullptr;
+
+  // Cast both thief and wielder to base class and check if both pointing to same
+  // memory location
+  if (!weapon || !wielder || !(dynamic_cast<TThing *>(thief) == dynamic_cast<TThing *>(wielder)))
+    return false;
+
+  wearSlotT limb = WEAR_NOWHERE;
 
   if (command == CMD_STAB)
     limb = static_cast<wearSlotT>(reinterpret_cast<uintptr_t>(arg));
 
-  if (command != CMD_STAB && strcmp(arg, "-special-"))
-    return false;
-
-  if (!victim || !object)
-    return false;
-
-  limb = command == CMD_BACKSTAB
-      ? WEAR_BACK
-      : command == CMD_SLIT
-      ? WEAR_NECK
-      : limb;
+  limb = command == CMD_BACKSTAB ? WEAR_BACK : command == CMD_SLIT ? WEAR_NECK : limb;
 
   if (limb == WEAR_NOWHERE || limb == HOLD_RIGHT || limb == HOLD_LEFT || limb == MAX_WEAR)
     return false;
-
-  sstring limbDescription = victim->describeBodySlot(limb);
 
   // 10% chance on stab, 50% on backstab/slit
   if (command == CMD_STAB) {
@@ -38,40 +37,31 @@ int thiefQuestWeapon(TBeing *victim, cmdTypeT command, const char *arg, TObj *ob
   } else if (::number(0, 1))
     return false;
 
-  auto weapon = dynamic_cast<TBaseWeapon *>(object);
-
-  auto thief = weapon
-      ? dynamic_cast<TBeing *>(weapon->equippedBy)
-      : nullptr;
-
-  if (!weapon || !thief)
-    return false;
-
   int damage = 0;
   spellNumT damageType = SKILL_STABBING;
 
   if (command == CMD_STAB) {
-    damage = thief->GetMaxLevel() * 1.5;
+    damage = wielder->GetMaxLevel() * 1.5;
   } else if (command == CMD_BACKSTAB) {
-    damage = thief->GetMaxLevel() * 2.5;
+    damage = wielder->GetMaxLevel() * 2.5;
     damageType = SKILL_BACKSTAB;
-    act("<W>The weapon sears down $N's spine!<z>", FALSE, thief, weapon, victim, TO_CHAR);
-    act("<W>The weapon sears down $N's spine!<z>", FALSE, thief, weapon, victim, TO_ROOM);
+    act("<W>The weapon sears down $N's spine!<z>", false, wielder, weapon, victim, TO_CHAR);
+    act("<W>The weapon sears down $N's spine!<z>", false, wielder, weapon, victim, TO_ROOM);
   } else {
-    damage = thief->GetMaxLevel() * 3;
+    damage = wielder->GetMaxLevel() * 3;
     damageType = SKILL_THROATSLIT;
-    act("<W>The weapon sears through $N's throat!<z>", FALSE, thief, weapon, victim, TO_CHAR);
-    act("<W>The weapon sears through $N's throat!<z>", FALSE, thief, weapon, victim, TO_ROOM);
+    act("<W>The weapon sears through $N's throat!<z>", false, wielder, weapon, victim, TO_CHAR);
+    act("<W>The weapon sears through $N's throat!<z>", false, wielder, weapon, victim, TO_ROOM);
   }
 
-  int rc = thief->reconcileDamage(victim, damage, damageType);
+  int rc = wielder->reconcileDamage(victim, damage, damageType);
   if (IS_SET_DELETE(rc, DELETE_VICT))
     return DELETE_VICT;
 
   if (victim->slotChance(limb) && !victim->isImmune(IMMUNE_BLEED, WEAR_BACK) &&
       !victim->isLimbFlags(limb, PART_BLEEDING) && !victim->isUndead()) {
     act("<r>Blood begins to pour from the wound!<z>", false, victim, nullptr, nullptr, TO_ROOM);
-    victim->rawBleed(limb, thief->GetMaxLevel() * 3 + 100, SILENT_YES, CHECK_IMMUNITY_NO);
+    victim->rawBleed(limb, wielder->GetMaxLevel() * 3 + 100, SILENT_YES, CHECK_IMMUNITY_NO);
   }
 
   return true;

--- a/code/code/spec/spec_objs_thief_quest.cc
+++ b/code/code/spec/spec_objs_thief_quest.cc
@@ -13,55 +13,64 @@ int thiefQuestWeapon(TBeing *victim, cmdTypeT command, const char *arg, TObj *ob
     return false;
 
   auto *weapon = dynamic_cast<TBaseWeapon *>(object);
-  auto *wielder = weapon ? dynamic_cast<TBeing *>(weapon->equippedBy) : nullptr;
 
-  // Cast both thief and wielder to base class and check if both pointing to same
-  // memory location
-  if (!weapon || !wielder || !(dynamic_cast<TThing *>(thief) == dynamic_cast<TThing *>(wielder)))
+  // Double cast required because thief comes in having already been cast
+  // from TBeing to TThing to TObj, and casting directly from TObj to TBeing
+  // is not allowed (outside of reinterpret_cast).
+  auto* thiefAsTBeing = dynamic_cast<TBeing*>(dynamic_cast<TThing*>(thief));
+
+  // Verify stabber is wielding the object in their primary hand
+  if (!weapon || !thiefAsTBeing || !(thiefAsTBeing->heldInPrimHand() == weapon))
     return false;
 
   wearSlotT limb = WEAR_NOWHERE;
 
+  // This reinterpret_cast is necessary because there's no clean way to pass the
+  // wearSlotT value of the stab location into the function, short of completely
+  // changing the function signature of every object spec proc function.
   if (command == CMD_STAB)
     limb = static_cast<wearSlotT>(reinterpret_cast<uintptr_t>(arg));
 
-  limb = command == CMD_BACKSTAB ? WEAR_BACK : command == CMD_SLIT ? WEAR_NECK : limb;
+  limb = command == CMD_BACKSTAB ? WEAR_BACK
+         : command == CMD_SLIT   ? WEAR_NECK
+                                 : limb;
 
   if (limb == WEAR_NOWHERE || limb == HOLD_RIGHT || limb == HOLD_LEFT || limb == MAX_WEAR)
     return false;
 
   // 10% chance on stab, 50% on backstab/slit
-  if (command == CMD_STAB) {
-    if (::number(0, 9))
-      return false;
-  } else if (::number(0, 1))
+  if (command == CMD_STAB && ::number(0, 9))
+    return false;
+
+  if (::number(0, 1))
     return false;
 
   int damage = 0;
   spellNumT damageType = SKILL_STABBING;
+  int level = thiefAsTBeing->GetMaxLevel();
 
   if (command == CMD_STAB) {
-    damage = wielder->GetMaxLevel() * 1.5;
+    damage = level * 1.5;
   } else if (command == CMD_BACKSTAB) {
-    damage = wielder->GetMaxLevel() * 2.5;
+    damage = level * 2.5;
     damageType = SKILL_BACKSTAB;
-    act("<W>The weapon sears down $N's spine!<z>", false, wielder, weapon, victim, TO_CHAR);
-    act("<W>The weapon sears down $N's spine!<z>", false, wielder, weapon, victim, TO_ROOM);
+    act("<W>The weapon sears down $N's spine!<z>", false, thiefAsTBeing, weapon, victim, TO_CHAR);
+    act("<W>The weapon sears down $N's spine!<z>", false, thiefAsTBeing, weapon, victim, TO_ROOM);
   } else {
-    damage = wielder->GetMaxLevel() * 3;
+    damage = level * 3;
     damageType = SKILL_THROATSLIT;
-    act("<W>The weapon sears through $N's throat!<z>", false, wielder, weapon, victim, TO_CHAR);
-    act("<W>The weapon sears through $N's throat!<z>", false, wielder, weapon, victim, TO_ROOM);
+    act("<W>The weapon sears through $N's throat!<z>", false, thiefAsTBeing, weapon, victim, TO_CHAR);
+    act("<W>The weapon sears through $N's throat!<z>", false, thiefAsTBeing, weapon, victim, TO_ROOM);
   }
 
-  int rc = wielder->reconcileDamage(victim, damage, damageType);
+  int rc = thiefAsTBeing->reconcileDamage(victim, damage, damageType);
   if (IS_SET_DELETE(rc, DELETE_VICT))
     return DELETE_VICT;
 
   if (victim->slotChance(limb) && !victim->isImmune(IMMUNE_BLEED, WEAR_BACK) &&
       !victim->isLimbFlags(limb, PART_BLEEDING) && !victim->isUndead()) {
     act("<r>Blood begins to pour from the wound!<z>", false, victim, nullptr, nullptr, TO_ROOM);
-    victim->rawBleed(limb, wielder->GetMaxLevel() * 3 + 100, SILENT_YES, CHECK_IMMUNITY_NO);
+    victim->rawBleed(limb, level * 3 + 100, SILENT_YES, CHECK_IMMUNITY_NO);
   }
 
   return true;


### PR DESCRIPTION
This proc had some bad logic that allowed it to attempt to trigger
whenever a weapon with the proc was in a character's inventory
when the character used the thief stab skill.

Because the proc was triggering when it shouldn't, it was passing
a garbage value to another call within that was causing a segfault
and crashing the game.

This commit also fixes that the proc was being executed twice
every time stab was used - once from the stab function itself, and
again from the normal check-proc-on-pulse.