### PR TITLE
Add a new `mvresponse` option to the `low` command

### DIFF
--- a/lib/txt/wiznews
+++ b/lib/txt/wiznews
@@ -1,3 +1,15 @@
+07-02-24: Added 'mvresponse' as a new option to the 'low' command, to allow
+          moving mob responses from the imm database to production. It works
+          just like mvroom/mvmob/etc.
+
+          Currently the only way to actually add/edit mob responses is through
+          the web-based builder tools at https://sneezy-mud.com/build. Once
+          the response has been saved in that tool, the 'low mvresponse' command
+          in-game will activate it.
+
+          This is intentionally not part of mvmob, to allow better auditing of
+          mob responses builders might add before putting them into production.
+
 05-29-24: Prop items are now implemented and available to use in your zonefiles.
           Information about them hasn't been added to the builder books yet.
 


### PR DESCRIPTION
This command will allow imms with appropriate powers to move mob responses from the imm database to the production database. Currently the only way to actually add/edit mob responses is through the web builder tools. Also cleaned up the code for `doLow` a bit.

I intentionally didn't merge this functionality into `mvmob`, as Vasco said it's likely the LOW would want to be able to activate mob responses separately at a chosen time, instead of automatically when moving the mob itself.