### PR TITLE
Fix mistake in final line of updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=build /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneez
 RUN chown -R sneezy:sneezy /home/sneezy
 EXPOSE 7900
 USER sneezy
-RUN ./sneezy
+CMD ./sneezy


### PR DESCRIPTION
The final line of the updated Dockerfile has a mistake, which this PR fixes.

RUN executes the command during the build of the image, which isn't what we want. CMD executes the command on container startup, which is correct. For some reason RUN still worked when testing in my local Docker setup, but causes a build failure
when done by the Github Action that builds/pushes a new image on commit.