### PR TITLE
Correcting mobs not loading 27100

### DIFF
--- a/lib/zonefiles/27100
+++ b/lib/zonefiles/27100
@@ -92,7 +92,7 @@ M 0 27100 1 27138
 M 0 27100 1 27139
 M 0 27100 1 27140
 
-M 1 27101 1 27105    elvish banshee
+M 0 27101 1 27105    elvish banshee
 
 M 0 27110 1 27131    Zombie in Crypt
 M 0 27110 1 27133
@@ -106,23 +106,23 @@ M 0 27102 1 27145
 M 0 27102 1 27146
 
 A 0 27101 27133         loading drelik randomly
-M 1 27103 1 -99    Drelik
+M 0 27103 1 -99    Drelik
 
-A 1 27100 27104         loading kalus randomly
-M 1 27104 1 -99    Kalus
+A 0 27100 27104         loading kalus randomly
+M 0 27104 1 -99    Kalus
 
 
 A 0 27101 27133         loading dreyfus randomly
-M 1 27105 1 -99    Dreyfus
+M 0 27105 1 -99    Dreyfus
 
-A 1 27100 27104          loading yez randomly
-M 1 27106 1 -99    Yez
+A 0 27100 27104          loading yez randomly
+M 0 27106 1 -99    Yez
 
 A 0 27101 27133         loading krak randomly
-M 1 27107 1 -99    Krak
+M 0 27107 1 -99    Krak
 
 A 0 27101 27133        loading brighton randomly 
-M 1 27108 1 -99    Brighton
+M 0 27108 1 -99    Brighton
 
 M 0 27109 1 27130    skeletal wizard
 S


### PR DESCRIPTION
After noticing that half of the mobs in the zone were not loading, I ran through some boot zone commands to see if I could force them to load. I discovered that some of the mobs would always load, some of them would sometimes load, and some of them would never load.

There were mistakes in some of the IF_FLAG characters for about half of the mob loads.

The area randomizer command in zonefiles is infrequently used, and I'm not that familiar with it.  So I didn't catch the error initially.