### PR TITLE
Prevent sacrifice and butcher/skinning from overlapping

### DIFF
--- a/code/code/disc/disc_adv_adventuring.cc
+++ b/code/code/disc/disc_adv_adventuring.cc
@@ -697,6 +697,15 @@ void TThing::skinMe(TBeing *ch, const char *arg)
           FALSE, ch, corpse, 0, TO_CHAR);
     return;
   }
+
+  // Don't allow skinning a corpse that's already being sacrificed, as the
+  // corpse will potentially disappear before skinning is done, causing a crash.
+  if (corpse->isCorpseFlag(CORPSE_SACRIFICE)) {
+    act("$p: That corpse is actively being sacrificed!", false, ch, corpse,
+      nullptr, TO_CHAR);
+    return;
+  }
+
   if (corpse->isCorpseFlag(CORPSE_PC_SKINNING)) {
     act("$p: Someone else is already skinning this.",
         FALSE, ch, corpse, 0, TO_CHAR);

--- a/code/code/disc/disc_adventuring.cc
+++ b/code/code/disc/disc_adventuring.cc
@@ -266,6 +266,15 @@ void TThing::butcherMe(TBeing *ch, const char *arg)
     ch->sendTo(COLOR_OBJECTS, format("You cannot butcher %s.\n\r") % obj->getName());
     return;
   }
+
+  // Don't allow butchering a corpse that's already being sacrificed, as the
+  // corpse will likely disappear before butcher is done, causing a crash.
+  if (corpse->isCorpseFlag(CORPSE_SACRIFICE)) {
+    act("$p: That corpse is actively being sacrificed!", false, ch, corpse,
+      nullptr, TO_CHAR);
+      return;
+  }
+
   if (corpse->isCorpseFlag(CORPSE_NO_REGEN)) {
     // a body part or something
     act("$p: You aren't able to butcher that.",

--- a/code/code/disc/disc_shaman.cc
+++ b/code/code/disc/disc_shaman.cc
@@ -761,6 +761,14 @@ void TBeing::doSacrifice(const char *arg) {
     return;
   }
 
+  // Don't allow sacrificing corpses that are being butchered or skinned. If
+  // sacrifice finishes before those skills a crash will likely occur.
+  if (corpse->isCorpseFlag(CORPSE_PC_BUTCHERING | CORPSE_PC_SKINNING)) {
+    act("That corpse is currently being... processed... by someone else.",
+      false, this, corpse, nullptr, TO_CHAR);
+      return;
+  }
+
   if (corpse->isCorpseFlag(CORPSE_SACRIFICE)) {
     act("Someone must be sacrificing $p currently.", false, this, corpse, nullptr, TO_CHAR);
     return;


### PR DESCRIPTION
If a corpse is being sacrificed at the same time someone else is butchering/skinning it, and the sacrifice finishes first, the next task pulse for the butcherer/skinner will still try to reference the now-deleted corpse, causing a heap-use-after-free crash. These changes prevent those skills from operating simultanesouly on the same corpse.

Fixes #415