### PR TITLE
Add a GitHub action to build and push images for the test branch, to streamline test server operation

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,33 @@
+name: Build and Publish - Test Server
+on:
+  push:
+    branches:
+      - "test"
+jobs:
+  build_image:
+    runs-on: ubuntu-20.04
+    name: Build Image
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: "true"
+
+      - name: Checkout sneezymud-docker repo
+        uses: actions/checkout@v4
+        with:
+          repository: sneezymud/sneezymud-docker
+          path: sneezymud-docker
+
+      - uses: mr-smithers-excellent/docker-build-push@v5
+        name: Build & Push Docker image
+        with:
+          image: sneezymud/sneezymud:test
+          addLatest: false
+          registry: registry.hub.docker.com
+          dockerfile: sneezymud-docker/docker/Dockerfile
+          buildArgs:
+            - "BRANCH=test"
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
Functions very similarly to the action for the main branch. This way we can push to test, have it automatically build and push the image to the existing sneezymud/sneezymud Docker Hub repo under the 'test' tag, and do `docker pull sneezymud/sneezymud:test` -> `docker-compose up -d` on the test server instead of having to manually build the image on there.

Will require very minor tweaks to the docker-compose.yml file on the test server to use the new image name, which won't even need to be committed.