### PR TITLE
update spell parser

### DIFF
--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1002,8 +1002,7 @@ class TBeing : public TThing {
     int preCastCheck();
     int preDiscCheck(spellNumT);
     int doCast(const char*);
-    std::tuple<spellNumT, sstring> parseSpellNum(
-      const sstring&) const;  // returns spell and target
+    std::tuple<spellNumT, sstring> parseSpellNum(const sstring&, const sstring& = "") const;
     int parseTarget(spellNumT, char*, TThing** ret);
     int doTrigger(const char*);
     int doStore(const char*);

--- a/code/code/misc/extern.h
+++ b/code/code/misc/extern.h
@@ -233,7 +233,7 @@ extern TPCorpse* pc_corpse_list;
 extern const int spec_skill_array[50];
 unsigned int CountBits(unsigned int);
 extern bool exit_ok(roomDirData*, TRoom**);
-extern spellNumT searchForSpellNum(const sstring& arg, exactTypeT exact);
+extern spellNumT searchForSpellNum(const sstring& arg, exactTypeT exact, bool unique = TRUE);
 extern bool thingsInRoomVis(TThing*, TRoom*);
 extern int get(TBeing*, TThing*, TThing*, getTypeT, bool);
 extern void portal_flag_change(TPortal*, unsigned int, const char*, setRemT);

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,11 @@
+02-25-25: Spell Parser Update
+          Updated the spell parser for mage/shaman spellcasting. The parser
+          now requires a unique match for spells. You might notice you have 
+          to give it a bit more.
+          For instance: 'cast d i' used to match detect invisibility but now
+          requires you to type 'cast de i' to disambiguate it from 
+          dispel invisibility
+
 02-10-25: Summoning group members now ignores summon immunity
 
 02-09-25: Protection Spell Rework


### PR DESCRIPTION
Updated the spell parser for mage/shaman spellcasting. The parser
now requires a unique match for spells. You might notice you have 
to give it a bit more.
For instance: 'cast d i' used to match detect invisibility but now
requires you to type 'cast de i' to disambiguate it from 
dispel invisibility

---

```
H:261 M:900 V:144 E:1,008,628,612 > cast protection from
No such spell exists.

H:261 M:900 V:144 E:1,008,628,612 > cast protection from fire
Although you no longer need to, you begin an incantation to facilitate your spell.
While not absolutely necessary, you trace a rune with your left hand to facilitate your spell in forming.
You touch a fiery red pebble to your forehead.
You glow with a faint red aura for a brief moment.
```

```
H:14 P:100.0 V:333 E:1.000 > cast telepathy blah blah blah
You concentrate intensely on your task.

H:14 P:100.0 V:333 E:1.000 >
With a flourish, you draw the final line of the magic pattern.
You utter the final words of the incantation.
You telepathically send the message, "blah blah blah"
```

