### PR TITLE
Fix global-buffer-overflow crash in immortal evaluate command

### DIFF
--- a/code/code/obj/obj_low.cc
+++ b/code/code/obj/obj_low.cc
@@ -320,7 +320,7 @@ int ObjectEvaluator::getStatPointsRaw()
     else if (m_obj->affected[iAff].location == APPLY_SPELL || m_obj->affected[iAff].location == APPLY_DISCIPLINE)
     {
       bonus = m_obj->affected[iAff].modifier2;
-      bonus *= applyCost[m_obj->affected[iAff].modifier];
+      bonus *= applyCost[m_obj->affected[iAff].location];
     }
     else if (m_obj->affected[iAff].location == APPLY_SPELL_EFFECT)
     {


### PR DESCRIPTION
PR fixes the following crash (explanation below):

```
2022|0913|15:37:59 :: Sidartha loaded <r>a molten shield<1>. (max: 9999, cur: 10)
2022|0913|15:38:02 :: Sidartha (61):examine shield
=================================================================
==8==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5579731f5eb0 at pc 0x557972656054 bp 0x7ffedbcb98e0 sp 0x7ffedbcb98d0
READ of size 4 at 0x5579731f5eb0 thread T0
    #0 0x557972656053 in ObjectEvaluator::getStatPointsRaw() code/obj/obj_low.cc:323
    #1 0x557972656431 in ObjectEvaluator::getPointValue(PointType) code/obj/obj_low.cc:55
    #2 0x557972443d13 in TBaseClothing::evaluateMe(TBeing*) const code/obj/obj_base_clothing.cc:155
    #3 0x5579712c6f4f in TObj::describeMe(TBeing*) const code/misc/info.cc:4411
    #4 0x55797123afc0 in TBeing::describeObject(TThing const*) code/misc/info.cc:4416
    #5 0x557971cdb9a8 in TBeing::doLook(sstring const&, cmdTypeT, TThing*) code/cmd/cmd_look.cc:633
    #6 0x55797123219b in TBeing::doExamine(char const*, TThing*) code/misc/info.cc:1089
    #7 0x557971686bb8 in TBeing::doCommand(cmdTypeT, sstring const&, TThing*, bool) code/misc/parse.cc:972
    #8 0x55797168d0d7 in TBeing::parseCommand(sstring const&, bool, bool) code/misc/parse.cc:2083
    #9 0x5579709ae0ed in processAllInput() code/sys/connect.cc:2750
    #10 0x557970b966b4 in TMainSocket::handleTimeAndSockets() code/sys/socket.cc:491
    #11 0x557970b96bd3 in procHandleTimeAndSockets::run(TPulse const&) const code/sys/socket.cc:1664
    #12 0x557970b6fccd in TScheduler::run(int) code/sys/process.cc:251
    #13 0x557970ba1b74 in TMainSocket::gameLoop() code/sys/socket.cc:1843
    #14 0x55797089f7b0 in run_the_game() code/sys/comm.cc:86
    #15 0x557970854718 in main code/main.cc:62
    #16 0x7ff51fce2082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
    #17 0x55797088b64d in _start (/home/sneezy/code/sneezy+0x87e64d)
0x5579731f5eb0 is located 16 bytes to the left of global variable '*.LC50' defined in 'code/obj/obj_low.cc' (0x5579731f5ec0) of size 12
  '*.LC50' is ascii string 'Light Armor'
0x5579731f5eb0 is located 39 bytes to the right of global variable '*.LC49' defined in 'code/obj/obj_low.cc' (0x5579731f5e80) of size 9
  '*.LC49' is ascii string 'Clothing'
SUMMARY: AddressSanitizer: global-buffer-overflow code/obj/obj_low.cc:323 in ObjectEvaluator::getStatPointsRaw()
Shadow bytes around the buggy address:
  0x0aafae636b80: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0aafae636b90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9
  0x0aafae636ba0: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aafae636bb0: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x0aafae636bc0: 00 00 00 04 f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9
=>0x0aafae636bd0: 00 01 f9 f9 f9 f9[f9]f9 00 04 f9 f9 f9 f9 f9 f9
  0x0aafae636be0: 00 05 f9 f9 f9 f9 f9 f9 00 04 f9 f9 f9 f9 f9 f9
  0x0aafae636bf0: 00 f9 f9 f9 f9 f9 f9 f9 00 06 f9 f9 f9 f9 f9 f9
  0x0aafae636c00: 00 06 f9 f9 f9 f9 f9 f9 00 07 f9 f9 f9 f9 f9 f9
  0x0aafae636c10: 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
  0x0aafae636c20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==8==ABORTING
```

Explanation:

The `ObjectEvaluator::getStatPointsRaw` function in `obj_low.cc` was using the wrong property to index an array, probably due to a copy/paste that wasn't thought through fully. The `applyCost` array needs to be indexed by the `.location` property, not the `.modifier` property. Indexing it by `.modifier` was causing it to use out-of-bounds values for the index.