### PR TITLE
Fix a crash that occurs when showing objects from incomplete zones

### DIFF
--- a/code/code/cmd/cmd_show.cc
+++ b/code/code/cmd/cmd_show.cc
@@ -595,6 +595,12 @@ void TPerson::doShow(const sstring &argument)
         continue;
 
       obj = read_object(objnx, REAL);
+      if (!obj) {
+        vlogf(LOG_BUG,
+          format("read_object failed in doShow(): zone = %d, vnum = %d") %
+            zone % objnx);
+        continue;
+      }
       buf2 = obj->getNameForShow(false, true, this);
       delete obj;
 

--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -2464,6 +2464,11 @@ TObj *read_object(int nr, readFileTypeT type)
 
   if(/*bootTime &&*/ obj_cache[nr]!=NULL){
     obj = makeNewObj(mapFileToItemType(convertTo<int>(obj_cache[nr]->s["type"])));
+    if (!obj) {
+      vlogf(LOG_BUG,
+        format("makeNewObj failed in read_object: nr = %d, i = %d") % nr % i);
+      return nullptr;
+    }
     obj->number=nr;
     if (!obj->isObjStat(ITEM_STRUNG)) {
       obj->name = obj_index[nr].name;


### PR DESCRIPTION
There were cases where `obj` would end up as `nullptr` when `makeNewObj` or `read_object` failed due to attempting to execute on a vnum from an incomplete zone, causing a null dereference afterwards.