### PR TITLE
Fix bug in whittle task that prevented it from working

### DIFF
--- a/code/code/task/task_whittle.cc
+++ b/code/code/task/task_whittle.cc
@@ -327,7 +327,7 @@ bool task_whittleCreateNew(TBeing* ch, sstring tStWood, int tIndex) {
 
   if (ch) {
     for (StuffIter it = ch->stuff.begin(); it != ch->stuff.end(); ++it) {
-      if (isname((*it)->name, tStWood)) {
+      if (isname(tStWood, (*it)->name)) {
         if ((tWood = dynamic_cast<TOrganic*>(*it))) {
           if (tWood->getOType() != ORGANIC_WOOD) {
             tWood = NULL;
@@ -354,7 +354,7 @@ bool task_whittleCreateNew(TBeing* ch, sstring tStWood, int tIndex) {
     for (StuffIter it = ch->stuff.begin(); it != ch->stuff.end();) {
       TThing* tObjTemp = *(it++);
 
-      if (!isname(tObjTemp->name, tStWood))
+      if (!isname(tStWood, tObjTemp->name))
         continue;
 
       if ((tWood = dynamic_cast<TOrganic*>(tObjTemp))) {

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,6 @@
+05-30-24: The whittle skill has been fixed and should now be usable again, at
+          least to whatever extent it was last time it worked.
+
 05-29-24: Prop item loads have been added, so they should start appearing
           in The World more over time. Currently only three zones feature them:
           Gnomish Wonders, Tsirin Prison, and Upper Cimea. And yes, that means


### PR DESCRIPTION
Whittle has been broken for who knows how long. It wasn't ever able to find any materials in the player's inventory no matter what arguments were used to try to start whittling. Turns out it was because the arguments passed to the `isname` function while looking for wood in the inventory were reversed, so a match was never found.

Closes #412.

Side note: I know all the code in and around the two lines I fixed is super ugly and outdated. I'm planning to refactor all of it at some later date, so all I did in this PR was fix the actual bug.