### PR TITLE
Overhaul sit/rest/sleep recovery and polish thief hide skill

### DIFF
--- a/code/code/disc/disc_thief_murder.cc
+++ b/code/code/disc/disc_thief_murder.cc
@@ -259,6 +259,7 @@ int TBeing::doBackstab(const char* argument, TBeing* vict) {
     if (!victim->isPc())
       dynamic_cast<TMonster*>(victim)->US(25);
     addSkillLag(SKILL_BACKSTAB, rc);
+    REMOVE_BIT(specials.affectedBy, AFF_HIDE);
   }
 
   if (IS_SET_DELETE(rc, DELETE_VICT)) {
@@ -319,6 +320,10 @@ int backstab(TBeing* thief, TBeing* victim) {
     return FALSE;
   }
   thief->reconcileHurt(victim, 0.04);
+
+  if (thief->isAffected(AFF_HIDE)) {
+    thief->sendTo("You leap from your hiding spot!\n\r");
+  }
 
   int modifier = 0;
 
@@ -591,6 +596,7 @@ int TBeing::doThroatSlit(const char* argument, TBeing* vict) {
     if (!victim->isPc())
       dynamic_cast<TMonster*>(victim)->US(25);
     addSkillLag(SKILL_THROATSLIT, rc);
+    REMOVE_BIT(specials.affectedBy, AFF_HIDE);
   }
 
   if (IS_SET_DELETE(rc, DELETE_VICT)) {
@@ -660,6 +666,10 @@ int throatSlit(TBeing* thief, TBeing* victim) {
     return FALSE;
   }
   thief->reconcileHurt(victim, 0.04);
+
+  if (thief->isAffected(AFF_HIDE)) {
+    thief->sendTo("You leap from your hiding spot!\n\r");
+  }
 
   int modifier = 0;
 

--- a/code/code/disc/disc_thief_stealth.cc
+++ b/code/code/disc/disc_thief_stealth.cc
@@ -907,38 +907,43 @@ int sneak(TBeing* thief, spellNumT skill) {
 }
 
 int TBeing::doHide() {
-  spellNumT skill = getSkillNum(SKILL_HIDE);
-
-  if (!doesKnowSkill(skill)) {
+  if (!doesKnowSkill(SKILL_HIDE)) {
     sendTo("You know nothing about hiding.\n\r");
-    return FALSE;
+    return 0;
   }
-  int rc = hide(this, skill);
-  if (rc)
-    addSkillLag(skill, rc);
 
-  return rc;
-}
-
-int hide(TBeing* thief, spellNumT skill) {
-  if (thief->fight()) {
-    thief->sendTo("No way!! You simply can NOT hide while fighting!\n\r");
-    return FALSE;
+  if (fight()) {
+    sendTo("No way!! You simply can NOT hide while fighting!\n\r");
+    return 0;
   }
-  thief->sendTo("You attempt to hide yourself.\n\r");
 
-  if (thief->riding) {
-    thief->sendTo("Yeah... right... while mounted\n\r");
-    return FALSE;
+  if (riding) {
+    sendTo("Yeah... right... while mounted\n\r");
+    return 0;
   }
-  int bKnown = thief->getSkillValue(skill);
-  bKnown += thief->plotStat(STAT_CURRENT, STAT_DEX, -40, 15, 0);
 
-  if (thief->bSuccess(bKnown, skill)) {
-    SET_BIT(thief->specials.affectedBy, AFF_HIDE);
+  if (isAffected(AFF_HIDE)) {
+    sendTo("You're already blending into your surroundings.\n\r");
+    return 0;
+  }
+
+  // TODO: Add a separate success check for hiding, after bSuccess passes, that
+  // accounts for circumstantial modifiers, such as: room lighting, terrain
+  // type, stats, etc. The sorts of things that would make hiding easier or
+  // harder regardless of the thief's skill level. bSuccess should only
+  // determine whether the thief has practiced the mechanics of hiding enough to
+  // properly attempt it, while the second check should determine whether the
+  // thief can actually find a good hiding spot in the current environment.
+
+  if (bSuccess(SKILL_HIDE)) {
+    SET_BIT(specials.affectedBy, AFF_HIDE);
+    sendTo("You deftly blend into your surroundings.\n\r");
   } else {
+    sendTo("You fail to blend into your surroundings.\n\r");
   }
-  return TRUE;
+
+  addSkillLag(SKILL_HIDE, 0);
+  return 1;
 }
 
 int TBeing::doSubterfuge(const char* arg) {
@@ -966,7 +971,7 @@ int subterfugeMiss(TBeing* thief, TBeing* victim) {
   if (victim->isPc()) {
     return false;
   }
-  
+
   if (!thief->fight()) {
     if (!thief->isAgile(0)) {
       act("$n tries to put on a show for you and falls on $s face!", FALSE, thief, NULL, victim, TO_VICT);
@@ -1004,7 +1009,7 @@ int subterfugePlayer(TBeing* thief, TBeing* victim) {
   }
 
   return true;
-} 
+}
 
 int subterfugeHit(TBeing* thief, TBeing* victim) {
 // Mob success actions
@@ -1146,7 +1151,7 @@ int subterfugeSuccess(TBeing* thief, TBeing* victim) {
 int subterfugeFail(TBeing* thief, TBeing* victim) {
    thief->sendTo("You fail to execute the subterfuge properly.\n\r");
     if (!thief->isCharismatic() && !victim->isPc()) {
-      act("WUH OH! $N looks pretty pissed off.", FALSE, thief, NULL, victim, TO_CHAR); 
+      act("WUH OH! $N looks pretty pissed off.", FALSE, thief, NULL, victim, TO_CHAR);
       act("$n tried to trick you! $e's gonna pay for that!", FALSE, thief, NULL, victim, TO_VICT);
       act("$n tried to trick $N! $e's gonna pay for that!", FALSE, thief, NULL, victim, TO_NOTVICT);
       thief->setCharFighting(victim);
@@ -1183,8 +1188,8 @@ int subterfuge(TBeing* thief, TBeing* victim) {
   int level = thief->getSkillLevel(SKILL_SUBTERFUGE);
   level = (max (1, (level + (thief->getChaReaction()))));
   int bKnown = thief->getSkillValue(SKILL_SUBTERFUGE);
-  
-  
+
+
 
   if (thief->isNotPowerful(victim, level, SKILL_SUBTERFUGE, SILENT_YES)) {
     act("$N's mind is too powerful to be confused.", FALSE, thief, NULL, victim, TO_CHAR);
@@ -1195,9 +1200,9 @@ int subterfuge(TBeing* thief, TBeing* victim) {
     thief->sendTo("You aren't skilled enough to trick monsters, yet.\n\r");
     return false;
   }
-  
+
   thief->addToMove(-25);
-  
+
   // bSuccess check
   if (!thief->bSuccess(bKnown, SKILL_SUBTERFUGE)) {
     return subterfugeFail(thief, victim);
@@ -1254,4 +1259,63 @@ int spy(TBeing* thief) {
   aff.bitvector = 0;
   thief->affectTo(&aff, -1);
   return TRUE;
+}
+
+bool willBreakHide(cmdTypeT tCmd) {
+  switch (tCmd) {
+    case CMD_BACKSTAB:
+    case CMD_SLIT:
+    case CMD_LOOK:
+    case CMD_SCORE:
+    case CMD_TROPHY:
+    case CMD_INVENTORY:
+    case CMD_HELP:
+    case CMD_WHO:
+    case CMD_NEWS:
+    case CMD_EQUIPMENT:
+    case CMD_WEATHER:
+    case CMD_SAVE:
+    case CMD_EXITS:
+    case CMD_TIME:
+    case CMD_HIDE:
+    case CMD_SNEAK:
+    case CMD_QUEST:
+    case CMD_LEVELS:
+    case CMD_WIZLIST:
+    case CMD_CONSIDER:
+    case CMD_CREDITS:
+    case CMD_TITLE:
+    case CMD_ATTRIBUTE:
+    case CMD_WORLD:
+    case CMD_SPY:
+    case CMD_CONCEAL:
+    case CMD_REST:
+    case CMD_SIT:
+    case CMD_STAND:
+    case CMD_SIGN:
+    case CMD_PTELL:
+    case CMD_EAT:
+    case CMD_DRINK:
+    case CMD_CLS:
+    case CMD_PROMPT:
+    case CMD_ALIAS:
+    case CMD_CLEAR:
+    case CMD_MOTD:
+    case CMD_PRACTICE:
+    case CMD_HISTORY:
+    case CMD_EVALUATE:
+    case CMD_DISGUISE:
+    case CMD_EMAIL:
+    case CMD_AFK:
+    case CMD_SPELLS:
+    case CMD_COMPARE:
+    case CMD_ZONES:
+    case CMD_NEWBIE:
+    case CMD_REQUEST:
+    case CMD_IGNORE:
+    case MAX_CMD_LIST:
+      return false;
+    default:
+      return true;
+  }
 }

--- a/code/code/disc/disc_thief_stealth.h
+++ b/code/code/disc/disc_thief_stealth.h
@@ -15,7 +15,6 @@ class CDStealth : public CDiscipline {
 
 int conceal(TBeing*, TBeing*);
 int sneak(TBeing*, spellNumT);
-int hide(TBeing*, spellNumT);
 int subterfuge(TBeing*, TBeing*);
 int subterfugeFail(TBeing*, TBeing*);
 int subterfugeSuccess(TBeing*, TBeing*);

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1049,6 +1049,7 @@ class TBeing : public TThing {
     void failSleep(TBeing*);
     void failPara(TBeing*);
     bool inGroup(const TBeing&) const;
+    bool hasGroupmateInRoom() const;
     int inCamp() const;
     int bumpHead(int*);
     virtual int bumpHeadDoor(roomDirData*, int*);

--- a/code/code/misc/extern.h
+++ b/code/code/misc/extern.h
@@ -389,6 +389,7 @@ extern const sstring getSectorDescrColor(sectorTypeT, TRoom*);
 extern spellNumT mapWeaponT(weaponT w);
 extern spellNumT getWtype_kluge(weaponT t);
 extern const std::vector<uint16_t> CLASS_BITVALUES;
+extern bool willBreakHide(cmdTypeT);
 
 // these needs C++ linkage to avoid conflict with functions in stdlib
 extern int remove(TBeing*, TThing*);

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -43,6 +43,7 @@
 #include "game_crazyeights.h"
 #include "game_drawpoker.h"
 #include "configuration.h"
+#include "task_regen_common.h"
 
 void TBeing::goThroughPortalMsg(const TPortal* o) const {
   char buf[256];
@@ -1193,7 +1194,7 @@ int TBeing::moveGroup(dirTypeT dir) {
         } else {
           followData* found = NULL;
           for (found = followers; found && found->follower != tft;
-               found = found->next)
+            found = found->next)
             ;
           if (!found) {
             vlogf(LOG_BUG,
@@ -1477,7 +1478,7 @@ int TBeing::displayMove(dirTypeT dir, int was_in, int total) {
   --(*this);
   *rp1 += *this;
   for (StuffIter it = rp1->stuff.begin(); it != rp1->stuff.end() && (t = *it);
-       ++it) {
+    ++it) {
     TBeing* ch = dynamic_cast<TBeing*>(t);
     if (!ch)
       continue;
@@ -1565,7 +1566,7 @@ int TBeing::displayMove(dirTypeT dir, int was_in, int total) {
     sprintf(tmp + strlen(tmp), " [%d]", total);
 
   for (StuffIter it = rp2->stuff.begin(); it != rp2->stuff.end() && (t = *it);
-       ++it) {
+    ++it) {
     TBeing* tbt = dynamic_cast<TBeing*>(t);
     if (!tbt)
       continue;
@@ -1671,14 +1672,14 @@ int TBeing::genericMovedIntoRoom(TRoom* rp, int was_in,
   int groupcount = 0;  // used to make mobs not go superaggro on groups - dash
 
   for (StuffIter it = roomp->stuff.begin();
-       it != roomp->stuff.end() && (t3 = *it); ++it) {
+    it != roomp->stuff.end() && (t3 = *it); ++it) {
     TBeing* tbt = dynamic_cast<TBeing*>(t3);
     if (tbt && inGroup(*tbt))
       groupcount++;
   }
   if (was_in != -1) {
     for (StuffIter it = real_roomp(was_in)->stuff.begin();
-         it != real_roomp(was_in)->stuff.end() && (t3 = *it); ++it) {
+      it != real_roomp(was_in)->stuff.end() && (t3 = *it); ++it) {
       TBeing* tbt = dynamic_cast<TBeing*>(t3);
       if (tbt && inGroup(*tbt))
         groupcount++;
@@ -1717,7 +1718,8 @@ int TBeing::genericMovedIntoRoom(TRoom* rp, int was_in,
       continue;
 
     if (was_in != -1) {
-      // was_in (room number) is passed as a pointer - receivers cast back to int
+      // was_in (room number) is passed as a pointer - receivers cast back to
+      // int
       rc = tmons->checkSpec(this, CMD_MOB_MOVED_INTO_ROOM, "",
         reinterpret_cast<TThing*>(static_cast<uintptr_t>(was_in)));
       if (rc) {
@@ -2269,7 +2271,7 @@ bool has_key(TBeing* ch, int key) {
 
   // check inv
   for (StuffIter it = ch->stuff.begin(); it != ch->stuff.end() && (t = *it);
-       ++it) {
+    ++it) {
     o = dynamic_cast<TObj*>(t);
     if (!o)
       continue;
@@ -2280,7 +2282,7 @@ bool has_key(TBeing* ch, int key) {
     if (!ring)
       continue;
     for (StuffIter it = ring->stuff.begin();
-         it != ring->stuff.end() && (t2 = *it); ++it) {
+      it != ring->stuff.end() && (t2 = *it); ++it) {
       o = dynamic_cast<TObj*>(t2);
       if (!o)
         continue;
@@ -2543,7 +2545,7 @@ int TBeing::portalLeaveCheck(char* argum, cmdTypeT cmd) {
 
   one_argument(argum, arg, cElements(arg));
   for (StuffIter it = roomp->stuff.begin();
-       it != roomp->stuff.end() && (t = *it); ++it) {
+    it != roomp->stuff.end() && (t = *it); ++it) {
     o = dynamic_cast<TPortal*>(t);
     if (o && (((cmd == CMD_LEAVE) && (!*arg || isname(arg, o->name))) ||
                ((cmd == CMD_EXITS) && *arg && isname(arg, o->name)))) {
@@ -2745,8 +2747,7 @@ void TBeing::doSit(const sstring& argument) {
         act("You sit down.", FALSE, this, 0, 0, TO_CHAR);
         act("$n sits down.", TRUE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_SITTING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * regenTime());
+        startRegenTask(*this, RegenTaskType::SIT);
         break;
       case POSITION_SITTING:
         sendTo("You're sitting already.\n\r");
@@ -2758,8 +2759,7 @@ void TBeing::doSit(const sstring& argument) {
         act("You stop resting, and sit up.", FALSE, this, 0, 0, TO_CHAR);
         act("$n stops resting.", TRUE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_SITTING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * regenTime());
+        startRegenTask(*this, RegenTaskType::SIT);
         break;
       case POSITION_SLEEPING:
         act("You have to wake up first.", FALSE, this, 0, 0, TO_CHAR);
@@ -2776,8 +2776,7 @@ void TBeing::doSit(const sstring& argument) {
         act("$n stops floating around, and sits down.", TRUE, this, 0, 0,
           TO_ROOM);
         setPosition(POSITION_SITTING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * regenTime());
+        startRegenTask(*this, RegenTaskType::SIT);
         break;
     }
   } else {
@@ -2845,8 +2844,7 @@ void TBeing::doRest(const sstring& argument) {
           0, 0, TO_CHAR);
         act("$n sits down, leans back and rests.", TRUE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_RESTING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * regenTime());
+        startRegenTask(*this, RegenTaskType::REST);
         break;
       case POSITION_SITTING:
         if (removeAllCasinoGames())
@@ -2856,8 +2854,7 @@ void TBeing::doRest(const sstring& argument) {
           TO_CHAR);
         act("$n leans back and rests.", TRUE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_RESTING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * regenTime());
+        startRegenTask(*this, RegenTaskType::REST);
         break;
       case POSITION_RESTING:
         act("You are already resting.", FALSE, this, 0, 0, TO_CHAR);
@@ -2873,8 +2870,7 @@ void TBeing::doRest(const sstring& argument) {
           FALSE, this, 0, 0, TO_CHAR);
         act("$n stops floating around, and rests.", FALSE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_SITTING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * regenTime());
+        startRegenTask(*this, RegenTaskType::REST);
         break;
     }
   } else {
@@ -2941,16 +2937,14 @@ void TBeing::doSleep(const sstring& argument) {
         sendTo("You go to sleep.\n\r");
         act("$n lies down and falls asleep.", TRUE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_SLEEPING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, regenTime());
+        startRegenTask(*this, RegenTaskType::SLEEP);
         break;
       case POSITION_CRAWLING:
       case POSITION_SITTING:
         sendTo("You go to sleep.\n\r");
         act("$n lies down and falls asleep.", TRUE, this, 0, 0, TO_ROOM);
         setPosition(POSITION_SLEEPING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, regenTime());
+        startRegenTask(*this, RegenTaskType::SLEEP);
         if (removeAllCasinoGames())
           break;
         break;
@@ -2966,8 +2960,7 @@ void TBeing::doSleep(const sstring& argument) {
         act("$n stops floating around, and lie down to sleep.", TRUE, this, 0,
           0, TO_ROOM);
         setPosition(POSITION_SLEEPING);
-        if (isPc())
-          start_task(this, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, regenTime());
+        startRegenTask(*this, RegenTaskType::SLEEP);
         break;
     }
   } else {

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -98,63 +98,6 @@ void TBeing::incorrectCommand() const {
          red() % norm());
 }
 
-bool willBreakHide(cmdTypeT tCmd, bool isPre) {
-  switch (tCmd) {
-    case CMD_BACKSTAB:
-      return (isPre ? false : true);
-    case CMD_SLIT:
-      return (isPre ? false : true);
-
-    case CMD_LOOK:
-    case CMD_SCORE:
-    case CMD_TROPHY:
-    case CMD_INVENTORY:
-    case CMD_HELP:
-    case CMD_WHO:
-    case CMD_NEWS:
-    case CMD_EQUIPMENT:
-    case CMD_WEATHER:
-    case CMD_SAVE:
-    case CMD_EXITS:
-    case CMD_TIME:
-    case CMD_HIDE:
-    case CMD_SNEAK:
-    case CMD_QUEST:
-    case CMD_LEVELS:
-    case CMD_WIZLIST:
-    case CMD_CONSIDER:
-    case CMD_CREDITS:
-    case CMD_TITLE:
-    case CMD_ATTRIBUTE:
-    case CMD_WORLD:
-    case CMD_SPY:
-    case CMD_CLS:
-    case CMD_PROMPT:
-    case CMD_ALIAS:
-    case CMD_CLEAR:
-    case CMD_MOTD:
-    case CMD_PRACTICE:
-    case CMD_HISTORY:
-    case CMD_EVALUATE:
-    case CMD_DISGUISE:
-    case CMD_EMAIL:
-    case CMD_AFK:
-    case CMD_SPELLS:
-    case CMD_COMPARE:
-    case CMD_ZONES:
-    case CMD_NEWBIE:
-    case CMD_REQUEST:
-    case CMD_IGNORE:
-    case MAX_CMD_LIST:
-      return false;
-
-    default:
-      return true;
-  }
-
-  return true;
-}
-
 extern int handleMobileResponse(TBeing*, cmdTypeT, const sstring&);
 
 // returns DELETE_THIS if this should be nuked
@@ -352,9 +295,6 @@ int TBeing::doCommand(cmdTypeT cmd, const sstring& argument, TThing* vict,
             format("%s %s%s") % name % commandArray[cmd]->name % newarg);
       }
     }
-
-    if (IS_SET(specials.affectedBy, AFF_HIDE) && willBreakHide(cmd, true))
-      REMOVE_BIT(specials.affectedBy, AFF_HIDE);
 
     rc = triggerSpecial(NULL, cmd, newarg.c_str());
     if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -2063,10 +2003,10 @@ int TBeing::parseCommand(const sstring& orig_arg, bool typedIn, bool doAlias) {
     return FALSE;
   }
 
-  if (IS_SET(specials.affectedBy, AFF_HIDE) && cmd != CMD_BACKSTAB)
+  if (isAffected(AFF_HIDE) && willBreakHide(cmd)) {
+    sendTo("You move from your hiding spot.\n\r");
     REMOVE_BIT(specials.affectedBy, AFF_HIDE);
-  if (IS_SET(specials.affectedBy, AFF_HIDE) && cmd != CMD_SLIT)
-    REMOVE_BIT(specials.affectedBy, AFF_HIDE);
+  }
 
   if (getCaptiveOf()) {
     if (!sameRoom(*getCaptiveOf())) {

--- a/code/code/misc/room.cc
+++ b/code/code/misc/room.cc
@@ -7,10 +7,15 @@
 // room.cc
 
 #include "room.h"
+#include <algorithm>
+#include <functional>
 #include "extern.h"
 #include "being.h"
 #include "monster.h"
+#include "obj.h"
 #include "weather.h"
+#include "obj_organic.h"
+#include "obj_flame.h"
 
 bool TRoom::isCitySector() const {
   switch (getSectorType()) {
@@ -470,6 +475,25 @@ int TRoom::getLight() {
 }
 
 TThing* TRoom::findInRoom(const std::function<bool(TThing*)>& predicate) {
-  auto found = std::find_if(stuff.begin(), stuff.end(), predicate);
+  auto found = std::ranges::find_if(stuff, predicate);
   return found != stuff.end() ? *found : nullptr;
+}
+
+const TThing* TRoom::findInRoom(
+  const std::function<bool(const TThing*)>& predicate) const {
+  auto found = std::ranges::find_if(stuff, predicate);
+  return found != stuff.end() ? *found : nullptr;
+}
+
+bool TRoom::hasCampfire() const {
+  return std::ranges::any_of(stuff, [](const TThing* obj) {
+    // Check for burning logs
+    if (const auto* log = dynamic_cast<const TOrganic*>(obj)) {
+      return log->itemType() == ITEM_RAW_ORGANIC &&
+             log->isObjStat(ITEM_BURNING);
+    }
+
+    // Check for flame objects
+    return dynamic_cast<const TFFlame*>(obj) != nullptr;
+  });
 }

--- a/code/code/misc/room.h
+++ b/code/code/misc/room.h
@@ -262,6 +262,8 @@ class TRoom : public TThing {
     int pitchBlackDark() { return getLight() <= 0; }
 
     TThing* findInRoom(const std::function<bool(TThing*)>&);
+    const TThing* findInRoom(const std::function<bool(const TThing*)>&) const;
+    bool hasCampfire() const;
 };
 
 const int ZONE_MAX_TIME = 50;

--- a/code/code/misc/utility.cc
+++ b/code/code/misc/utility.cc
@@ -183,48 +183,53 @@ time_info_data* TBeing::age() const {
   return (&player_age);
 }
 
-bool TBeing::inGroup(const TBeing& tbt) const {
-  if ((this == &tbt) || (&tbt == dynamic_cast<const TBeing*>(riding)) ||
-      (&tbt == dynamic_cast<const TBeing*>(rider)))
-    return TRUE;
-
-  if (!isAffected(AFF_GROUP))
-    return FALSE;
-
-  TBeing* tbt2 = dynamic_cast<TBeing*>(tbt.rider);
-  if (tbt2 && inGroup(*tbt2))
-    return TRUE;
-
-  if (!tbt.isAffected(AFF_GROUP))
-    return FALSE;
-
-  if (!master && !tbt.master)
-    return FALSE;
-
-  if (this == tbt.master)
-    return TRUE;
-
-  if (master == &tbt)
-    return TRUE;
-
-  if (master == tbt.master) {
-    return TRUE;
+bool TBeing::inGroup(const TBeing& being) const {
+  // Self, mount, and rider are always considered "in group" regardless of
+  // AFF_GROUP state. Several mechanics (group buff spells, regen helpers)
+  // rely on a character always being part of their own group.
+  if (this == &being || &being == riding || &being == rider) {
+    return true;
   }
 
-  return FALSE;
+  if (!isAffected(AFF_GROUP)) {
+    return false;
+  }
+
+  if (const auto* riderBeing = dynamic_cast<const TBeing*>(being.rider);
+    riderBeing && inGroup(*riderBeing)) {
+    return true;
+  }
+
+  if (!being.isAffected(AFF_GROUP)) {
+    return false;
+  }
+
+  return this == being.master || master == &being ||
+         (master && master == being.master);
 }
 
-unsigned int TBeing::numberInGroupInRoom() const {
-  TThing* t = NULL;
-  unsigned int count = 0;
-
-  for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (t = *it); ++it) {
-    TBeing* tbt = dynamic_cast<TBeing*>(t);
-    if (tbt && inGroup(*tbt))
-      count++;
+namespace {
+  bool thingInGroup(const TBeing& being, const TThing& thing) {
+    if (const auto* beingThing = dynamic_cast<const TBeing*>(&thing)) {
+      return being.inGroup(*beingThing);
+    }
+    return false;
   }
-  return count;
+}  // namespace
+
+unsigned int TBeing::numberInGroupInRoom() const {
+  if (!roomp) {
+    return 0;
+  }
+
+  return std::ranges::count_if(roomp->stuff,
+    [this](const TThing* thing) { return thingInGroup(*this, *thing); });
+}
+
+bool TBeing::hasGroupmateInRoom() const {
+  // Self always counts as one group member via inGroup; require at least
+  // one other group member in the room before granting "groupmate" bonuses.
+  return numberInGroupInRoom() > 1;
 }
 
 bool getall(const char* name, char* newname) {
@@ -1898,7 +1903,7 @@ bool TBeing::checkBusy(const sstring& buf) const {
     sendTo("You are still busy orienting yourself.");
   }
 #if 0
-  int tmpnum = (hitsPerRound ? (int) (cantHit/hitsPerRound + 1) : 1000000); 
+  int tmpnum = (hitsPerRound ? (int) (cantHit/hitsPerRound + 1) : 1000000);
   sendTo(format(" (Roughly %d round%s to go)\n\r") % tmpnum % (tmpnum > 1) ? "s" : "");
 #else
   float tmpnum = (hitsPerRound ? (cantHit / hitsPerRound) : 1000000);

--- a/code/code/obj/obj_bed.cc
+++ b/code/code/obj/obj_bed.cc
@@ -7,6 +7,7 @@
 #include "games.h"
 #include "obj_bed.h"
 #include "obj_base_corpse.h"
+#include "task_regen_common.h"
 
 TBed::TBed() :
   TObj(),
@@ -254,8 +255,7 @@ void TBed::sitMe(TBeing* ch) {
       act("$n crawls into the $o and sits upon it.", TRUE, ch, this, 0,
         TO_ROOM);
       ch->setPosition(POSITION_SITTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SIT);
       ch->mount(this);
       break;
     case POSITION_STANDING:
@@ -267,8 +267,7 @@ void TBed::sitMe(TBeing* ch) {
         act("$n sits down on the $o.", TRUE, ch, this, 0, TO_ROOM);
       }
       ch->setPosition(POSITION_SITTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SIT);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -287,8 +286,7 @@ void TBed::sitMe(TBeing* ch) {
           TO_ROOM);
       }
       ch->setPosition(POSITION_SITTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SIT);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -304,8 +302,7 @@ void TBed::sitMe(TBeing* ch) {
       act("$n stops floating around, and sits down on the $o.", TRUE, ch, this,
         0, TO_ROOM);
       ch->setPosition(POSITION_SITTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SIT, "", 350, 0, 1, 0, 4 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SIT);
       break;
   }
 }
@@ -331,8 +328,7 @@ void TBed::restMe(TBeing* ch) {
       act("$n crawls into the $o and rests $s tired bones.", TRUE, ch, this, 0,
         TO_ROOM);
       ch->setPosition(POSITION_RESTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::REST);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -348,8 +344,7 @@ void TBed::restMe(TBeing* ch) {
           TO_ROOM);
       }
       ch->setPosition(POSITION_RESTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::REST);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -367,8 +362,7 @@ void TBed::restMe(TBeing* ch) {
       }
 
       ch->setPosition(POSITION_RESTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::REST);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -389,8 +383,7 @@ void TBed::restMe(TBeing* ch) {
       act("$n stops floating around, and rests on the $o.", FALSE, ch, this, 0,
         TO_ROOM);
       ch->setPosition(POSITION_RESTING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_REST, "", 350, 0, 1, 0, 2 * ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::REST);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -417,8 +410,7 @@ void TBed::sleepMe(TBeing* ch) {
       act("$n crawls into the $o and goes to sleep.", TRUE, ch, this, 0,
         TO_ROOM);
       ch->setPosition(POSITION_SLEEPING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SLEEP);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -429,8 +421,7 @@ void TBed::sleepMe(TBeing* ch) {
       act("$n lies down and falls asleep in the $o.", TRUE, ch, this, 0,
         TO_ROOM);
       ch->setPosition(POSITION_SLEEPING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SLEEP);
       if (ch->riding != this)
         ch->mount(this);
       break;
@@ -440,8 +431,7 @@ void TBed::sleepMe(TBeing* ch) {
       act("$n leans back and falls asleep in the $o.", TRUE, ch, this, 0,
         TO_ROOM);
       ch->setPosition(POSITION_SLEEPING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SLEEP);
       if (ch->riding != this)
         ch->mount(this);
       if (ch->checkBlackjack())
@@ -459,8 +449,7 @@ void TBed::sleepMe(TBeing* ch) {
       act("$n stops floating around, and lies down in the $o.", TRUE, ch, this,
         0, TO_CHAR);
       ch->setPosition(POSITION_SLEEPING);
-      if (ch->isPc())
-        start_task(ch, 0, 0, TASK_SLEEP, "", 350, 0, 1, 0, ch->regenTime());
+      startRegenTask(*ch, RegenTaskType::SLEEP);
       if (ch->riding != this)
         ch->mount(this);
       break;

--- a/code/code/task/task_regen_common.cc
+++ b/code/code/task/task_regen_common.cc
@@ -1,0 +1,310 @@
+#include "task_regen_common.h"
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <unordered_map>
+
+#include "ansi.h"
+#include "being.h"
+#include "connect.h"
+#include "defs.h"
+#include "enum.h"
+#include "parse.h"
+#include "room.h"
+#include "spells.h"
+#include "sstring.h"
+#include "task.h"
+
+namespace {
+
+  struct BonusConfig {
+      std::function<bool(const TBeing&)> test;
+      int amount{1};
+      const char* message;
+      const char* startupMessage;
+  };
+
+  const std::array bonusChecks = std::to_array<BonusConfig>({
+    {
+      .test = [](const TBeing& ch) { return ch.inCamp(); },
+      .message = "Being in a camp makes you feel better.\n\r",
+      .startupMessage = "<o>being in a camp<1>",
+    },
+    {
+      .test = [](const TBeing& ch) { return ch.hasGroupmateInRoom(); },
+      .message = "Having a companion to guard your back puts you at ease.\n\r",
+      .startupMessage = "<p>having a companion to guard your back<1>",
+    },
+    {
+      .test =
+        [](const TBeing& ch) { return ch.roomp && ch.roomp->hasCampfire(); },
+      .message = "The crackling fire warms your body and spirits.\n\r",
+      .startupMessage = "<r>the warmth of a campfire<1>",
+    },
+    {
+      .test = [](const TBeing& ch) { return ch.isAffected(AFF_HIDE); },
+      .message = "Being hidden from view helps you relax and recover.\n\r",
+      .startupMessage = "<k>being hidden from view<1>",
+    },
+    {
+      .test = [](const TBeing& ch) { return ch.homeTurf(); },
+      .message = "The familiar surroundings put you at ease.\n\r",
+      .startupMessage = "<g>familiar surroundings<1>",
+    },
+    {
+      .test = [](const TBeing& ch) { return ch.backgroundBonus(); },
+      .message = "Your experience helps you find a comfortable spot.\n\r",
+      .startupMessage = "<G>your experience in this terrain<1>",
+    },
+  });
+
+  // TODO(Cirius): Convert these to global tweaks
+  constexpr int MANA_GAIN_PER_TICK = 1;
+  constexpr double PIETY_GAIN_PER_TICK = 0.10;
+
+  constexpr int MESSAGE_CHANCE = 20;
+
+  int processRegen(TBeing& ch, int pulse, int regenMod, bool silent) {
+    ch.task->calcNextUpdate(pulse, regenMod * ch.regenTime());
+
+    if (ch.task->status) {
+      ch.updatePos();
+      ch.task->status = 0;
+      return 1;
+    }
+
+    if (!ch.roomp || ch.roomp->isRoomFlag(ROOM_NO_HEAL)) {
+      return 1;
+    }
+
+    int regenAmt = 1;
+
+    for (const auto& bonus : bonusChecks) {
+      if (bonus.test(ch)) {
+        regenAmt += bonus.amount;
+
+        if (!silent && percentChance(MESSAGE_CHANCE)) {
+          ch.sendTo(bonus.message);
+        }
+      }
+    }
+
+    ch.addToHit(regenAmt);
+
+    if (ch.getMove() < ch.moveLimit()) {
+      ch.addToMove(std::min(regenAmt, ch.moveLimit() - ch.getMove()));
+    }
+
+    ch.addToMana(MANA_GAIN_PER_TICK);
+    ch.addToPiety(PIETY_GAIN_PER_TICK);
+    ch.updatePos();
+
+    if (ch.desc) {
+      constexpr auto flags = CHANGED_HP | CHANGED_MANA | CHANGED_LIFEFORCE |
+                             CHANGED_PIETY | CHANGED_MOVE;
+      if (ch.ansi()) {
+        ch.desc->updateScreenAnsi(flags);
+      } else if (ch.vt100()) {
+        ch.desc->updateScreenVt100(flags);
+      }
+    }
+
+    return 1;
+  }
+
+  struct RegenTaskConfig {
+      taskTypeT taskType;
+      std::function<bool(TBeing&, cmdTypeT, const char*)> cmdHandler;
+      std::function<void(TBeing&)> applyFightingPenalty;
+      int tickRateMultiplier{1};
+      bool silent{false};
+      const char* description;
+  };
+
+  const std::unordered_map<RegenTaskType, RegenTaskConfig> configs{
+    {
+      RegenTaskType::REST,
+      {
+        .taskType = TASK_REST,
+        .cmdHandler = [](TBeing& ch, cmdTypeT cmd, const char* arg) -> bool {
+          switch (cmd) {
+            case CMD_ABORT:
+            case CMD_STOP:
+            case CMD_STAND:
+              ch.stopTask();
+              ch.doStand();
+              break;
+            case CMD_SLEEP:
+              ch.stopTask();
+              ch.doSleep(arg);
+              break;
+            case CMD_SIT:
+              ch.stopTask();
+              ch.doSit(arg);
+              break;
+            case CMD_REST:
+              ch.sendTo("You are already nice and comfy.\n\r");
+              break;
+            default:
+              return false;
+          }
+          return true;
+        },
+        .applyFightingPenalty =
+          [](TBeing& ch) {
+            ch.cantHit += ch.loseRound(1);
+            if (!::number(0, 2)) {
+              ch.cantHit += ch.loseRound(1);
+            }
+          },
+        .tickRateMultiplier = 2,
+        .description = "resting",
+      },
+    },
+    {
+      RegenTaskType::SLEEP,
+      {
+        .taskType = TASK_SLEEP,
+        .cmdHandler = [](TBeing& ch, cmdTypeT cmd, const char* arg) -> bool {
+          switch (cmd) {
+            case CMD_ABORT:
+            case CMD_STOP:
+            case CMD_STAND:
+            case CMD_WAKE:
+              ch.stopTask();
+              ch.doWake(arg);
+              break;
+            case CMD_SLEEP:
+              ch.sendTo("You start to dream about sleeping.\n\r");
+              break;
+            default:
+              return false;
+          }
+          return true;
+        },
+        .applyFightingPenalty =
+          [](TBeing& ch) {
+            ch.cantHit += ch.loseRound(1);
+            if (!::number(0, 1)) {
+              ch.cantHit += ch.loseRound(1);
+            }
+          },
+        .silent = true,
+        .description = "sleeping",
+      },
+    },
+    {
+      RegenTaskType::SIT,
+      {
+        .taskType = TASK_SIT,
+        .cmdHandler = [](TBeing& ch, cmdTypeT cmd, const char* arg) -> bool {
+          switch (cmd) {
+            case CMD_ABORT:
+            case CMD_STOP:
+            case CMD_STAND:
+              ch.stopTask();
+              ch.doStand();
+              break;
+            case CMD_REST:
+              ch.stopTask();
+              ch.doRest(arg);
+              break;
+            case CMD_SLEEP:
+              ch.stopTask();
+              ch.doSleep(arg);
+              break;
+            case CMD_SIT:
+              ch.sendTo(
+                "You look around and notice your butt is already on "
+                "something.\n\r");
+              break;
+            default:
+              return false;
+          }
+          return true;
+        },
+        .applyFightingPenalty =
+          [](TBeing& ch) {
+            if (!::number(0, 2)) {
+              ch.cantHit += ch.loseRound(1);
+            }
+          },
+        .tickRateMultiplier = 4,
+        .description = "sitting",
+      },
+    },
+  };
+
+}  // namespace
+
+void sendRegenStartupMessage(TBeing& ch) {
+  sstring msg = "Your recovery will be <c>enhanced<1> by...\n\r";
+  bool hasBonuses = false;
+
+  for (const auto& bonus : bonusChecks) {
+    if (bonus.test(ch)) {
+      msg += "   ...";
+      msg += bonus.startupMessage;
+      msg += "...\n\r";
+      hasBonuses = true;
+    }
+  }
+
+  if (hasBonuses) {
+    ch.sendTo(msg + "\n\r");
+  }
+}
+
+void startRegenTask(TBeing& ch, RegenTaskType type) {
+  // Tasks are a player-state mechanism. NPCs receive their position-aware
+  // recovery through updateHalfTickStuff (see periodic.cc), which already
+  // accounts for inCamp/bedRegen/etc. Attaching a task to a mob would
+  // conflict with mob AI's position management and leak taskData on mob
+  // deletion paths that don't call stopTask.
+  if (!ch.isPc()) {
+    return;
+  }
+
+  // Historical timeLeft value used by every regen-task start_task call site.
+  // Effectively a sentinel - the actual update cadence is driven by the
+  // nextUpdate parameter computed from regenTime() below.
+  constexpr int REGEN_TASK_TIME_LEFT = 350;
+
+  const auto& config = configs.at(type);
+
+  sendRegenStartupMessage(ch);
+  start_task(&ch, nullptr, nullptr, config.taskType, "", REGEN_TASK_TIME_LEFT,
+    0, 1, 0, config.tickRateMultiplier * ch.regenTime());
+}
+
+int task_regen(TBeing& ch, RegenTaskType type, int pulse, cmdTypeT cmd,
+  const char* arg) {
+  if (!ch.task) {
+    return 0;
+  }
+
+  if (ch.isLinkdead() || ch.getPosition() != static_cast<positionTypeT>(type)) {
+    ch.stopTask();
+    return 0;
+  }
+
+  [[maybe_unused]] const auto& [taskType, cmdHandler, applyFightingPenalty,
+    tickRateMultiplier, silent, description] = configs.at(type);
+
+  const int regenMod =
+    std::max(tickRateMultiplier / (ch.hasClass(CLASS_THIEF) ? 2 : 1), 1);
+
+  switch (cmd) {
+    case CMD_TASK_CONTINUE:
+      return processRegen(ch, pulse, regenMod, silent);
+    case CMD_TASK_FIGHTING:
+      ch.sendTo(format("You are unable to fight while %s!\n\r") % description);
+      applyFightingPenalty(ch);
+      ch.stopTask();
+      return 1;
+    default:
+      // false = let caller process; true = eat command
+      return cmdHandler(ch, cmd, arg) || cmd >= MAX_CMD_LIST;
+  }
+}

--- a/code/code/task/task_regen_common.h
+++ b/code/code/task/task_regen_common.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "enum.h"
+#include "parse.h"
+
+class TBeing;
+
+enum class RegenTaskType : char {
+  SLEEP = POSITION_SLEEPING,
+  SIT = POSITION_SITTING,
+  REST = POSITION_RESTING,
+};
+
+int task_regen(TBeing&, RegenTaskType, int, cmdTypeT, const char*);
+
+void sendRegenStartupMessage(TBeing&);
+
+// Starts a regen task with the canonical start_task parameters and emits the
+// startup bonus message. Use this instead of calling start_task directly for
+// TASK_SLEEP, TASK_REST, or TASK_SIT.
+void startRegenTask(TBeing&, RegenTaskType);

--- a/code/code/task/task_rest.cc
+++ b/code/code/task/task_rest.cc
@@ -1,98 +1,14 @@
-//////////////////////////////////////////////////////////////////////////
-//
-//      SneezyMUD 4.0 - All rights reserved, SneezyMUD Coding Team
-//      "task.cc" - All functions related to tasks that keep mobs/PCs busy
-//
-//////////////////////////////////////////////////////////////////////////
+#include <cassert>
 
 #include "being.h"
-#include "handler.h"
 #include "obj.h"
+#include "parse.h"
 #include "room.h"
-#include "connect.h"
+#include "task.h"
+#include "task_regen_common.h"
 
 int task_rest(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
   TObj*) {
-  if (ch->isLinkdead() || (ch->getPosition() != POSITION_RESTING)) {
-    ch->stopTask();
-    return FALSE;
-  }
-  if (ch->utilityTaskCommand(cmd))
-    return FALSE;
-  switch (cmd) {
-    case CMD_TASK_CONTINUE:
-      // v3.1 : this was 2*regenTime
-      ch->task->calcNextUpdate(pulse, 4 * ch->regenTime());
-      if (!ch->task->status) {
-        if (!ch->roomp->isRoomFlag(ROOM_NO_HEAL)) {
-          ch->addToMana(1);
-          ch->addToPiety(.10);
-          if (ch->hasClass(CLASS_SHAMAN) &&
-              !ch->affectedBySpell(SPELL_SHAPESHIFT) && !ch->isImmortal()) {
-            if (ch->GetMaxLevel() > 5) {
-              if (1 > ch->getLifeforce()) {
-                ch->updateHalfTickStuff();
-              } else {
-                ch->addToLifeforce(-1);
-                ch->sendTo(
-                  "Your lack of activity drains your precious lifeforce.\n\r");
-              }
-            } else {
-              ch->addToHit(1);
-            }
-          } else {
-            ch->addToHit(1);
-          }
-          if (ch->getMove() < ch->moveLimit())
-            ch->addToMove(1);
-          if (ch->desc && ch->ansi()) {
-            ch->desc->updateScreenAnsi(CHANGED_HP);
-            ch->desc->updateScreenAnsi(CHANGED_MANA);
-            ch->desc->updateScreenAnsi(CHANGED_LIFEFORCE);
-            ch->desc->updateScreenAnsi(CHANGED_PIETY);
-            ch->desc->updateScreenAnsi(CHANGED_MOVE);
-          } else if (ch->desc && ch->vt100()) {
-            ch->desc->updateScreenVt100(CHANGED_HP);
-            ch->desc->updateScreenVt100(CHANGED_PIETY);
-            ch->desc->updateScreenVt100(CHANGED_MANA);
-            ch->desc->updateScreenVt100(CHANGED_LIFEFORCE);
-            ch->desc->updateScreenVt100(CHANGED_MOVE);
-          }
-        }
-      }
-      ch->updatePos();
-      if (ch->task) {
-        ch->task->status = 0;
-      }
-      break;
-    case CMD_ABORT:
-    case CMD_STOP:
-    case CMD_STAND:
-      ch->stopTask();
-      ch->doStand();
-      break;
-    case CMD_SLEEP:
-      ch->stopTask();
-      ch->doSleep(arg);
-      break;
-    case CMD_SIT:
-      ch->stopTask();
-      ch->doSit(arg);
-      break;
-    case CMD_REST:
-      ch->sendTo("You are already nice and comfy.\n\r");
-      break;
-    case CMD_TASK_FIGHTING:
-      ch->sendTo("You are unable to rest while under attack!\n\r");
-      ch->cantHit += ch->loseRound(1);
-      if (!::number(0, 2))
-        ch->cantHit += ch->loseRound(1);
-      ch->stopTask();
-      break;
-    default:
-      if (cmd < MAX_CMD_LIST)
-        return FALSE;  // process command
-      break;           // eat the command
-  }
-  return TRUE;
+  assert(ch);
+  return task_regen(*ch, RegenTaskType::REST, pulse, cmd, arg);
 }

--- a/code/code/task/task_sit.cc
+++ b/code/code/task/task_sit.cc
@@ -1,91 +1,14 @@
-//////////////////////////////////////////////////////////////////////////
-//
-// SneezyMUD - All rights reserved, SneezyMUD Coding Team
-//
-//////////////////////////////////////////////////////////////////////////
+#include <cassert>
 
 #include "being.h"
 #include "obj.h"
+#include "parse.h"
 #include "room.h"
-#include "connect.h"
+#include "task.h"
+#include "task_regen_common.h"
 
 int task_sit(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
   TObj*) {
-  if (ch->isLinkdead() || (ch->getPosition() != POSITION_SITTING)) {
-    ch->stopTask();
-    return FALSE;
-  }
-  if (ch->utilityTaskCommand(cmd))
-    return FALSE;
-  switch (cmd) {
-    case CMD_TASK_CONTINUE:
-      // v3.1 : this was 4*regenTime
-      ch->task->calcNextUpdate(pulse, 6 * ch->regenTime());
-      if (!ch->task->status) {
-        if (!ch->roomp->isRoomFlag(ROOM_NO_HEAL)) {
-          ch->addToMana(1);
-          if (ch->hasClass(CLASS_SHAMAN) &&
-              !ch->affectedBySpell(SPELL_SHAPESHIFT) && !ch->isImmortal()) {
-            if (ch->GetMaxLevel() > 5) {
-              if (1 > ch->getLifeforce()) {
-                ch->updateHalfTickStuff();
-              } else {
-                ch->addToLifeforce(-1);
-                ch->sendTo(
-                  "Your lack of activity drains your precious lifeforce.\n\r");
-              }
-            } else {
-              ch->addToHit(1);
-            }
-          } else {
-            ch->addToHit(1);
-          }
-          if (ch->getMove() < ch->moveLimit())
-            ch->addToMove(1);
-          if (ch->ansi()) {
-            ch->desc->updateScreenAnsi(CHANGED_HP);
-            ch->desc->updateScreenAnsi(CHANGED_MANA);
-            ch->desc->updateScreenAnsi(CHANGED_LIFEFORCE);
-            ch->desc->updateScreenAnsi(CHANGED_MOVE);
-          } else if (ch->vt100()) {
-            ch->desc->updateScreenVt100(CHANGED_HP);
-            ch->desc->updateScreenVt100(CHANGED_MANA);
-            ch->desc->updateScreenVt100(CHANGED_LIFEFORCE);
-            ch->desc->updateScreenVt100(CHANGED_MOVE);
-          }
-        }
-      }
-      ch->updatePos();
-      ch->task->status = 0;
-      break;
-    case CMD_ABORT:
-    case CMD_STOP:
-    case CMD_STAND:
-      ch->stopTask();
-      ch->doStand();
-      break;
-    case CMD_REST:
-      ch->stopTask();
-      ch->doRest(arg);
-      break;
-    case CMD_SLEEP:
-      ch->stopTask();
-      ch->doSleep(arg);
-      break;
-    case CMD_SIT:
-      ch->sendTo(
-        "You look around and notice your butt is already on something.\n\r");
-      break;
-    case CMD_TASK_FIGHTING:
-      ch->sendTo("You are unable to fight while sitting!\n\r");
-      if (!::number(0, 2))
-        ch->cantHit += ch->loseRound(1);
-      ch->stopTask();
-      break;
-    default:
-      if (cmd < MAX_CMD_LIST)
-        return FALSE;  // process command
-      break;           // eat the command
-  }
-  return TRUE;
+  assert(ch);
+  return task_regen(*ch, RegenTaskType::SIT, pulse, cmd, arg);
 }

--- a/code/code/task/task_sleep.cc
+++ b/code/code/task/task_sleep.cc
@@ -1,85 +1,14 @@
-//////////////////////////////////////////////////////////////////////////
-//
-// SneezyMUD - All rights reserved, SneezyMUD Coding Team
-//
-//////////////////////////////////////////////////////////////////////////
+#include <cassert>
 
 #include "being.h"
+#include "obj.h"
+#include "parse.h"
 #include "room.h"
-#include "connect.h"
+#include "task.h"
+#include "task_regen_common.h"
 
 int task_sleep(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
   TObj*) {
-  if (ch->isLinkdead() || (ch->getPosition() != POSITION_SLEEPING)) {
-    ch->stopTask();
-    return FALSE;
-  }
-  if (ch->utilityTaskCommand(cmd))
-    return FALSE;
-
-  int regentime = ch->regenTime();
-  switch (cmd) {
-    case CMD_TASK_CONTINUE:
-      ch->task->calcNextUpdate(pulse, regentime);
-      if (!ch->task->status) {
-        if (!ch->roomp->isRoomFlag(ROOM_NO_HEAL)) {
-          ch->addToMana(1);
-          if (ch->hasClass(CLASS_SHAMAN) &&
-              !ch->affectedBySpell(SPELL_SHAPESHIFT) && !ch->isImmortal()) {
-            if (ch->GetMaxLevel() > 5) {
-              if (1 > ch->getLifeforce()) {
-                ch->updateHalfTickStuff();
-              } else {
-                ch->sendTo(
-                  "Your lack of activity drains your precious lifeforce.\n\r");
-                ch->addToLifeforce(-1);
-              }
-            } else {
-              ch->addToHit(1);
-            }
-          } else {
-            ch->addToHit(1);
-          }
-          if (ch->getMove() < ch->moveLimit())
-            ch->addToMove(1);
-
-          if (ch->ansi()) {
-            ch->desc->updateScreenAnsi(CHANGED_HP);
-            ch->desc->updateScreenAnsi(CHANGED_MANA);
-            ch->desc->updateScreenAnsi(CHANGED_LIFEFORCE);
-            ch->desc->updateScreenAnsi(CHANGED_MOVE);
-          } else if (ch->vt100()) {
-            ch->desc->updateScreenVt100(CHANGED_HP);
-            ch->desc->updateScreenVt100(CHANGED_MANA);
-            ch->desc->updateScreenVt100(CHANGED_LIFEFORCE);
-            ch->desc->updateScreenVt100(CHANGED_MOVE);
-          }
-        }
-      }
-      ch->updatePos();
-      ch->task->status = 0;
-      break;
-    case CMD_ABORT:
-    case CMD_STOP:
-    case CMD_STAND:
-    case CMD_WAKE:
-      ch->stopTask();
-      ch->doWake(arg);
-      break;
-    case CMD_SLEEP:
-      ch->sendTo("You start to dream about sleeping.\n\r");
-      break;
-    case CMD_TASK_FIGHTING:
-      ch->sendTo("You are unable to sleep while under attack!\n\r");
-      ch->cantHit += ch->loseRound(1);
-      if (!::number(0, 1))
-        ch->cantHit += ch->loseRound(1);
-      ch->stopTask();
-      break;
-    default:
-      if (cmd < MAX_CMD_LIST)
-        return FALSE;  // process command
-      break;           // eat the command
-  }
-  return TRUE;
+  assert(ch);
+  return task_regen(*ch, RegenTaskType::SLEEP, pulse, cmd, arg);
 }

--- a/docs/systems/important/rest-recovery.md
+++ b/docs/systems/important/rest-recovery.md
@@ -1,31 +1,31 @@
 ---
 title: Rest and Recovery System
-description: Regeneration of HP, mana, movement, piety, and lifeforce through half-tick recovery and task-based recovery tied to positions and class abilities.
+description: Regeneration of HP, mana, piety, and movement through half-tick recovery and task-based recovery tied to positions, environmental bonuses, and class abilities.
 category: important
-keywords: [regeneration, half-tick recovery, task-based recovery, penance, yoginsa, camping, hospital room, bed bonus]
+keywords: [regeneration, half-tick recovery, task-based recovery, regen bonus stack, penance, yoginsa, camping, hospital room, bed bonus]
 primary_symbols:
-  functions: [hitGain, manaGain, moveGain, regenTime, updateHalfTickStuff, inCamp, bedRegen, canMeditate]
+  functions: [hitGain, manaGain, moveGain, regenTime, updateHalfTickStuff, inCamp, bedRegen, canMeditate, task_regen, processRegen, sendRegenStartupMessage, startRegenTask]
   classes: [TBeing, TPerson, TBed]
-  enums: [POSITION_SLEEPING, POSITION_RESTING, POSITION_SITTING, POSITION_STANDING, POSITION_FIGHTING, ROOM_NO_HEAL, ROOM_HOSPITAL, SPELL_ENLIVEN, AFFECT_WET, SKILL_MEDITATE, SKILL_PENANCE, SKILL_YOGINSA, SKILL_ENCAMP, SKILL_WOHLIN, AFF_GROUP, Pulse::ONE_SECOND, Pulse::MOBACT, Pulse::UPDATE, Pulse::MUDHOUR, TASK_SLEEP, TASK_REST, TASK_SIT, TASK_MEDITATE, TASK_PENANCE, TASK_YOGINSA, PERMANENT_DURATION]
+  enums: [POSITION_SLEEPING, POSITION_RESTING, POSITION_SITTING, POSITION_STANDING, POSITION_FIGHTING, ROOM_NO_HEAL, ROOM_HOSPITAL, SPELL_ENLIVEN, AFFECT_WET, SKILL_MEDITATE, SKILL_PENANCE, SKILL_YOGINSA, SKILL_ENCAMP, SKILL_WOHLIN, AFF_HIDE, AFF_GROUP, Pulse::ONE_SECOND, Pulse::MOBACT, Pulse::UPDATE, Pulse::MUDHOUR, TASK_SLEEP, TASK_REST, TASK_SIT, TASK_MEDITATE, TASK_PENANCE, TASK_YOGINSA, PERMANENT_DURATION, RegenTaskType, CLASS_THIEF]
 ---
 
 ## Overview
 
-How do characters recover from damage, restore spent mana, and regain stamina after exertion? The rest and recovery system manages regeneration of HP, mana, movement, piety, and lifeforce through multiple overlapping mechanisms.
+How do characters recover from damage, restore spent mana, and regain stamina after exertion? The rest and recovery system manages regeneration of HP, mana, and movement through multiple overlapping mechanisms.
 
-Recovery in SneezyMUD operates on two parallel tracks: **half-tick recovery** applies globally to all characters every 36 seconds regardless of activity, while **task-based recovery** provides bonus regeneration tied to specific positions (sleeping, resting, sitting) and class abilities (meditation, penance, yoginsa). Environmental factors like beds, camps, and hospital rooms layer additional bonuses on top of these base rates.
+Recovery in SneezyMUD operates on two parallel tracks: **half-tick recovery** applies globally to all characters every 36 seconds regardless of activity, while **task-based recovery** provides bonus regeneration tied to specific positions (sleeping, resting, sitting) and class abilities (meditation, penance, yoginsa). Environmental factors like beds, camps, hospital rooms, and the regen bonus stack layer additional bonuses on top of these base rates.
 
-The system balances recovery speed against vulnerability and capability. Sleeping provides the fastest regeneration but leaves you defenseless and unable to act. Resting offers good recovery while permitting limited actions. Standing gives only half-tick recovery but full combat readiness. This creates meaningful tactical decisions about when and where to recover.
+The system balances recovery speed against vulnerability and capability. Sleeping provides the fastest regeneration for most classes but leaves the character defenseless and unable to act. Resting offers good recovery while permitting limited actions. Sitting is slower still but the lightest commitment. Standing gives only half-tick recovery but full combat readiness. Thieves get a class-specific multiplier that doubles their effective regen rate while sitting or resting, putting their rest recovery on par with sleep for other classes. This creates meaningful tactical decisions about when and where to recover.
 
 Recovery rates scale with level, constitution, and environmental bonuses. A level 50 character in a hospital bed with the enliven spell active recovers dramatically faster than a low-level character standing in hostile territory. Class-specific abilities provide additional recovery options: mages meditate for mana, clerics perform penance for piety, monks practice yoginsa for enhanced healing with bonus curative effects.
 
-A wounded warrior returns from battle to the inn. Lying down to sleep triggers a task that grants +1 HP, +1 mana, and +1 movement on each cycle. Simultaneously, every 36 seconds the global half-tick adds their full hitGain() and manaGain() values. If they sleep on a bed in a hospital room, both multipliers stack. After several minutes, they wake fully restored and ready for the next adventure.
+A wounded warrior returns from battle to the inn. Lying down to sleep triggers a task that grants +1 HP, +1 mana, +0.10 piety, and +1 movement on each cycle, plus +1 HP and +1 movement for each active regen bonus (camp, campfire, groupmate in the room, and so on). Simultaneously, every 36 seconds the global half-tick adds their full hitGain() and manaGain() values. If they sleep on a bed in a hospital room, both multipliers stack. After several minutes, they wake fully restored and ready for the next adventure.
 
 ## Patterns
 
 ### Position Selection
 
-Always choose sleeping when maximum recovery speed is needed and safety is ensured. Sleep provides the fastest task interval and grants all three primary resources. If you need to perform limited actions during recovery, use resting instead - the interval is twice as long but you remain somewhat responsive.
+For most classes, sleeping is the fastest recovery option when safety is assured, with rest at half that rate and sit at a quarter. Resting and sitting let the character remain aware of their surroundings and respond to events. Thieves are an exception - their `regenMod` divides by 2, so a thief resting recovers as fast as another class sleeping, and a thief sitting recovers as fast as another class resting. A thief therefore has little reason to ever sleep outside of a bed.
 
 Never attempt to sleep or rest while in combat, flying, or in water without aquatic adaptation. The system rejects these attempts and wastes the player's action. Check these conditions before allowing position changes.
 
@@ -33,25 +33,21 @@ Never attempt to sleep or rest while in combat, flying, or in water without aqua
 
 Never assume fixed task intervals. The `regenTime()` function calculates intervals dynamically based on the character's current regeneration rates. Higher regeneration rates produce shorter intervals. The formula divides the update pulse length by the slowest of the character's HP, mana, and movement gain rates.
 
-### Shaman Lifeforce Handling
-
-Always check for shaman class when implementing HP recovery logic. Shamans above level 5 drain lifeforce instead of gaining HP through sleep/rest tasks. They must rely on half-tick recovery for HP or maintain positive lifeforce through spirit consumption. Never grant task-based HP to shamans without first checking lifeforce status.
-
 ### ROOM_NO_HEAL Behavior
 
-ROOM_NO_HEAL blocks nearly all recovery. The flag stops task-based regeneration completely and blocks half-tick HP and mana recovery. Only movement recovery continues, reduced by two-thirds. Characters in these rooms cannot recover HP or mana through any passive mechanism.
+`ROOM_NO_HEAL` blocks nearly all recovery. The flag stops task-based regeneration completely (the regen task aborts the tick early before applying gains or evaluating the bonus stack) and blocks half-tick HP and mana recovery. Only movement recovery continues, reduced by two-thirds. Characters in these rooms cannot recover HP or mana through any passive mechanism.
 
 ### Camp Application
 
-Never tie camp bonuses to position. Unlike most recovery mechanics, camp bonuses from `inCamp()` apply directly to `hitGain()` and `moveGain()` calculations. Characters receive camp benefits whether standing, sitting, or sleeping. The bonus scales with the camper's skill level, with groupmates receiving half the benefit.
+Camp creates two distinct recovery effects that stack. The percentage bonus from `inCamp()` applies inside `hitGain()` and `moveGain()`, scaling the half-tick recovery rate regardless of position - a camped character receives it whether standing, sitting, or sleeping, with the bonus scaling by the camper's skill level (groupmates receive half). Separately, the regen task bonus stack adds a flat +1 HP and +1 move per tick whenever a character is sitting, resting, or sleeping in a camped room. A camped character resting therefore benefits from both: the percentage-scaled half-tick gain and the flat per-tick bonus.
 
 ### Combat Interruption
 
-Always apply round loss penalties when characters are attacked while resting or sleeping. The task fighting handler causes 1-2 lost combat rounds before stopping the task. This represents the vulnerability cost of recovery positions.
+Being attacked in a recovery position stops the task and imposes a round-loss penalty that varies by position: rest loses 1 round plus a 33% chance of a second, sleep loses 1 round plus a 50% chance of a second, and sit has only a 33% chance of losing a single round. Sleep's penalty is harshest because the character is unconscious when attacked; sit is lightest because the character remains aware of their surroundings.
 
 ### Piety Recovery
 
-Always use rest position for piety recovery through the task system. Sleep does NOT grant piety despite being faster for other resources. The penance skill provides the best piety recovery for clerics and deikhan, scaling with duration.
+All three recovery positions grant a nominal +0.10 piety per tick through the unified regen handler. This is a small baseline - real piety recovery for clerics and deikhan comes from the penance skill, which scales with duration.
 
 ### Meditation Position Requirements
 
@@ -83,19 +79,43 @@ Always check wet status for aquatic characters. Wet aquatic characters gain 1.3x
 | `inCamp()` | function | Check camp status and return skill level bonus |
 | `bedRegen()` | function | Apply bed bonus to recovery calculation |
 | `canMeditate()` | function | Validate position for meditation skills |
+| `task_regen()` | function | Unified handler for TASK_SLEEP/REST/SIT |
+| `processRegen()` | function | Per-tick body that applies the bonus stack and updates resources |
+| `startRegenTask()` | function | Common entry point for `doSit`/`doRest`/`doSleep` and the bed equivalents |
+| `sendRegenStartupMessage()` | function | Print the active bonus list when a regen task begins |
+| `RegenTaskType` | enum | Selector for the per-task config map; values alias `positionTypeT` |
 | `TBeing` | class | Base class with recovery methods |
 | `TPerson` | class | Player class with specialized hitGain/manaGain |
 | `TBed` | class | Furniture providing recovery bonuses |
 
 ### Position Recovery Rates
 
-| Position | Task Interval | HP | Mana | Move | Piety | Notes |
-|----------|---------------|----|----|------|-------|-------|
-| `POSITION_SLEEPING` | `regenTime()` | +1 | +1 | +1 | None | Fastest, vulnerable |
-| `POSITION_RESTING` | `2 * regenTime()` | +1 | +1 | +1 | +0.10 | Only position with piety |
-| `POSITION_SITTING` | `4 * regenTime()` | +1 | +1 | +1 | None | Slowest task bonus |
-| `POSITION_STANDING` | None | None | None | None | None | Half-tick only |
-| `POSITION_FIGHTING` | None | None | None | None | None | No recovery |
+All three recovery positions (`SLEEPING`, `RESTING`, `SITTING`) share a single unified task handler in `task_regen_common.cc`. Each tick grants +1 HP, +1 mana, +0.10 piety, and +1 move (up to `moveLimit()`). The bonus system adds +1 to HP/move per active bonus source (see below). Sleep suppresses bonus flavor messages because the character is unconscious.
+
+| Position | Task Interval (non-thief) | Task Interval (thief) | HP | Mana | Move | Piety | Bonuses Apply |
+|----------|---------------------------|-----------------------|----|------|------|-------|---------------|
+| `POSITION_SLEEPING` | `regenTime()` | `regenTime()` | +1 | +1 | +1 | +0.10 | Yes (silent) |
+| `POSITION_RESTING` | `2 * regenTime()` | `regenTime()` | +1 | +1 | +1 | +0.10 | Yes |
+| `POSITION_SITTING` | `4 * regenTime()` | `2 * regenTime()` | +1 | +1 | +1 | +0.10 | Yes |
+| `POSITION_STANDING` | None | None | None | None | None | None | Half-tick only |
+| `POSITION_FIGHTING` | None | None | None | None | None | None | No recovery |
+
+Thieves divide their tick rate multiplier by 2 (floored at 1), effectively doubling their regen rate while awake. Sleep is unaffected because it is already at the floor.
+
+### Regen Bonuses
+
+Each of the following conditions adds +1 to HP and move regen per tick while a regen task is active. They stack - a character in a camp with a hidden groupmate next to a campfire on home terrain would accumulate all applicable bonuses. Rest and sit emit a 20% chance flavor message per tick per active bonus; sleep suppresses them.
+
+| Condition | Check |
+|-----------|-------|
+| Camp | `inCamp()` (own or groupmate's) |
+| Groupmate in room | `hasGroupmateInRoom()` |
+| Campfire in room | `roomp->hasCampfire()` |
+| Hidden from view | `isAffected(AFF_HIDE)` |
+| Home terrain | `homeTurf()` (race matches sector) |
+| Background experience | `backgroundBonus()` (background matches sector) |
+
+A summary of active bonuses is sent to the character when the task starts via `sendRegenStartupMessage()`, which all three position commands (`doRest`, `doSleep`, `doSit`) call after `setPosition()`.
 
 ### Position Command Restrictions
 
@@ -104,7 +124,7 @@ Common restrictions across doSleep, doRest, and doSit:
 - Cannot enter position while fighting or berserking
 - Cannot sleep or rest in water sectors without being aquatic or using a boat
 - ROOM_NO_HEAL prevents task-based recovery but allows position change
-- Sleep loses sneak status automatically
+- All three commands clear the sneak affect on entry. Hide handling is covered in the Hide Interaction section under Implementation.
 
 ### Recovery Modifiers
 
@@ -233,9 +253,11 @@ Task interval examples:
 | `limits.cc` | hitGain, manaGain, moveGain, regenTime calculations |
 | `periodic.cc` | updateHalfTickStuff half-tick handler |
 | `movement.cc` | doSleep, doRest, doSit, doWake commands |
-| `task_sleep.cc` | TASK_SLEEP handler |
-| `task_rest.cc` | TASK_REST handler |
-| `task_sit.cc` | TASK_SIT handler |
+| `task_regen_common.cc` | Unified `task_regen` handler, `bonusChecks` array, `sendRegenStartupMessage` helper, per-task `RegenTaskConfig` map |
+| `task_regen_common.h` | `RegenTaskType` enum, public declarations |
+| `task_sleep.cc` | TASK_SLEEP thin delegation to `task_regen` |
+| `task_rest.cc` | TASK_REST thin delegation to `task_regen` |
+| `task_sit.cc` | TASK_SIT thin delegation to `task_regen` |
 | `task_meditate.cc` | TASK_MEDITATE handler |
 | `task_penance.cc` | TASK_PENANCE handler |
 | `disc_monk_meditation.cc` | TASK_YOGINSA handler |
@@ -252,17 +274,34 @@ HP and mana regeneration have additional prerequisites. The character must not b
 
 ### Position Task Startup
 
-When a player executes sleep, rest, or sit commands, the movement handler validates prerequisites: no flying, no water without boat/aquatic status, no combat, no berserk mode. Sleeping additionally clears the sneak affect as stealth is incompatible with unconsciousness.
+When a player executes sleep, rest, or sit commands, the movement handler validates prerequisites: no flying, no water without boat/aquatic status, no combat, no berserk mode. All three call `loseSneak()` on entry to clear the sneak affect.
 
-After setting the new position, the handler calls `start_task()` with the appropriate task type and interval multiplier. Sleep uses `regenTime()` directly for the fastest interval. Rest doubles the interval. Sit quadruples it. Only PCs receive tasks; NPCs rely solely on half-tick recovery.
+After setting the new position, the handler calls `startRegenTask()` (declared in `task_regen_common.h`), which emits a summary of any active regen bonuses via `sendRegenStartupMessage()` and then invokes `start_task()` with the canonical parameter set for the requested `RegenTaskType`. The bed object methods (`TBed::sitMe`, `restMe`, `sleepMe`) call `startRegenTask` the same way, so resting on a bedroll or other bed object also produces the bonus list. The initial task interval is the base `regenTime()` (sleep) or a multiple of it (rest doubles, sit quadruples) - the per-task config carries the multiplier, and the same value is reused on every subsequent tick via `calcNextUpdate()`. Only PCs receive tasks; NPCs rely solely on half-tick recovery.
+
+### Hide Interaction
+
+The Hidden entry in the regen bonus stack tests `isAffected(AFF_HIDE)` on each tick, so a hidden character benefits from the bonus only as long as the affect remains set when the tick fires. Two code paths govern whether hide survives entering a recovery position:
+
+1. **`willBreakHide()`** in `disc_thief_stealth.cc` lists commands that do *not* break hide. `CMD_REST`, `CMD_SIT`, and `CMD_STAND` are on the do-not-break list, so a hidden thief can drop into rest or sit without losing the affect. `CMD_SLEEP` is not on the list, so issuing the sleep command strips `AFF_HIDE` before the regen task starts.
+2. The hide/break check runs in `parseCommand()` (`parse.cc`), not inside `doRest`/`doSit`/`doSleep`. By the time the position handler runs, hide has already been preserved or cleared by the parser. `loseSneak()` inside the position handlers only touches the sneak affect, not hide.
+
+Combined effect: a hidden thief who rests or sits keeps the Hidden bonus indefinitely (until they take an action that does break hide, e.g. backstab or any non-listed command). A hidden character who sleeps loses hide before the task starts and never receives the bonus, which is consistent with the regen task suppressing all bonus flavor messages during sleep.
 
 ### Task Execution Cycle
 
-Each task handler receives control when its interval expires. The handler first calls `calcNextUpdate()` to schedule the next iteration, then checks ROOM_NO_HEAL to determine if recovery should apply.
+All three position tasks delegate to `task_regen()` in `task_regen_common.cc`, which reads a per-task `RegenTaskConfig` from a compile-time map keyed by `RegenTaskType` (whose enumerators alias the corresponding `positionTypeT` values). The config carries the tick rate multiplier, the silence flag, the combat-interruption lambda, and the task-specific command handler (for CMD_SIT, CMD_REST, CMD_WAKE, etc.).
 
-For standard sleep/rest/sit tasks, each cycle adds +1 to HP, mana, and movement (if below maximum). Rest additionally grants +0.10 piety. The shaman special case intercepts this flow for characters above level 5 who are not shapeshifted or immortal - instead of gaining HP, they lose 1 lifeforce with a warning message. Low-level shamans recover normally.
+On `CMD_TASK_CONTINUE`, `processRegen()` runs:
 
-Task handlers receive CMD_TASK_CONTINUE (normal cycle), CMD_TASK_FIGHTING (combat interruption), and CMD_GENERIC_PULSE (time advancement). On CMD_TASK_CONTINUE, the handler applies recovery (if not blocked by ROOM_NO_HEAL), calls `calcNextUpdate()` to schedule the next cycle, and returns FALSE to keep the task active. On CMD_TASK_FIGHTING, the handler applies cantHit penalty, stops the task via `stopTask()`, and returns FALSE.
+1. `calcNextUpdate()` schedules the next tick using `regenMod * regenTime()`, where `regenMod = max(tickRateMultiplier / (thief ? 2 : 1), 1)`.
+2. If the room has `ROOM_NO_HEAL`, the function returns early without applying any gains or evaluating the bonus stack.
+3. `regenAmt` starts at 1. Each entry in the `bonusChecks` array is evaluated; active bonuses add +1 to `regenAmt` and (if not silent) have a 20% chance to emit their flavor message.
+4. HP gains `regenAmt`. Move gains `min(regenAmt, moveLimit - getMove())`, guarded to avoid decrementing when current move exceeds the cap (which can happen via potions, aegis, or vampire drain). Mana gains +1 and piety gains +0.10.
+5. `updatePos()` runs and the GMCP/ANSI/VT100 screen updates fire.
+
+Bonuses only affect HP and move - mana and piety gains are fixed regardless of how many bonuses are active.
+
+On `CMD_TASK_FIGHTING`, the config's `applyFightingPenalty` lambda runs and the task is stopped. On unknown commands, the config's `cmdHandler` lambda runs; if it handles the command it returns true, otherwise the helper falls through to `cmd >= MAX_CMD_LIST` to distinguish utility commands (let the caller process them) from task-eating commands.
 
 ### HP Gain Calculation
 
@@ -318,7 +357,7 @@ Mage meditation through TASK_MEDITATE runs on a 4 * Pulse::MOBACT interval (appr
 
 On successful skill check, the character gains their full manaGain() value minus 1 (minimum 1). Failure grants only +1 mana. Regardless of success, +1 HP and +1 movement (if below max) apply every cycle.
 
-Cleric/deikhan penance through TASK_PENANCE runs on a 5 * Pulse::MOBACT interval (approximately 6 seconds). A counter increments each cycle, providing a 0.3 multiplier bonus to piety gain that increases over time. Failed checks still grant 0.6-0.8 piety, better than resting's 0.10.
+Cleric/deikhan penance through TASK_PENANCE runs on a 5 * Pulse::MOBACT interval (approximately 6 seconds). A counter increments each cycle, providing a 0.3 multiplier bonus to piety gain that increases over time. Failed checks still grant 0.6-0.8 piety, far better than the nominal 0.10 granted by the generic regen tasks.
 
 Monk yoginsa through TASK_YOGINSA runs on the same interval as meditation. Success grants 80% of hitGain(), 50% of moveGain(), and 50% of manaGain(). Additionally, the Wohlin skill tree provides automatic curative effects at various thresholds: salve at 20%, cure poison at 35%, sterilize at 50%, cure disease at 60%, clot at 75%, and hunger reduction at 90%.
 
@@ -326,7 +365,7 @@ For SKILL_YOGINSA, success requires two rolls: bSuccess against the SKILL_YOGINS
 
 ### Combat Interruption Handling
 
-When a character in a recovery task is attacked, the CMD_TASK_FIGHTING case triggers. The handler sends a warning message, applies 1-2 lost combat rounds (the second round has 33% chance via `number(0,2) == 0`), and calls `stopTask()` to end recovery. This represents the disorientation of being caught in a vulnerable position.
+When a character in a recovery task is attacked, the `CMD_TASK_FIGHTING` branch of `task_regen` sends a position-appropriate warning (`"You are unable to fight while %s!"` with the task description), invokes the task's `applyFightingPenalty` lambda, and calls `stopTask()`. Each position configures its own penalty lambda, which lets the three tasks impose different costs for the same interruption (see the Combat Interruption pattern above for the specific probabilities).
 
 ## Troubleshooting
 
@@ -334,11 +373,11 @@ When a character in a recovery task is attacked, the CMD_TASK_FIGHTING case trig
 
 **Symptom:** Character sleeps but HP does not increase over time.
 
-**Likely cause:** Multiple possibilities - shaman lifeforce depletion, ROOM_NO_HEAL flag, or combat state.
+**Likely cause:** `ROOM_NO_HEAL` flag or active combat. The unified regen task delivers HP/mana/move/piety regardless of class - it does not branch on the character class. (For half-tick HP recovery specifically, see the early-return guards listed under HP Gain Calculation.)
 
-**Diagnostic approach:** Check if character is shaman above level 5 with zero lifeforce. Check room flags for ROOM_NO_HEAL. Verify character's fight() returns null. For shamans, check lifeforce value and shapeshifted status.
+**Diagnostic approach:** Check room flags for `ROOM_NO_HEAL`. Verify character's `fight()` returns null. If the regen task ticks are firing but the visible bar is not moving, confirm the screen update path (GMCP/ANSI/VT100) is reaching the descriptor.
 
-**Fix:** For shamans, restore lifeforce through spirit consumption. For room issues, move to a different room. For combat state, wait for combat to end naturally.
+**Fix:** Move out of the no-heal room or wait for combat to end.
 
 ### Mana Regeneration Slower Than Expected
 

--- a/lib/help/recovery
+++ b/lib/help/recovery
@@ -1,0 +1,62 @@
+Recovery refers to how your character regains hit points, moves, and other
+resources between fights.  This help file explains how the recovery system
+works while you are sitting, resting, or sleeping, and how to make the most
+of it.
+
+The three recovery positions all heal you over time, but at different rates
+and with different costs:
+
+  SLEEP - Fastest recovery, but you are unconscious and helpless.  Best in
+          a place you trust to be safe.
+  REST  - Slower than sleep, but you remain aware of your surroundings and
+          can react to events.
+  SIT   - Slowest of the three, but the lightest commitment.
+
+While in any of these positions, you also recover small amounts of mana
+and piety per tick.  These are nominal amounts only.  For real mana or
+piety regeneration, use the corresponding skills (meditation for mana,
+penance for piety).
+
+<c>Recovery Bonuses<1>
+
+When you begin a recovery task, the game will list any bonuses that are
+currently active.  Each active bonus increases the amount of HP and moves
+you regain per tick.  Bonuses stack, so a prepared adventurer can recover
+significantly faster than someone who simply lies down in the wilderness.
+
+The available bonuses are:
+
+  <o>Camp<1>            - You or a groupmate has set up an encampment in
+                    the room.  See HELP ENCAMP.
+  <r>Campfire<1>        - There is a lit campfire in the room.
+  <p>Groupmate<1>       - You have at least one groupmate in the same room
+                    watching your back.
+  <k>Hidden<1>          - You are hidden from view.  Note that hide is
+                    typically broken when you sleep, so this bonus mostly
+                    applies to resting and sitting.
+  <g>Familiar Terrain<1> - You are on terrain native to your race.
+  <G>Background<1>      - The terrain matches your character's background.
+
+A clever adventurer might establish a campsite near their hunting grounds
+as a retreat between fights, taking advantage of stacked bonuses to recover
+quickly without having to travel back to a safer area.
+
+<c>Special Cases<1>
+
+<c>Thieves<1> learn to "sleep with one eye open."  Their training lets them
+recover from resting and sitting at twice the normal rate, putting their
+resting recovery on par with what other classes get from sleeping.  Because
+of this, sleep offers no additional benefit to a thief and is rarely
+worthwhile given the extra vulnerability.
+
+<c>Beds and other furniture<1> (including portable bedrolls) provide their
+own bonus on top of the normal recovery rate.  This bonus is separate from
+the bonus list above - it scales the underlying recovery rather than adding
+a flat amount per tick.  Larger beds suit larger characters; trying to use
+a bed that is too small for you reduces or eliminates the bonus.
+
+Recovery does not work in rooms flagged as no-heal.  In those rooms, only
+movement regenerates and at a reduced rate.
+
+See Also: SLEEP, REST, SIT, ENCAMP, LIFEFORCE, MEDITATE, PENANCE
+Related Topics: MOVEMENT

--- a/lib/help/rest
+++ b/lib/help/rest
@@ -14,7 +14,8 @@ benefit.
 
 To stop resting, merely stand up or change to some other position.
 
-<R>WARNING:<z> Resting can be detrimental to the lifeforce of a Shaman.
+For details on how recovery works, what bonuses can apply while resting,
+and how the various classes are affected, see HELP RECOVERY.
 
-See Also: SLEEP, SIT, STAND, CRAWL
+See Also: RECOVERY, SLEEP, SIT, STAND, CRAWL, ENCAMP
 Related Topics: MOVEMENT

--- a/lib/help/sit
+++ b/lib/help/sit
@@ -13,7 +13,8 @@ benefit.  Note that SIT BED will sit on the first unoccupied BED in the room.
 
 To stop sitting, merely stand up or change to some other position.
 
-<R>WARNING:<z> Sitting can be detrimental to the lifeforce of a Shaman.
+For details on how recovery works, what bonuses can apply while sitting,
+and how the various classes are affected, see HELP RECOVERY.
 
-See Also: SLEEP, REST, STAND, CRAWL, LIFEFORCE
+See Also: RECOVERY, SLEEP, REST, STAND, CRAWL, LIFEFORCE
 Related Topics: MOVEMENT

--- a/lib/help/sleep
+++ b/lib/help/sleep
@@ -14,7 +14,8 @@ benefit.
 
 To stop sleeping, merely wake up.
 
-<R>WARNING:<z> Sleeping can be detrimental to the liforce of a Shaman.
+For details on how recovery works, what bonuses can apply while sleeping,
+and how the various classes are affected, see HELP RECOVERY.
 
-See Also: WAKE, REST, SIT, STAND, CRAWL, LIFEFORCE
+See Also: RECOVERY, WAKE, REST, SIT, STAND, CRAWL, ENCAMP, LIFEFORCE
 Related Topics: MOVEMENT

--- a/lib/txt/news.d/2026-04-04-rest-and-sleep-groupmate-bonus
+++ b/lib/txt/news.d/2026-04-04-rest-and-sleep-groupmate-bonus
@@ -1,0 +1,47 @@
+Made some notable changes to sit/rest/sleep and certain class interactions
+with those tasks
+
+1) The tick rate for resting and sitting have been restored to their
+   historic values.
+    - Rest now ticks half as often as sleep, and sit ticks half as
+       often as rest.
+    - The amount restored per tick is still identical between all
+      three modes - as before, only their tick rate and how quickly
+      one can respond when attacked differentiates them.
+
+2) Thieves now recover more quickly than other classes when resting
+   or sitting.
+    - Specifically, rest for thieves ticks at the same speed as sleep
+      for other classes, and sit ticks at the same speed as rest.
+    - This change represents thieves "sleeping with one eye open" due
+      to their vocation, being able to gain more benefit than other classes
+      from recovering in positions that provide more situational awareness
+      and less comfort.
+    - It's intended to bring thief recovery a bit more into line with other
+      classes while utilizing a more aggressive, hit-and-run playstyle where
+      they might frequently be recovering while being actively hunted.
+    - With this change, thieves should default to using rest over sleep in
+      most situations. Sleeping in a bed will still result in higher total
+      recovery for the amount regained on game ticks, compared to resting in
+      a bed.
+
+3) Resting, sleeping, and sitting now reward you for being prepared.
+    - When you begin one of these tasks, you can gain circumstantial
+      increases to the amount of HP and moves regained per tick.
+    - Any bonuses being applied will be displayed when you begin the task.
+    - See HELP RECOVERY for full details.
+
+4) Made several improvements/fixes to the thief 'hide' skill
+    - It should now be very obvious when hide is successful, when it
+      failed, and when it ends.
+    - Added several new commands to the list of skills that don't break
+      a successful hide (including sit and rest, which ties hide into the
+      new recovery bonuses mechanic).
+
+5) Shamans now recover HP during rest, sit, and sleep like other classes.
+    - Previously they lost lifeforce instead of recovering HP/move. This
+    was pointlessly punishing (even moreso with multiclass enabled now)
+    and served no real gameplay purpose.
+    - Shaman will still take damage when performing actions that reduce
+    their lifeforce when already out of lifeforce. This change only
+    relates to the drain specifically associated with recovery tasks.


### PR DESCRIPTION
## Summary

Originally a small "groupmate bonus" patch, this branch grew into a full overhaul of the sit/rest/sleep recovery tasks plus a polish pass on the thief hide skill so it interacts cleanly with the new bonuses.

### Recovery refactor (`task/task_regen_common.{cc,h}`)

The three near-identical `TASK_SLEEP/REST/SIT` handlers are unified into a single `task_regen()` keyed by a `RegenTaskType` enum. Per-task differences (tick rate multiplier, command handling, fighting penalty, message silence) live in a `RegenTaskConfig` map. The legacy `task_sleep.cc` / `task_rest.cc` / `task_sit.cc` files are now thin delegations.

Behavior changes folded into the new handler:

- **Tick rates restored to historic values.** Rest = 2x sleep, sit = 4x sleep. Per-tick recovery amounts are unchanged - only cadence and combat-interrupt risk differ between positions.
- **Stacking bonus list.** Each active bonus grants +1 HP and +1 move per tick, with a 20% chance per tick to emit a flavor message (suppressed during sleep, since the character is unconscious). Bonuses:
  - Camp (room has an encampment)
  - Campfire (room contains burning logs or a flame object)
  - Groupmate (at least one other group member in the room)
  - Hidden (`AFF_HIDE`)
  - Familiar terrain (race-native terrain)
  - Background (terrain matches character background)
- **Active bonuses are summarized when the task starts** via a new `sendRegenStartupMessage()`.
- **Thief "sleep with one eye open" multiplier.** Thieves halve their tick interval (floored at 1), so rest ticks at sleep speed and sit ticks at rest speed. Their default recovery position should now be rest, not sleep.
- **Shaman lifeforce drain removed from regen tasks.** Shamans now recover HP/move/mana from rest/sit/sleep like every other class. Lifeforce drains tied to other actions are unaffected.

New helpers added in support:

- `TBeing::hasGroupmateInRoom()` - requires at least one *other* group member in the room, since `inGroup()` already counts self.
- `TRoom::hasCampfire()` - detects burning logs (`TOrganic` + `ITEM_BURNING`) or flame objects (`TFFlame`).
- `startRegenTask()` - centralizes the `start_task()` boilerplate previously duplicated at every `doSit` / `doRest` / `doSleep` call site (including the `TBed::` equivalents) and emits the startup bonus summary.
- `const` overload of `TRoom::findInRoom` for read-only callers.

### Hide skill polish (`disc/disc_thief_stealth.cc`, `disc/disc_thief_murder.cc`)

- `doHide()` now inlines the helper `hide()`, emits explicit success/failure messages, rejects already-hidden callers up front, and blocks hiding while mounted (matching the existing fighting guard).
- `willBreakHide` moved out of `parse.cc` next to the rest of the hide implementation. Its unused `isPre` parameter is gone, and `CMD_REST/SIT/STAND/SIGN/PTELL/EAT/DRINK` join the do-not-break list. `REST` and `SIT` are the important additions: a hidden thief can drop into a recovery position and pick up the new Hidden bonus.
- The two duplicate `AFF_HIDE` checks in `parseCommand` collapse into a single `willBreakHide(cmd)` call that also tells the player "You move from your hiding spot." The redundant pre-trigger AFF_HIDE strip in `doCommand` is gone since `parseCommand` already handles it.
- Backstab and throat slit clear `AFF_HIDE` after a successful strike and print "You leap from your hiding spot!" when launched from hiding.

### Documentation

- New `HELP RECOVERY` (`lib/help/recovery`) as the canonical reference for tick rates, the bonus stack, the thief multiplier, the shaman normalization, and bed/furniture interactions.
- `HELP REST` / `HELP SIT` / `HELP SLEEP` stripped of duplicated bonus paragraphs and pointed at `HELP RECOVERY`. Fixed the long-standing "liforce" typo in `HELP SLEEP`.
- `docs/systems/important/rest-recovery.md` rewritten to describe the unified handler, the bonus checks array, the per-task `RegenTaskConfig` map, and the thief `regenMod` calculation. Symbol/keyword frontmatter and the file table now point at `task_regen_common.{cc,h}` instead of the now-thin per-position files.
- News entry covers all five user-visible changes.

Original groupmate bonus PR was sneezymud/sneezymud#529.