### PR TITLE
Fix crash in whirlwind caused by mob fleeing

### DIFF
--- a/code/code/cmd/cmd_whirlwind.cc
+++ b/code/code/cmd/cmd_whirlwind.cc
@@ -102,7 +102,8 @@ int TBeing::doWhirlwind()
   else if (weapon->isSlashWeapon())
     damageType = DAMAGE_HACKED;
 
-  // Loop for each person in room
+  // Loop for each person in room and determine if they're a valid whirlwind target. If so, add them
+  // to the vector for later.
   std::vector<TBeing *> validTargets{};
   for (TThing *thing : roomp->stuff) {
     auto *being = dynamic_cast<TBeing *>(thing);
@@ -114,6 +115,12 @@ int TBeing::doWhirlwind()
     validTargets.push_back(being);
   }
 
+  // Apply whirlwind damage and delete dead victims in a separate loop. This is necessary because
+  // when applying the damage from whirlwind there's a chance the victim will have an immediate flee
+  // triggered when taken below 10% health. If this happens during the previous loop, the victim is
+  // removed from the TRoom::stuff list being iterated and causes the iterator to become invalid
+  // before the loop is complete, triggering a crash. Doing it in a secondary loop afterwards
+  // prevents this.
   for (TBeing *being: validTargets) {
     if (being->inRoom() != in_room)
       continue;


### PR DESCRIPTION
Tentative fix for a crash caused in rare case where mob insta-flees when hit by a non-fatal whirlwind. I say tentative, because I wasn't able to reproduce the crash before or after the changes. However, based on tracing the code produced in the crash log, I don't see any reason why this shouldn't work to prevent it from happening again.

The mob leaving the room was removing it from the TRoom::stuff list before the whirlwind skill finished iterating over the same list to find valid targets, which invalidated the iterator back in the whirlwind code.

Fixed this by changing where the damage from whirlwind gets applied. Instead of doing so while still iterating through the room stuff list, now it just creates a vector of valid targets then applies the damage and deletes where necessary from that vector, afterwards.

Also noticed that there was no message for when the attack missed a valid target, so I added a simple one, and changed the verbiage sent by the command a bit to indicate that the attack might miss.

Crash log for posterity:
```

2022|0608|18:06:26 :: Rancid (7329):whirlwind 
=================================================================
==8==ERROR: AddressSanitizer: heap-use-after-free on address 0x603001575bb0 at pc 0x563906648790 bp 0x7fff04220710 sp 0x7fff04220700
READ of size 8 at 0x603001575bb0 thread T0
    #0 0x56390664878f in std::_List_iterator<TThing*>::operator++() /usr/include/c++/9/bits/stl_list.h:219
    #1 0x56390664878f in TBeing::doWhirlwind() code/cmd/cmd_whirlwind.cc:108
    #2 0x563905d7b8ad in TBeing::doCommand(cmdTypeT, sstring const&, TThing*, bool) code/misc/parse.cc:1225
    #3 0x563905d7fa47 in TBeing::parseCommand(sstring const&, bool, bool) code/misc/parse.cc:2082
    #4 0x5639050b466d in processAllInput() code/sys/connect.cc:2750
    #5 0x56390529c554 in TMainSocket::handleTimeAndSockets() code/sys/socket.cc:491
    #6 0x56390529ca73 in procHandleTimeAndSockets::run(TPulse const&) const code/sys/socket.cc:1635
    #7 0x56390527624d in TScheduler::run(int) code/sys/process.cc:251
    #8 0x5639052a7884 in TMainSocket::gameLoop() code/sys/socket.cc:1814
    #9 0x563904fa5e40 in run_the_game() code/sys/comm.cc:86
    #10 0x563904f5b188 in main code/main.cc:62
    #11 0x7f82840790b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #12 0x563904f91cdd in _start (/home/sneezy/code/sneezy+0x87ccdd)
0x603001575bb0 is located 0 bytes inside of 24-byte region [0x603001575bb0,0x603001575bc8)
freed by thread T0 here:
    #0 0x7f82848e451f in operator delete(void*) ../../../../src/libsanitizer/asan/asan_new_delete.cc:165
    #1 0x5639061282dc in __gnu_cxx::new_allocator<std::_List_node<TThing*> >::deallocate(std::_List_node<TThing*>*, unsigned long) /usr/include/c++/9/ext/new_allocator.h:128
    #2 0x5639061282dc in std::allocator_traits<std::allocator<std::_List_node<TThing*> > >::deallocate(std::allocator<std::_List_node<TThing*> >&, std::_List_node<TThing*>*, unsigned long) /usr/include/c++/9/bits/alloc_traits.h:469
    #3 0x5639061282dc in std::__cxx11::_List_base<TThing*, std::allocator<TThing*> >::_M_put_node(std::_List_node<TThing*>*) /usr/include/c++/9/bits/stl_list.h:442
    #4 0x5639061282dc in std::__cxx11::list<TThing*, std::allocator<TThing*> >::_M_erase(std::_List_iterator<TThing*>) /usr/include/c++/9/bits/stl_list.h:1926
    #5 0x5639061282dc in std::__cxx11::list<TThing*, std::allocator<TThing*> >::remove(TThing* const&) /usr/include/c++/9/bits/list.tcc:349
    #6 0x56390610d861 in TThing::operator--() code/misc/structs.cc:882
    #7 0x563906121e65 in TBeing::operator--() code/misc/structs.cc:831
    #8 0x563905bc3eac in TBeing::rawMoveTied(dirTypeT, int) code/misc/movement.cc:453
    #9 0x563905c15eb3 in TBeing::rawMove(dirTypeT) code/misc/movement.cc:1060
    #10 0x563905c1ab90 in TBeing::moveOne(dirTypeT) code/misc/movement.cc:1101
    #11 0x563905c6e5ba in TBeing::doFlee(char const*) code/misc/offense.cc:980
    #12 0x563905d79d63 in TBeing::doCommand(cmdTypeT, sstring const&, TThing*, bool) code/misc/parse.cc:1360
    #13 0x563905d7fa47 in TBeing::parseCommand(sstring const&, bool, bool) code/misc/parse.cc:2082
    #14 0x563905d886cc in TBeing::addCommandToQue(sstring const&) code/misc/parse.cc:3268
    #15 0x56390542d936 in TBeing::tellStatus(int, bool, bool) code/misc/combat.cc:4588
    #16 0x56390564fbd0 in TBeing::applyDamage(TBeing*, int, spellNumT) code/misc/damage.cc:400
    #17 0x563905652e3b in TBeing::reconcileDamage(TBeing*, int, spellNumT) code/misc/damage.cc:134
    #18 0x5639066475d5 in whirlwind code/cmd/cmd_whirlwind.cc:27
    #19 0x5639066475d5 in TBeing::doWhirlwind() code/cmd/cmd_whirlwind.cc:115
    #20 0x563905d7b8ad in TBeing::doCommand(cmdTypeT, sstring const&, TThing*, bool) code/misc/parse.cc:1225
    #21 0x563905d7fa47 in TBeing::parseCommand(sstring const&, bool, bool) code/misc/parse.cc:2082
    #22 0x5639050b466d in processAllInput() code/sys/connect.cc:2750
    #23 0x56390529c554 in TMainSocket::handleTimeAndSockets() code/sys/socket.cc:491
    #24 0x56390529ca73 in procHandleTimeAndSockets::run(TPulse const&) const code/sys/socket.cc:1635
    #25 0x56390527624d in TScheduler::run(int) code/sys/process.cc:251
    #26 0x5639052a7884 in TMainSocket::gameLoop() code/sys/socket.cc:1814
    #27 0x563904fa5e40 in run_the_game() code/sys/comm.cc:86
    #28 0x563904f5b188 in main code/main.cc:62
    #29 0x7f82840790b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
previously allocated by thread T0 here:
    #0 0x7f82848e3587 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:104
    #1 0x56390611d894 in __gnu_cxx::new_allocator<std::_List_node<TThing*> >::allocate(unsigned long, void const*) /usr/include/c++/9/ext/new_allocator.h:114
    #2 0x56390611d894 in std::allocator_traits<std::allocator<std::_List_node<TThing*> > >::allocate(std::allocator<std::_List_node<TThing*> >&, unsigned long) /usr/include/c++/9/bits/alloc_traits.h:443
    #3 0x56390611d894 in std::__cxx11::_List_base<TThing*, std::allocator<TThing*> >::_M_get_node() /usr/include/c++/9/bits/stl_list.h:438
    #4 0x56390611d894 in std::_List_node<TThing*>* std::__cxx11::list<TThing*, std::allocator<TThing*> >::_M_create_node<TThing*>(TThing*&&) /usr/include/c++/9/bits/stl_list.h:630
    #5 0x56390611d894 in void std::__cxx11::list<TThing*, std::allocator<TThing*> >::_M_insert<TThing*>(std::_List_iterator<TThing*>, TThing*&&) /usr/include/c++/9/bits/stl_list.h:1907
    #6 0x56390611d894 in std::__cxx11::list<TThing*, std::allocator<TThing*> >::push_front(TThing*&&) /usr/include/c++/9/bits/stl_list.h:1163
    #7 0x56390611d894 in TRoom::operator+=(TThing&) code/misc/structs.cc:719
    #8 0x56390519269d in runResetCmdM(zoneData&, resetCom&, unsigned int, bool&, TMonster*&, bool&, TObj*&, bool&) code/sys/db.cc:3039
    #9 0x56390515cffc in resetCom::execute(zoneData&, unsigned int, bool&, TMonster*&, bool&, TObj*&, bool&) code/sys/db.cc:4170
    #10 0x56390515cffc in zoneData::resetZone(bool, bool) code/sys/db.cc:3634
    #11 0x5639051cbd1b in bootDb() code/sys/db.cc:583
    #12 0x563904fa5cdd in run_the_game() code/sys/comm.cc:81
    #13 0x563904f5b188 in main code/main.cc:62
    #14 0x7f82840790b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/9/bits/stl_list.h:219 in std::_List_iterator<TThing*>::operator++()
Shadow bytes around the buggy address:
  0x0c06802a6b20: fa fa fd fd fd fd fa fa fd fd fd fd fa fa 00 00
  0x0c06802a6b30: 00 fa fa fa 00 00 00 fa fa fa fd fd fd fd fa fa
  0x0c06802a6b40: 00 00 00 00 fa fa 00 00 00 fa fa fa fd fd fd fd
  0x0c06802a6b50: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x0c06802a6b60: fd fd fa fa fd fd fd fd fa fa 00 00 00 00 fa fa
=>0x0c06802a6b70: fd fd fd fd fa fa[fd]fd fd fa fa fa fd fd fd fd
  0x0c06802a6b80: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x0c06802a6b90: fd fd fa fa fd fd fd fa fa fa 00 00 01 fa fa fa
  0x0c06802a6ba0: fd fd fd fd fa fa 00 00 00 fa fa fa 00 00 00 fa
  0x0c06802a6bb0: fa fa 00 00 00 00 fa fa 00 00 00 fa fa fa fd fd
  0x0c06802a6bc0: fd fd fa fa fd fd fd fd fa fa fd fd fd fd fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==8==ABORTING
```