### PR TITLE
Change ownership of copied files using --chown flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ ARG UID=1000
 RUN useradd -m -u "$UID" sneezy && \
   mkdir -p /home/sneezy/code/objs/ && \
   mkdir -p /home/sneezy/lib
+
 WORKDIR /home/sneezy/code
-COPY --from=build /home/sneezy/sneezymud/code/sneezy /home/sneezy/code/sneezy
-COPY --from=build /home/sneezy/sneezymud/lib /home/sneezy/lib
-COPY --from=build /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg
-RUN chown -R sneezy:sneezy /home/sneezy
+
+COPY --from=build --chown=sneezy:sneezy /home/sneezy/sneezymud/code/sneezy /home/sneezy/code/sneezy
+COPY --from=build --chown=sneezy:sneezy /home/sneezy/sneezymud/lib /home/sneezy/lib
+COPY --from=build --chown=sneezy:sneezy /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg
+
 EXPOSE 7900
 USER sneezy
 CMD ./sneezy


### PR DESCRIPTION
With the new order of commands from the previous Dockerfile changes the `RUN chown` line is now copying all the files into its layer, greatly increasing the final size of the image for no reason:
```
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
72f36a5c3972   29 hours ago   CMD ["/bin/sh" "-c" "./sneezy"]                 0B        buildkit.dockerfile.v0
<missing>      29 hours ago   USER sneezy                                     0B        buildkit.dockerfile.v0
<missing>      29 hours ago   EXPOSE map[7900/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      29 hours ago   RUN |1 UID=1000 /bin/sh -c chown -R sneezy:s…   882MB     buildkit.dockerfile.v0
<missing>      29 hours ago   COPY /home/sneezy/sneezymud/code/sneezy.cfg …   737B      buildkit.dockerfile.v0
<missing>      29 hours ago   COPY /home/sneezy/sneezymud/lib /home/sneezy…   3MB       buildkit.dockerfile.v0
<missing>      29 hours ago   COPY /home/sneezy/sneezymud/code/sneezy /hom…   879MB     buildkit.dockerfile.v0
<missing>      29 hours ago   WORKDIR /home/sneezy/code                       0B        buildkit.dockerfile.v0
<missing>      29 hours ago   RUN |1 UID=1000 /bin/sh -c useradd -m -u "$U…   334kB     buildkit.dockerfile.v0
<missing>      29 hours ago   ARG UID=1000                                    0B        buildkit.dockerfile.v0
<missing>      29 hours ago   RUN /bin/sh -c apt-get update && TZ=utc apt-…   110MB     buildkit.dockerfile.v0
<missing>      29 hours ago   ENV DEBIAN_FRONTEND=noninteractive              0B        buildkit.dockerfile.v0
<missing>      8 days ago     /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      8 days ago     /bin/sh -c #(nop) ADD file:5696198fbfd407485…   72.8MB
<missing>      8 days ago     /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
<missing>      8 days ago     /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
<missing>      8 days ago     /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
<missing>      8 days ago     /bin/sh -c #(nop)  ARG RELEASE                  0B
```
Removing the `RUN chown` and using the --chown flag in the COPY commands fixes this issue and is the recommended way to change ownership of copied files anyway.