### PR TITLE
Update .git-blame-ignore-revs file with hash of codebase format commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
-# To enable the use of this file in your local repo, type the following at the CLI:
-# git config blame.ignoreRevsFile .git-blame-ignore-revs
+# To enable the use of this file in your local repo, type the following at the
+# CLI: git config blame.ignoreRevsFile .git-blame-ignore-revs
+c8e88392aa4c2d97ee7a9a6aa6847169d1fc0ab1


### PR DESCRIPTION
To prevent git blame from seeing the full codebase format commit. See instructions in file.