### PR TITLE
GitHub Actions - Add master branch compilation cache workflow and update test workflow

### DIFF
--- a/.github/workflows/create-master-cache.yml
+++ b/.github/workflows/create-master-cache.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_and_cache:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build and Cache
     steps:
       - name: Checkout this commit
@@ -45,7 +45,7 @@ jobs:
 
       - name: Compile code
         run: |
-          scons -C code -j`nproc` CXX=g++-9 pretty=1 debug=1 sanitize=1 olevel=2 sneezy
+          scons -C code -j`nproc` CXX=g++-9 pretty=0 debug=1 sanitize=1 olevel=2 sneezy
 
       - name: Cache compilation results
         uses: actions/cache/save@v4

--- a/.github/workflows/create-master-cache.yml
+++ b/.github/workflows/create-master-cache.yml
@@ -1,0 +1,66 @@
+# Caches created via actions/cache are not shared between PRs. However, a cache created on a parent branch is accessible by a child branch, including PRs that are attempting to merge to the parent branch. Therefore, if we create a cache of the build files every time changes are pushed to master, new PRs should be able to utilize those during their compilation to enable incremental compilation via scons's .sconsign.dblite file.
+name: Create Master Branch Compilation Cache
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build_and_cache:
+    runs-on: ubuntu-latest
+    name: Build and Cache
+    steps:
+      - name: Checkout this commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          set -e
+          sudo apt-get update
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install --yes --no-install-recommends g++-9 build-essential libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libmariadb-dev scons libcurl4-openssl-dev ca-certificates
+
+      # Used cached build objects from previous version of master, if available, to avoid a full recompilation if no source files changes.
+      - name: Restore cached build objects
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            code/.sconsign.dblite
+            code/objs/libsneezy.a
+            code/objs/main.o
+            code/objs/cmd
+            code/objs/disc
+            code/objs/game
+            code/objs/misc
+            code/objs/obj
+            code/objs/spec
+            code/objs/sys
+            code/objs/task
+          key: ${{ runner.os }}-scons-master-${{ hashFiles('code/code/**.cc', 'code/code/**.h') }}
+          restore-keys: |
+            ${{ runner.os }}-scons-master-
+
+      - name: Compile code
+        run: |
+          scons -C code -j`nproc` CXX=g++-9 pretty=1 debug=1 sanitize=1 olevel=2 sneezy
+
+      - name: Cache compilation results
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            code/.sconsign.dblite
+            code/objs/libsneezy.a
+            code/objs/main.o
+            code/objs/cmd
+            code/objs/disc
+            code/objs/game
+            code/objs/misc
+            code/objs/obj
+            code/objs/spec
+            code/objs/sys
+            code/objs/task
+          # Use a unique key for each cache based on a hash of the source files, as GitHub Actions caches are immutable once created and a new cache won't overwrite the old one if the key is the same. Using restore-keys in the test.yml workflow will still allow the PR to find the most recent cache starting with ${{ runner.os }}-scons-master-.
+          key: ${{ runner.os }}-scons-master-${{ hashFiles('code/code/**.cc', 'code/code/**.h') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build and Test
     steps:
       - name: Checkout this commit
@@ -56,7 +56,7 @@ jobs:
 
       - name: Compile code. Will utilize cached build output from last update to master to perform incremental compilation, if available.
         run: |
-          scons -C code -j`nproc` CXX=g++-9 pretty=1 debug=1 sanitize=1 olevel=2 sneezy
+          scons -C code -j`nproc` CXX=g++-9 pretty=0 debug=1 sanitize=1 olevel=2 sneezy
 
       - name: Verify the game boots up successfully
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,10 @@
 name: Build and Test
 on:
   pull_request:
-    paths:
-      # Only run on changes to files that are actually included in the build or this file itself
-      - "code/code/**.cpp"
-      - "code/code/**.cc"
-      - "code/code/**.h"
-      - ".github/workflows/test.yml"
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Build and Test
     steps:
       - name: Checkout this commit
@@ -18,8 +12,63 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: sudo apt-get update
-      - run: sudo apt-get install software-properties-common
-      - run: sudo apt-get update
-      - run: sudo apt-get install --yes --no-install-recommends build-essential libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libmariadbclient-dev scons libcurl4-openssl-dev
-      - run: scons -C code -j`nproc` -Q pretty=0 debug=1 sanitize=1 olevel=2 sneezy
+      - name: Install dependencies
+        run: |
+          set -e
+          sudo apt-get update
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install --yes --no-install-recommends g++-9 build-essential libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libmariadb-dev scons libcurl4-openssl-dev ca-certificates mariadb-server
+
+      - name: Verify, configure, and seed a test database
+        run: |
+          set -e
+          sudo systemctl is-active --quiet mariadb || sudo systemctl start mariadb
+          sudo mariadb -e "create database sneezy; create database immortal;"
+          sudo mariadb -e "create user 'runner'@'localhost'; grant all on sneezy.* to 'runner'@'localhost'; grant all on immortal.* to 'runner'@'localhost';"
+          for db in immortal sneezy ; do
+            for phase in tables views data ; do
+              [ -d "_Setup-data/sql_$phase/$db" ] || continue
+              for sql in _Setup-data/sql_$phase/$db/*.sql ; do
+                echo "loading '$sql'"
+                mysql $db < $sql
+              done
+            done
+          done
+
+      - name: Restore cached build objects from master branch
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            code/.sconsign.dblite
+            code/objs/libsneezy.a
+            code/objs/main.o
+            code/objs/cmd
+            code/objs/disc
+            code/objs/game
+            code/objs/misc
+            code/objs/obj
+            code/objs/spec
+            code/objs/sys
+            code/objs/task
+          key: ${{ runner.os }}-scons-master-${{ hashFiles('code/code/**.cc', 'code/code/**.h') }}
+          restore-keys: |
+            ${{ runner.os }}-scons-master-
+
+      - name: Compile code. Will utilize cached build output from last update to master to perform incremental compilation, if available.
+        run: |
+          scons -C code -j`nproc` CXX=g++-9 pretty=1 debug=1 sanitize=1 olevel=2 sneezy
+
+      - name: Verify the game boots up successfully
+        run: |
+          set -e
+          ./code/sneezy 2>&1 | tee output.log &
+          SNEEZY_PID=$!
+          while kill -0 $SNEEZY_PID ; do
+            if tail -n 100 output.log | grep -q "Entering game loop." ; then
+              echo "Sneezy started successfully"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Sneezy process crashed"
+          exit 1


### PR DESCRIPTION
This PR solves several issues related to our GitHub Actions.

The current `Build and Test` workflow defined in `.github/workflows/test.yml` simply ensures that the codebase compiles successfully and runs on every submitted PR. 

This is often a waste of time, as it's common for a PR not to modify any source files at all. Use, for instance, the example of a PR that updates some zonefiles. Compiling the code tells us nothing useful in this instance.

However, it's completely possible that a change to a zonefile could still cause the game to crash on boot. With the current configuration of the Build and Test workflow, this would only be discovered after the PR containing the zonefile changes had been approved and merged to master (assuming that the problem wasn't somehow caught before submission or by review/approval).

This problem can be solved as shown in the updated version of `test.yml` in this PR. By including MariaDB server in the packages, we can use the SQL dumps in `_Setup_files` to create and seed a test database within the VM used by the workflow, compile the code, and with a bit of shell scripting confirm that the game successfully boots up completely.

Now, when a PR featuring only non-source changes is submitted, the workflow will confirm that the game can boot utilizing these new changes before allowing merging the PR to master. This will even work for database updates, assuming the SQL dumps are updated as part of the PR.

However, this leaves the issue of having to compile the code for every PR, and even every time a PR is modified - even when no source files were modified. We can solve this problem by adding a new workflow - `create-master-cache.yml` - that runs whenever new code is merged to the master branch.

This new workflow utilizes the `actions/cache` GitHub Action to compile the master branch then save the resulting `.o` files, `libsneezy.a` file, and the `.sconsign.dblite` compilation database created by scons to a repo-specific cache provided for free by GitHub. With these files available during a build, scons will perform incremental compilation, only re-compiling files that have changed since the previous run and even skipping the linking step if possible.

`test.yml` can then be configured to utilize the most recent cache of build objects from the master branch by restoring the cache before beginning compilation, greatly speeding up the build (or skipping it almost entirely, if no source files changed).

I've tested these extensively in my own fork and this submission is the result of many iterations, so I'm very confident they'll work as expected. Here's some links to completed workflows utilizing this PR's code as proof:
- `create-master-cache.yml` compiling and caching the build in response to changes being pushed to master: https://github.com/drewhershey/sneezymud/actions/runs/7573889527/job/20627018125
- `test.yml` utilizing the cached build from master to speed up compilation, creating and seeding a test db, and verifying the game successfully boots:
https://github.com/drewhershey/sneezymud/actions/runs/7573926822/job/20627149859

Nothing will need to change as far as the configuration of the actual GitHub repo settings goes. Since I used the same workflow/job name in the new version of `test.yml`, it will still be set up to run on every PR and be required to pass before the PR can be merged. Because `create-master-cache.yml` is triggered by merges to master, it will run automatically in the background whenever a new PR is merged but won't block anything if it for some reason fails.

Notes:
- The compilation command used by both workflows is identical to that used by the Dockerfile that creates the production Docker images, except that fortify=1 is removed.
    - fortify=1 doesn't actually do anything. It's possible whoever added that meant to use harden=1, which adds many security features to the executable. However, the SConstruct file automatically ignores harden=1 if debug=1 is used, and debug=1 is required for sanitize=1. Changing this behavior would require  updates to the SConstruct file. Assuming we'd rather have ASan active than security features that are very unlikely to be useful, I just removed fortify=1 and didn't replace it with harden=1.

- The `test.yml` workflow now uses `ubuntu-22.04` (the current LTS) as the image for the VM, instead of `ubuntu-20.04`. This is because 20.04 has an older version of MariaDB installed by default that causes conflicts with the newer version we use, and causes the `create and seed db` step (and therefore the entire workflow) to fail.
    - Because Ubuntu 22.04 comes with a newer version of GCC installed by default but our production Docker images still use g++-9 on Ubuntu 20.04, I explicitly install and use g++-9 in these workflows to ensure compatibility. We'll want to remove this when we update the Docker builds to use 22.04.
