### PR TITLE
Allow '@set level' to set target equal to user's level

### DIFF
--- a/code/code/cmd/cmd_set.cc
+++ b/code/code/cmd/cmd_set.cc
@@ -651,8 +651,7 @@ mob->getName());
       sendTo("Sorry, only positive numbers allowed.\n\r");
       return;
     }
-    if (parm < GetMaxLevel() ||
-        (parm <= GetMaxLevel() && this == mob)) {
+    if (parm <= GetMaxLevel()) {
       if (hasWizPower(POWER_SET_IMP_POWER)) {
         if (parm2 >= MIN_CLASS_IND && parm2 < MAX_CLASSES) {
           mob->setLevel(classIndT(parm2), parm);
@@ -716,7 +715,7 @@ mob->getName());
         }
       }
     } else {
-      sendTo("You can only set level less than your own.\n\r");
+      sendTo("You can only set level less than or equal to your own.\n\r");
       return;
     }
     if (!mob->isImmortal() && (parm > MAX_MORT) && mob->isPc()) {


### PR DESCRIPTION
Simple change to allow imms to set other players equal to their own level, primarily to allow multiple level 60 immortals. This does mean that once a character is set to level 60 only they themselves will be able to lower their level back down from then on, so raising someone to level 60 should currently be considered "permanent". If this causes issues it can easily be changed.