### PR TITLE
Removing Elderly Alchemist from trainer list

### DIFF
--- a/lib/zonefiles/100
+++ b/lib/zonefiles/100
@@ -63,11 +63,6 @@ M 0 6845 1 6988          Sorcery Trainer
 E 1 6907 20 1                   Glamourous Ring
 ? 0 3 0 E
 E 1 6909 10 4                   Luxuriant Black Silk Robe
-M 0 6846 1 380          Alchemy Trainer
-? 0 3 0 E
-E 1 6907 20 1                   Glamourous Ring
-? 0 3 0 E
-E 1 6909 10 4                   Luxuriant Black Silk Robe
 
 M 0 237 1 3372               Thief-trainer advanced basic 100
 M 0 262 1 635                Nimble-thief trainer basic 50


### PR DESCRIPTION
removing very confusing zonefile entry regarding quest mob that is no longer trainer