### PR TITLE
Spelltask prompt

### DIFF
--- a/code/code/misc/constants.cc
+++ b/code/code/misc/constants.cc
@@ -1275,6 +1275,7 @@ const char* const auto_name[MAX_AUTO] = {
   "Auto Group",
   "No Map",
   "Map Tags",
+  "Spelltask"
 };
 
 // disc_num, class_nums, practice

--- a/code/code/misc/toggle.cc
+++ b/code/code/misc/toggle.cc
@@ -1211,6 +1211,15 @@ void TBeing::doToggle(const char* arg2) {
       sendTo("You will now automatically group new followers.\n\r");
       SET_BIT(desc->autobits, AUTO_AUTOGROUP);
     }
+  } else if (is_abbrev(arg, "spelltask")) {
+    if (IS_SET(desc->autobits, AUTO_SPELLTASK)) {
+      sendTo("You will no longer see spelltask updates in the prompt.\n\r");
+      REMOVE_BIT(desc->autobits, AUTO_SPELLTASK);
+    } else {
+      sendTo(
+        "You will now see spelltask updates in the prompt.\n\r");
+      SET_BIT(desc->autobits, AUTO_SPELLTASK);
+    }
   } else if (is_abbrev(arg, "list") && hasWizPower(POWER_TOGGLE)) {
     for (togTypeT t = TOG_NONE; t < MAX_TOG_TYPES; t++) {
       if (t == TOG_NONE)

--- a/code/code/misc/toggle.h
+++ b/code/code/misc/toggle.h
@@ -46,8 +46,9 @@ const unsigned int AUTO_NOTELL = (1 << 23);
 const unsigned int AUTO_AUTOGROUP = (1 << 24);
 const unsigned int AUTO_MAP = (1 << 25);
 const unsigned int AUTO_MAPTAGS = (1 << 26);
+const unsigned int AUTO_SPELLTASK = (1 << 27);
 
-const int MAX_AUTO = 27;  // move and change
+const int MAX_AUTO = 28;  // move and change
 
 const unsigned long PLR_BRIEF = (1 << 0);
 const unsigned long PLR_COMPACT = (1 << 1);

--- a/code/code/sys/connect.cc
+++ b/code/code/sys/connect.cc
@@ -2402,6 +2402,12 @@ void setPrompts(fd_set out) {
                 ch->getName() % ch->task->orig_arg);
           }
         }
+      } else {
+        if (ch && ch->spelltask && IS_SET(ch->desc->autobits, AUTO_SPELLTASK)) {
+          sprintf(promptbuf, "\n\r%s : %2d > ", discArray[ch->spelltask->spell]->name, ch->spelltask->rounds);
+          d->output.push(
+            CommPtr(new UncategorizedComm(sstring(promptbuf).cap())));
+        }
       }
 
       if (d->str && (d->prompt_mode != DONT_SEND)) {

--- a/lib/txt/news
+++ b/lib/txt/news
@@ -1,3 +1,8 @@
+03-17-25: New Toggle: "spelltask"
+          - This toggle will show the spell you are casting in the prompt
+          along with the number of rounds remaining until the spell is 
+          complete. This toggle is off by default.
+          
 03-09-25: Restored the old Eyes of Fertuman spell
           - The spell now can be used to find mobs and objects by name
           - The spell has less restrictions on what it can find than it did


### PR DESCRIPTION
New Toggle: "spelltask"
- This toggle will show the spell you are casting in the prompt
along with the number of rounds remaining until the spell is 
complete. This toggle is off by default.

like this:
```
meteor swarm :  3 > H:260 M:766 V:144 E:1,008,788,995  <ENGAGED tradeswoman=perfect> <Elfmage/tank=excellent> >
```