### PR TITLE
Fix arch vampire and energy drain touch mob combat procs

### DIFF
--- a/code/code/spec/spec_mobs_combat.cc
+++ b/code/code/spec/spec_mobs_combat.cc
@@ -497,7 +497,7 @@ int arch_vampire(TBeing* vampire, cmdTypeT cmd, const char*, TMonster*, TObj*) {
   // energyDrain function, as that just introduces problems when non-mage mobs attempt it.
   // The bite is an innate ability, anyway.
   int dam = vampire->getSkillDam(victim, SPELL_ENERGY_DRAIN, vampire->GetMaxLevel(), 100);
-  int vit = dice(number(1, vampire->GetMaxLevel()), 4);
+  int vit = dice(::number(1, vampire->GetMaxLevel()), 4);
 
   // The proc could be made less punishing here - for instance, by adding a 'victim->isAgile()' call
   if (victim->isLucky(levelLuckModifier(vampire->GetMaxLevel()))) {
@@ -509,6 +509,7 @@ int arch_vampire(TBeing* vampire, cmdTypeT cmd, const char*, TMonster*, TObj*) {
     act("Before you can react $n bites you, feeding briefly then darting away!", true, vampire,
       nullptr, victim, TO_VICT, "<r>");
 
+    victim->addToMove(-vit);
     if (vampire->reconcileDamage(victim, dam, SPELL_ENERGY_DRAIN) == -1) {
       delete victim;
       victim = nullptr;

--- a/code/code/spec/spec_mobs_combat.cc
+++ b/code/code/spec/spec_mobs_combat.cc
@@ -10,27 +10,44 @@
 #include "disc_afflictions.h"
 #include "materials.h"
 
-int vampire(TBeing *ch, cmdTypeT cmd, const char *, TMonster *myself, TObj *)
-{
-  if ((cmd != CMD_MOB_COMBAT) || !myself->awake())
-    return FALSE;
+int vampire(TBeing* ch, cmdTypeT cmd, const char*, TMonster*, TObj*) {
+  auto* victim = ch->fight();
 
-  if (ch->spelltask)
-    return FALSE;
+  // Mob spec procs don't get called if their position is < POSITION_STANDING
+  if (cmd != CMD_MOB_COMBAT || !ch || !victim || !ch->sameRoom(*victim) || ch->spelltask)
+    return false;
 
-  if (ch->fight() && ch->sameRoom(*ch->fight())) {
-    act("$n touches $N!", TRUE, ch, 0, ch->fight(), TO_NOTVICT);
-    act("$n touches you in an attempt to suck away your energy!",
-        TRUE, ch, 0, ch->fight(), TO_VICT);
+  act("$n touches $N...", true, ch, nullptr, victim, TO_NOTVICT);
+  act("$n touches you in an attempt to suck away your energy...", true, ch, nullptr, victim,
+    TO_VICT);
 
-    if (!ch->doesKnowSkill(SPELL_ENERGY_DRAIN))
-      ch->setSkillValue(SPELL_ENERGY_DRAIN,120);
+  auto level = ch->GetMaxLevel();
 
-    return energyDrain(ch,ch->fight());
+  // No need to call actual spell function, as this is an innate ability. Just calculate damage,
+  // using mob's level as adv_learn value.
+  int dam = ch->getSkillDam(victim, SPELL_ENERGY_DRAIN, level, level);
+  int vit = dice(number(1, level), 4);
+
+  if (!dam || victim->getImmunity(IMMUNE_DRAIN) >= 100 ||
+      victim->isLucky(levelLuckModifier(level))) {
+    act("Nothing happens.", false, ch, nullptr, nullptr, TO_ROOM);
+  } else {
+    act("$N screams in agony as energy pours from $S body!", false, ch, nullptr, victim,
+      TO_NOTVICT);
+    act("You scream in agony as energy pours from your body!", false, ch, nullptr, victim, TO_VICT);
+    if (ch->reconcileDamage(victim, dam, SPELL_ENERGY_DRAIN) == -1) {
+      delete victim;
+      victim = nullptr;
+    }
+    victim->addToMove(-vit);
   }
-  return FALSE;
-}
 
+  ch->addSkillLag(SPELL_ENERGY_DRAIN, 0);
+
+  // Whatever the result, return true to prevent 'ch' from performing any other mob actions this
+  // pulse.
+  return true;
+}
 
 int kraken(TBeing *ch, cmdTypeT cmd, const char *, TMonster *myself, TObj *)
 {
@@ -458,35 +475,59 @@ int paralyzeBite(TBeing *, cmdTypeT cmd, const char *, TMonster *myself, TObj *)
   return TRUE;
 }
 
-// Arch does two drains at once!
-int arch_vampire(TBeing *ch, cmdTypeT cmd, const char *, TMonster *, TObj *)
-{
-  if ((cmd != CMD_MOB_COMBAT) || !ch->awake())
-    return FALSE;
+// If this proc is deemed too punishing we can gate it behind a random roll or specialAttack call
+int arch_vampire(TBeing* vampire, cmdTypeT cmd, const char*, TMonster*, TObj*) {
+  TBeing* victim = vampire->fight();
 
-  if (ch->spelltask)
-    return FALSE;
+  if (cmd != CMD_MOB_COMBAT || !victim || !vampire->sameRoom(*victim) || vampire->spelltask)
+    return false;
 
-  if (ch->fight() && ch->fight()->sameRoom(*ch)) {
-    act("$n bites $N!", 1, ch, 0, ch->fight(), TO_NOTVICT);
-    act("$n bites you!", 1, ch, 0, ch->fight(), TO_VICT);
-    if (!ch->doesKnowSkill(SPELL_ENERGY_DRAIN))
-      ch->setSkillValue(SPELL_ENERGY_DRAIN,2*ch->GetMaxLevel());
-
-    energyDrain(ch,ch->fight());
-
-#if 0
-// energyDrain goes through spelltask stuff, so can't double cast it anymore
-    if (ch->fight() && ch->fight()->sameRoom(*ch)) {
-      energyDrain(ch,ch->fight());
+  if (victim->getImmunity(IMMUNE_DRAIN) >= 100 || victim->isUndead()) {
+    // Don't spam the message too much
+    if (!::number(0, 3)) {
+      act("$n stares at $N hungrily but senses a feeding attempt would be futile.", false, vampire,
+        nullptr, victim, TO_NOTVICT);
+      act("$n stares at you hungrily but senses a feeding attempt would be futile.", false, vampire,
+        nullptr, victim, TO_VICT);
     }
-#endif
-
-    return TRUE;
+    return false;
   }
-  return FALSE;
-}
 
+  // Calculate damage for bite attack. No need to pseudo-cast the real spell by calling the
+  // energyDrain function, as that just introduces problems when non-mage mobs attempt it.
+  // The bite is an innate ability, anyway.
+  int dam = vampire->getSkillDam(victim, SPELL_ENERGY_DRAIN, vampire->GetMaxLevel(), 100);
+  int vit = dice(number(1, vampire->GetMaxLevel()), 4);
+
+  // The proc could be made less punishing here - for instance, by adding a 'victim->isAgile()' call
+  if (victim->isLucky(levelLuckModifier(vampire->GetMaxLevel()))) {
+    act("$N narrowly avoids $n's lunging bite!", true, vampire, nullptr, victim, TO_NOTVICT);
+    act("You narrowly avoid $n's lunging bite!", true, vampire, nullptr, victim, TO_VICT);
+  } else {
+    act("$n bites $N, feeding briefly then darting away!", true, vampire, nullptr, victim,
+      TO_NOTVICT, "<r>");
+    act("Before you can react $n bites you, feeding briefly then darting away!", true, vampire,
+      nullptr, victim, TO_VICT, "<r>");
+
+    if (vampire->reconcileDamage(victim, dam, SPELL_ENERGY_DRAIN) == -1) {
+      delete victim;
+      victim = nullptr;
+    } else {
+      act("$N sags, weakening due to blood loss.", true, vampire, nullptr, victim, TO_NOTVICT);
+      act("You sag, feeling weaker due to blood loss.", true, vampire, nullptr, victim, TO_VICT);
+    }
+
+    // The normal energy drain spell doesn't restore HP to the caster, but vampire bite does
+    vampire->addToHit(dam);
+    vampire->addToMove(vit);
+  }
+
+  // Add some skill lag to prevent rapid fire bites in consecutive rounds
+  vampire->addSkillLag(SPELL_ENERGY_DRAIN, 0);
+
+  // Return true whether or not bite lands, to prevent any further mob actions this pulse.
+  return true;
+}
 
 int rust_monster(TBeing *, cmdTypeT cmd, const char *, TMonster *me, TObj *)
 {

--- a/code/code/spec/spec_mobs_combat.cc
+++ b/code/code/spec/spec_mobs_combat.cc
@@ -35,11 +35,11 @@ int vampire(TBeing* ch, cmdTypeT cmd, const char*, TMonster*, TObj*) {
     act("$N screams in agony as energy pours from $S body!", false, ch, nullptr, victim,
       TO_NOTVICT);
     act("You scream in agony as energy pours from your body!", false, ch, nullptr, victim, TO_VICT);
+    victim->addToMove(-vit);
     if (ch->reconcileDamage(victim, dam, SPELL_ENERGY_DRAIN) == -1) {
       delete victim;
       victim = nullptr;
     }
-    victim->addToMove(-vit);
   }
 
   ch->addSkillLag(SPELL_ENERGY_DRAIN, 0);

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,44 @@
+06-22-22 : Fixed energy drain touch and vampire bite mob special procs
+
+           These two mob procs have been broken for a long time. Mobs with these
+           procs might be noticeably more dangerous now, so step carefully.
+          
+           - Vampire bite proc: Vampires around The World have remembered how to 
+             use their fangs properly and are again able to drain health and
+             vitality from their victims with a bite. This fix doesn't affect the 
+             special vampire bite that turns a PC into a vampire - that's a 
+             separate thing which happens much less frequently. 
+             
+             The following mobs have the vampire bite proc:
+              - Dalia'Pantin
+              - a female vampire
+              - the arch nemesis
+              - a lesser vampire
+              - the arch vampire
+              - Lorto
+
+           - Energy drain touch proc: You may have previously noticed these mobs 
+             touching you with no perceivable effect (because there wasn't one),
+             but be assured something can now actually happen.
+
+             The following mobs have the energy drain touch proc:
+              - a topiary unicorn
+              - a topiary lion
+              - a topiary bear
+              - a topiary elephant
+              - the Interrogator
+              - a gruesome fade
+              - General Benjamin
+              - General Alaric
+              - Noctagon
+              - a water apparition
+              - Lixlor
+              - a young mindflayer
+              - a drider
+              - an elvish banshee
+              - a grimlock
+              - Cladosporium (nocturnal version)
+
 06-11-22 : Fixed several crashes related to shapeshifting/lycanthropy and re-enabled
            the lycanthropy transformation for PCs
            - Fixed saves while shapeshifted


### PR DESCRIPTION
Due to popular demand, this PR fixes two mob combat special procs that have been in a broken state for a very long time. The proc code is almost entirely rewritten, but maintains the intended function/spirit of the original code.

There's a good chance this will make mobs with these procs much harder, but the overwhelming feeling on Discord was that it would be a positive change. The procs can easily be made less punishing with a few simple tweaks.

See news file for list of mobs affected by this fix.