### PR TITLE
Medit string buffers

### DIFF
--- a/code/code/misc/create_mobs.cc
+++ b/code/code/misc/create_mobs.cc
@@ -568,7 +568,7 @@ static void change_mob_long_desc(TBeing *ch, TMonster *mob, editorEnterTypeT typ
   ch->sendTo("\n\r\n\rNew mob long description:\n\r");
   ch->sendTo("Terminate with a ~ ON A SEPERATE LINE. ` on a separate line erases the current long description. Press <ENTER> again to continue.\n\r");
   ch->desc->str = &mob->player.longDescr;
-  ch->desc->max_str = SHORT_STRING_LENGTH;
+  ch->desc->max_str = LONG_STRING_LENGTH;
 }
 
 static void change_mob_desc(TBeing *ch, TMonster *mob, editorEnterTypeT type)

--- a/code/code/misc/structs.h
+++ b/code/code/misc/structs.h
@@ -111,6 +111,8 @@ const int WAIT_SEC     = 4;
 const int WAIT_ROUND   = 4;
 
 const unsigned int MAX_STRING_LENGTH   = 32000;
+const unsigned int SHORT_STRING_LENGTH   = 128;
+const unsigned int LONG_STRING_LENGTH   = 256;
 const int MAX_INPUT_LENGTH    = 1024;
 const int MAX_MESSAGES        =  60;
 const int MAX_ITEMS           = 15;

--- a/code/code/sys/connect.cc
+++ b/code/code/sys/connect.cc
@@ -1957,6 +1957,12 @@ namespace {
 
 void Descriptor::sstring_add(sstring s)
 {
+
+  if (max_str && (int)(str->length() + s.toCRLF().length()) > max_str - 1){
+    writeToQ("Input limit exceeded.  Ignoring!\n\r");
+    return;
+  }
+
   bool terminator = false;
   bool t2 = false;
 
@@ -1993,10 +1999,10 @@ void Descriptor::sstring_add(sstring s)
         return;
       }
       writeToQ(format("Write your %s, use ~ when done, or ` to cancel.\n\r") % sstring(name).uncap());
-      *str += s;
+      *str += s.toCRLF();
     } else {
       // body of idea
-      *str += s;
+      *str += s.toCRLF();
     }
   } else {
     // not a bug/idea
@@ -2353,7 +2359,13 @@ void setPrompts(fd_set out)
       }
 
       if (d->str && (d->prompt_mode != DONT_SEND)) {
-        d->output.push(CommPtr(new UncategorizedComm("-> ")));
+        if (d->max_str) {
+          d->output.push(CommPtr(new UncategorizedComm(format("(%i/%i)-> ")
+                    % d->str->length() 
+                    % (d->max_str - 1))));
+        } else {
+          d->output.push(CommPtr(new UncategorizedComm("-> ")));
+        }
       } else if (d->pagedfile && (d->prompt_mode != DONT_SEND)) {
         sprintf(promptbuf, "\n\r[ %sReturn%s to continue, %s(r)%sefresh, %s(b)%sack, page %s(%d/%d)%s, or %sany other key%s to quit ]\n\r", 
             d->green(),  d->norm(),

--- a/code/code/tests/ValueTraits.h
+++ b/code/code/tests/ValueTraits.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxxtest/TestSuite.h>
-#include "sstring.h"
+#include "code/sys/sstring.h"
 
 namespace CxxTest {
   CXXTEST_TEMPLATE_INSTANTIATION


### PR DESCRIPTION
Addresses #431 

* Prevents Descriptor string from growing over max_str limit (if set)
* Adjusts some string length limits in Medit, moves CRLF process upstream to string creation