### PR TITLE
Fix heap-use-after-free crash in `processAllInput()`

### DIFF
--- a/code/code/sys/connect.cc
+++ b/code/code/sys/connect.cc
@@ -2713,8 +2713,19 @@ void processAllInput()
           continue;
         } 
         if (IS_SET_DELETE(rc, DELETE_VICT)) {
-          delete d->character;
-          d->character = NULL;
+          if (!d->character) continue;
+          
+          if (d == d->character->desc) {
+            vlogf(LOG_BUG, format("d == d->character->desc inside "
+                                  "processAllInput() for %s (Account: %s)") %
+                             d->character->getName() %
+                             (d->account ? d->account->name : "unknown"));
+            delete d->character;
+            d = nullptr;
+          } else {
+            delete d->character;
+            d->character = nullptr;
+          }
           continue;
         }
       } else if (d->str) 


### PR DESCRIPTION
Should fix a heap-use-after-free that's caused some crashes recently. Must be happening when `d` somehow is equal to `d->character->desc` when a player rents out of the game but haven't been able to reproduce it myself.

Fixes #426 (see that issue for stack trace)