### PR TITLE
Use ubuntu-20.04 base image in Build and Test Github Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [ pull_request ]
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Build and Test
     steps:
     - name: Checkout this commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     - run: sudo apt-get update
     - run: sudo apt-get install software-properties-common
     - run: sudo apt-get update
-    - run: sudo apt-get install scons g++-9 libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libmariadbclient-dev libmariadb3 ccache
-    - run: scons -C code -j4 -Q ccache=1 pretty=0 sanitize=1 shared=0 check sneezy
-
+    - run: sudo apt-get install scons g++-9 libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libmariadb-dev libmariadb3 ccache
+    - run: scons -C code -j4 -Q ccache=1 pretty=0 sanitize=1 shared=0
 


### PR DESCRIPTION
libmariadbclient-dev appears to have been deprecated in favor of libmariadb-dev

Should fix this error in our "Build and Test" Github Action:

![image](https://user-images.githubusercontent.com/7330404/206368026-ae98d580-e377-48b5-85d5-eb1e22391524.png)
