### PR TITLE
move weapon check to only where needed

### DIFF
--- a/code/code/spec/spec_objs_deikhan_sword.cc
+++ b/code/code/spec/spec_objs_deikhan_sword.cc
@@ -122,12 +122,6 @@ int doHarm(TBeing* ch, TBeing* vict, TObj* o) {
 int deikhanSword(TBeing* vict, cmdTypeT cmd, const char* arg, TObj* o, TObj*) {
   TBeing* ch;
 
-  TBaseWeapon* tWeap;
-  if (!(tWeap = dynamic_cast<TBaseWeapon*>(o)))
-    return FALSE;
-  // damageLevel of the weapon (devastator is 52)
-  int weaponLevel = tWeap->damageLevel();
-
   if (!(ch = dynamic_cast<TBeing*>(o->equippedBy)))
     return FALSE;  // weapon not equipped (carried or on ground)
 
@@ -145,6 +139,12 @@ int deikhanSword(TBeing* vict, cmdTypeT cmd, const char* arg, TObj* o, TObj*) {
   }
 
   if (cmd == CMD_OBJ_HIT && vict) {
+    TBaseWeapon* tWeap;
+    if (!(tWeap = dynamic_cast<TBaseWeapon*>(o)))
+      return FALSE;
+    // damageLevel of the weapon (devastator is 52)
+    int weaponLevel = tWeap->damageLevel();
+
     if (!::number(0, 24) && weaponLevel >= 40) {
       doBlind(ch, vict, o);
       return TRUE;


### PR DESCRIPTION
Moving weapon level check to inside the where we strictly expect to need a weapon CMD_OBJ_HIT. This allows the proc to be used on other objects without error. 