### PR TITLE
Fix low mvroom command

### DIFF
--- a/code/code/cmd/cmd_low.cc
+++ b/code/code/cmd/cmd_low.cc
@@ -732,7 +732,7 @@ void TMonster::checkMobStats(tinyfileTypeT forReal) {
   }
 #if 0
   if (strlen(getName()) > MAX_NAME_LENGTH-1) {
-    vlogf(LOG_LOW, format("%s (%d) had excessive mob name length.") % 
+    vlogf(LOG_LOW, format("%s (%d) had excessive mob name length.") %
          getName() % mobVnum());
   }
 #endif
@@ -945,7 +945,7 @@ void TObj::checkObjStats() {
           vlogf(LOG_LOW,format("Mega shadow on %s") % getName());
         break;
       } else if (i==(MAX_OBJ_AFFECT-1))
-        vlogf(LOG_LOW,format("obj %s has too many affects to set shadow on it.") % 
+        vlogf(LOG_LOW,format("obj %s has too many affects to set shadow on it.") %
                getName());
     }
 #endif
@@ -1178,9 +1178,9 @@ void mvRoom(TPerson& ch, const sstring& immortal, int block,
   for (auto vnum : vnums) {
     //// room
     db_immo.query(
-      "select vnum, x, y, z, name, description, room_flag, sector, teletime, "
-      "teletarg, telelook, river_speed, river_dir, capacity, height, spec from "
-      "room where owner='%s' and vnum=%i and block=%i",
+      "select vnum, x, y, z, name, description, zone, room_flag, sector, "
+      "teletime, teletarg, telelook, river_speed, river_dir, capacity, height, "
+      "spec from room where owner='%s' and vnum=%i and block=%i",
       immortal.c_str(), vnum, block);
 
     if (db_immo.fetchRow()) {
@@ -1189,17 +1189,17 @@ void mvRoom(TPerson& ch, const sstring& immortal, int block,
       db_beta.query("delete from room where vnum=%i", vnum);
       db_beta.query(
         "insert into room "
-        "(vnum,x,y,z,name,description,room_flag,sector,teletime,teletarg,"
+        "(vnum,x,y,z,name,description,zone,room_flag,sector,teletime,teletarg,"
         "telelook,river_speed,river_dir,capacity,height,spec) values "
-        "(%s,%s,%s,%s, '%s','%s',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+        "(%s,%s,%s,%s,'%s','%s',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
         db_immo["vnum"].c_str(), db_immo["x"].c_str(), db_immo["y"].c_str(),
         db_immo["z"].c_str(), db_immo["name"].c_str(),
-        db_immo["description"].c_str(), db_immo["room_flag"].c_str(),
-        db_immo["sector"].c_str(), db_immo["teletime"].c_str(),
-        db_immo["teletarg"].c_str(), db_immo["telelook"].c_str(),
-        db_immo["river_speed"].c_str(), db_immo["river_dir"].c_str(),
-        db_immo["capacity"].c_str(), db_immo["height"].c_str(),
-        db_immo["spec"].c_str());
+        db_immo["description"].c_str(), db_immo["zone"].c_str(),
+        db_immo["room_flag"].c_str(), db_immo["sector"].c_str(),
+        db_immo["teletime"].c_str(), db_immo["teletarg"].c_str(),
+        db_immo["telelook"].c_str(), db_immo["river_speed"].c_str(),
+        db_immo["river_dir"].c_str(), db_immo["capacity"].c_str(),
+        db_immo["height"].c_str(), db_immo["spec"].c_str());
 
       //// roomextra
       db_beta.query("delete from roomextra where vnum=%i", vnum);

--- a/code/code/misc/enum.cc
+++ b/code/code/misc/enum.cc
@@ -1068,6 +1068,8 @@ int mapWizPowerToFile(wizPowerT att) {
       return 111;
     case POWER_DISTRIBUTE:
       return 112;
+    case POWER_MAP_RECALC:
+      return 113;
     case MAX_POWER_INDEX:
       break;
   }
@@ -1303,6 +1305,8 @@ wizPowerT mapFileToWizPower(int att) {
       return POWER_CLONE;
     case 112:
       return POWER_DISTRIBUTE;
+    case 113:
+      return POWER_MAP_RECALC;
     default:
       break;
   }

--- a/code/code/misc/person.cc
+++ b/code/code/misc/person.cc
@@ -319,8 +319,8 @@ void TPerson::doMap(const sstring& arg) {
   else if (is_abbrev(cmd, "remove") || cmd == "rm")
     doMapRm(rest);
   else if (cmd == "recalc") {
-    if (this->GetMaxLevel() < 60) {
-      sendTo("Nuh-uh.\n\r");
+    if (!this->hasWizPower(POWER_MAP_RECALC)) {
+      sendTo("You haven't been granted this power.");
       return;
     }
     doMapRecalc(convertTo<int>(rest));

--- a/code/code/misc/wiz_powers.cc
+++ b/code/code/misc/wiz_powers.cc
@@ -269,6 +269,7 @@ void setWizPowers(const TBeing* doer, TBeing* ch, const sstring& arg) {
     ch->setWizPower(POWER_REPLACE);
     ch->setWizPower(POWER_RESIZE);
     ch->setWizPower(POWER_NO_LIMITS);
+    ch->setWizPower(POWER_MAP_RECALC);
   } else if (arg == "remgod") {
     ch->remWizPower(POWER_LOW);
     ch->remWizPower(POWER_GOD);
@@ -288,6 +289,7 @@ void setWizPowers(const TBeing* doer, TBeing* ch, const sstring& arg) {
     ch->remWizPower(POWER_REPLACE);
     ch->remWizPower(POWER_RESIZE);
     ch->remWizPower(POWER_NO_LIMITS);
+    ch->remWizPower(POWER_MAP_RECALC);
   } else if (arg == "allpowers") {
     wizPowerT wpt;
     for (wpt = MIN_POWER_INDEX; wpt < MAX_POWER_INDEX; wpt++)
@@ -724,6 +726,8 @@ const sstring getWizPowerName(wizPowerT wpt) {
       return "No Limitations";
     case POWER_CLONE:
       return "Clone";
+    case POWER_MAP_RECALC:
+      return "Recalculate Map";
     case MAX_POWER_INDEX:
       break;
   }

--- a/code/code/misc/wiz_powers.h
+++ b/code/code/misc/wiz_powers.h
@@ -124,6 +124,7 @@ enum wizPowerT {
   POWER_NO_LIMITS,   // this lets gods edit/goto/blah outside thier
                      // blocks/imperia
   POWER_DISTRIBUTE,  // lets you distribute objects on mobs, on mud-wide scale
+  POWER_MAP_RECALC,
 
   MAX_POWER_INDEX
 };


### PR DESCRIPTION
The "zone" field was left out of the query which was causing the inserts to the room table to fail.

```
2023|1217|00:44:35 :: Database: query failed: Field 'zone' doesn't have a default value
2023|1217|00:44:35 :: Database: insert into room (vnum,x,y,z,name,description,room_flag,sector,teletime,teletarg,telelook,river_speed,river_dir,capacity,height,spec) values (35722,-68,14,-2, 'Large Room in the Burrow','   This large room is somewhat cleaner then the other tunnels and warrens in\nthe burrow.  There is another large room to the west.  More rooms lie to the\nnorth, northeast, and east.  A curtain hangs over a large hole in the south\nwall.  The room itself is decorated with shiney objects and colorful, rotting\ntapestries.  A slightly rank smell drifts in from the west.\n',131080,33,0,0,0,0,-1,0,100,0)
```

Tested working in my dev build using the latest backup from the live server. Was able to run `low mvroom vasco 2 35700-35799` and confirm there was no errors in the log this time, and the room entries now show up in the database as expected.