### PR TITLE
adding impactSpec functionality

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -6,12 +6,14 @@
 
 #include "being.h"
 #include "combat.h"
+#include "limbs.h"
 #include "obj_base_clothing.h"
 #include "obj_base_weapon.h"
 #include "being.h"
 #include "room.h"
 #include "extern.h"
 #include "handler.h"
+#include "obj_general_weapon.h"
 
 bool TBeing::canBash(TBeing* victim, silentTypeT silent) {
   if (checkBusy())
@@ -354,22 +356,57 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
 
   int shieldDam =
     getSkillDam(victim, skill, getSkillLevel(skill), getAdvLearning(skill));
+  wearSlotT atkLimb = WEAR_ARM_R;
+  if (!isRightHanded())
+    atkLimb = WEAR_ARM_L;
+  TObj* atkGear = dynamic_cast<TObj*>(equipment[atkLimb]);
+  // Determine which limb gets hit - same logic for all damage types
+  wearSlotT limb = WEAR_BODY;
+  if (!this->isTanking()) {
+    limb = WEAR_BACK; 
+  }
+  if (victim->isAgile(0)){
+    limb = WEAR_ARM_R;
+    if (percentChance(50)){
+      limb = WEAR_ARM_L;
+    }
+    
+    if ((victim->getHeight()*2/3) > this->getHeight()) {
+      limb = WEAR_LEG_R;
+      if (percentChance(50)){
+        limb = WEAR_LEG_L;
+      }
+    }
+  }
+  if (this->getHeight() > (3*victim->getHeight()/2)){
+    limb = WEAR_HEAD;
+  }
 
-  // extra damage done by shield with spikes 10-20-00 -dash
+  // Add shield weight bonus to damage
   if (isHoldingShield && itemInSecondaryHand) {
     shieldDam += (int)((itemInSecondaryHand->getWeight() / 4.0) + 1.0);
 
-    if (itemInSecondaryHand->isSpiked() ||
-        itemInSecondaryHand->isObjStat(ITEM_SPIKED)) {
-      act("The spikes on your $o sink into $N.", FALSE, this,
-        itemInSecondaryHand, victim, TO_CHAR);
-      act("The spikes on $n's $o sink into $N.", FALSE, this,
-        itemInSecondaryHand, victim, TO_NOTVICT);
-      act("The spikes on $n's $o sink into you.", FALSE, this,
-        itemInSecondaryHand, victim, TO_VICT);
-      shieldDam += 2;
+    // Add extra damage for spiked shield
+    if (itemInSecondaryHand->isSpiked()) {
+      int spikeDam = ::number(1, 5);
+      shieldDam += spikeDam;
     }
   }
+  // Add extra damage for thornflesh
+  else if (this->affectedBySpell(SPELL_THORNFLESH) && !atkGear) {
+    int thornDam = ::number(1, 5);
+    shieldDam += thornDam;
+  }
+  // Add extra damage for spiked arm gear
+  else if (atkGear && atkGear->isSpiked()) {
+    int spikeDam = ::number(1, 5);
+    shieldDam += spikeDam;
+  }
+
+  // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
+  // This handles messaging, bleeding, equipment damage, etc.
+  wearSlotT attackerLimb = isHoldingShield ? getSecondaryHand() : atkLimb;
+  impactSpec(this, victim, attackerLimb, limb);
 
   if (reconcileDamage(victim, shieldDam, SKILL_BASH) == -1)
     return DELETE_VICT;

--- a/code/code/cmd/cmd_chop.cc
+++ b/code/code/cmd/cmd_chop.cc
@@ -10,6 +10,8 @@
 #include "being.h"
 #include "combat.h"
 #include "disc_monk.h"
+#include "obj_general_weapon.h"
+
 
 static int chopMiss(TBeing* c, TBeing* v) {
   act("$n swings wildly as $e tries to chop $N.", FALSE, c, 0, v, TO_NOTVICT);
@@ -24,11 +26,10 @@ static int chopMiss(TBeing* c, TBeing* v) {
 
 // returns DELETE_VICT
 static int chopHit(TBeing* c, TBeing* v, int score) {
-  int rc;
   int slot;
-  int temp, limb_dam;
+  int temp;
   wearSlotT pos = WEAR_NOWHERE;
-  TObj* item;
+  wearSlotT handSlot = WEAR_HAND_R;
 
   temp = ::number(1, score);
   if (temp < 30) {
@@ -38,17 +39,24 @@ static int chopHit(TBeing* c, TBeing* v, int score) {
     } else if (!c->isRightHanded() && v->hasPart(WEAR_ARM_R)) {
       pos = WEAR_ARM_R;
       slot = 1;
-    } else
+    } else {
+      pos = WEAR_BODY; 
       slot = 2;
-  } else if (temp < 80)
+    }
+  } else if (temp < 80) {
+    pos = WEAR_BODY;
     slot = 2;  // body shot
-  else if (temp < 90)
+  } else if (temp < 90) {
+    pos = WEAR_NECK;
     slot = 3;  // neck shot
-  else
+  } else {
+    pos = WEAR_HEAD;
     slot = 4;  // head shot
-  if (!v->isHumanoid())
-    slot = 5;  // non-human side shot
-
+  }
+  if (!v->isHumanoid()) {
+   pos = WEAR_WAIST; 
+   slot = 5;  // non-human side shot
+  }
   // Set default damage
   int dam = c->getSkillDam(v, SKILL_CHOP, c->getSkillLevel(SKILL_CHOP),
     c->getAdvLearning(SKILL_CHOP));
@@ -63,32 +71,15 @@ static int chopHit(TBeing* c, TBeing* v, int score) {
         TO_VICT);
       act("Your mighty chop hits $N's arm.", FALSE, c, 0, v, TO_CHAR);
       dam /= 3;
-      limb_dam = (::number(1, c->getSkillLevel(SKILL_CHOP))) / 3;
-      item = dynamic_cast<TObj*>(v->equipment[pos]);
-      if (!item) {
-        v->sendTo("You should think about wearing armor on your arms!\n\r");
-        //        v->cantHit += v->loseRound(1);
-        rc = c->damageLimb(v, pos, NULL, &limb_dam);
-        if (IS_SET_DELETE(rc, DELETE_VICT))
-          return DELETE_VICT;
-      } else if (c->dentItem(v, item, 1, c->getPrimaryHand()) == DELETE_ITEM) {
-        delete item;
-        item = NULL;
-      }
       break;
     case 2:  // BODY SHOT
       act("$n hits $N's chest with a mighty chop!", FALSE, c, 0, v, TO_NOTVICT);
       act("Your chest throbs with pain as $n's chop hits you!", FALSE, c, 0, v,
         TO_VICT);
       act("Your chop lands square on $N's chest!", FALSE, c, 0, v, TO_CHAR);
-      item = dynamic_cast<TObj*>(v->equipment[WEAR_BODY]);
-      if (!item) {
+      if (!v->equipment[WEAR_BODY]) {
         v->sendTo("You should think about wearing armor on your body!\n\r");
-        //        v->cantHit += v->loseRound(1);
         dam += 3;
-      } else if (c->dentItem(v, item, 1, c->getPrimaryHand()) == DELETE_ITEM) {
-        delete item;
-        item = NULL;
       }
       break;
     case 3:  // NECK SHOT
@@ -96,16 +87,11 @@ static int chopHit(TBeing* c, TBeing* v, int score) {
       act("Your neck thobs with pain as $n chops it! OUCH!", FALSE, c, 0, v,
         TO_VICT);
       act("Your chop lands square on $N's neck!", FALSE, c, 0, v, TO_CHAR);
-      //     v->cantHit += v->loseRound(1);
       dam += 2;
-      item = dynamic_cast<TObj*>(v->equipment[WEAR_NECK]);
-      if (!item) {
+      if (!v->equipment[WEAR_NECK]) {
         v->sendTo("You should think about wearing armor on your neck!\n\r");
         v->cantHit += v->loseRound(1);
         dam += 4;
-      } else if (c->dentItem(v, item, 1, c->getPrimaryHand()) == DELETE_ITEM) {
-        delete item;
-        item = NULL;
       }
       break;
     case 4:  // HEAD SHOT
@@ -117,14 +103,9 @@ static int chopHit(TBeing* c, TBeing* v, int score) {
         TO_CHAR);
       v->cantHit += v->loseRound(1);
       dam += 4;
-      item = dynamic_cast<TObj*>(v->equipment[WEAR_HEAD]);
-      if (!item) {
+      if (!v->equipment[WEAR_HEAD]) {
         v->sendTo("You should think about wearing armor on your head!\n\r");
-        //        v->cantHit += v->loseRound(1);
         dam += 2;
-      } else if (c->dentItem(v, item, 1, c->getPrimaryHand()) == DELETE_ITEM) {
-        delete item;
-        item = NULL;
       }
       break;
     case 5:  // SIDE SHOT
@@ -135,17 +116,12 @@ static int chopHit(TBeing* c, TBeing* v, int score) {
       act("Your chop lands square on $N's side!", FALSE, c, 0, v, TO_CHAR);
       break;
   }
+  if (!c->isRightHanded()){
+    handSlot = WEAR_HAND_L;
+  }
 
-  item = dynamic_cast<TObj*>(c->equipment[c->getPrimaryHand()]);
-  if (item)
-    if (item->isSpiked() || item->isObjStat(ITEM_SPIKED)) {
-      act("The spikes on your $o sink into $N.", FALSE, c, item, v, TO_CHAR);
-      act("The spikes on $n's $o sink into $N.", FALSE, c, item, v, TO_NOTVICT);
-      act("The spikes on $n's $o sink into you.", FALSE, c, item, v, TO_VICT);
-
-      if (c->reconcileDamage(v, (int)(dam * 0.15), TYPE_STAB) == -1)
-        return DELETE_VICT;
-    }
+  // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
+  impactSpec(c, v, handSlot, pos);
 
   if (c->reconcileDamage(v, dam, SKILL_CHOP) == -1)
     return DELETE_VICT;

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -9,6 +9,7 @@
 #include "being.h"
 #include "combat.h"
 #include "obj_base_clothing.h"
+#include "obj_general_weapon.h"
 
 static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
   int percent;
@@ -59,7 +60,7 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
   percent = 0;
 
   percent += c->getDexReaction() * 5;
-  percent -= victim->getAgiReaction() * 10;
+  percent -= victim->getAgiReaction() * 5;
 
   if (victim->riding) {
     // difficult
@@ -71,7 +72,7 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
 
   if ((c->bSuccess(bKnown + percent, skill) &&
         // insure they can hit this critter
-        (i = c->specialAttack(victim, skill)) && i != GUARANTEED_FAILURE &&
+        (i = c->specialAttack(victim, skill, 0, STAT_STR, STAT_DEX, STAT_BRA, STAT_AGI, false)) && i != GUARANTEED_FAILURE &&
         // make sure they have reasonable training
         (percent < bKnown)) ||
       !victim->awake()) {
@@ -111,22 +112,19 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
         victim, TO_NOTVICT);
       act("$n wrestles you to the $g.", TRUE, c, 0, victim, TO_VICT);
 
-      // if eqipment worn on body is spiked, add a little extra 10-20-00, -dash
+      // if equipment worn on body is spiked, add a little extra damage
       if (((obj = c->equipment[WEAR_BODY]) &&
             (tbc = dynamic_cast<TBaseClothing*>(obj)) &&
-            (tbc->isSpiked() || tbc->isObjStat(ITEM_SPIKED)))) {
+            (tbc->isSpiked()))) {
         suitDam = (int)((tbc->getWeight() / 10) + 1);
-
-        act("The spikes on your $o sink into $N.", FALSE, c, tbc, victim,
-          TO_CHAR);
-        act("The spikes on $n's $o sink into $N.", FALSE, c, tbc, victim,
-          TO_NOTVICT);
-        act("The spikes on $n's $o sink into you.", FALSE, c, tbc, victim,
-          TO_VICT);
 
         if (c->reconcileDamage(victim, suitDam, TYPE_STAB) == -1)
           return DELETE_VICT;
       }
+
+      // Use impactSpec to handle all impact effects (spikes, thorns, hardness)
+      wearSlotT targetLimb = victim->getPartHit(c, TRUE);
+      impactSpec(c, victim, WEAR_BODY, targetLimb);
 
       rc = c->crashLanding(POSITION_SITTING);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -136,7 +134,8 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
       if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
         return rc;
 
-      rc = victim->crashLanding(POSITION_SITTING);
+      positionTypeT pinned = victim->isAgile(0) ? POSITION_SITTING : POSITION_RESTING;
+      rc = victim->crashLanding(pinned);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_VICT;
 

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -13,6 +13,7 @@
 #include "combat.h"
 #include "enum.h"
 #include "skill_handler.h"
+#include "obj_general_weapon.h"
 
 bool TBeing::canHeadbutt(TBeing* victim, const silentTypeT silent) const {
   // Define static vector of tests that need to pass before headbutt can
@@ -103,74 +104,54 @@ int TBeing::headbuttHit(TBeing* victim) {
       return DELETE_VICT;
 
     return TRUE;
-  } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_LEGS)) {
-    pos = (::number(0, 1) ? WEAR_FOOT_L : WEAR_FOOT_R);
-    dam_type = DAMAGE_HEADBUTT_FOOT;
-    act("$n headbutts $N, slamming $s head into $N's foot.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S foot.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your foot.", FALSE, this, 0,
-      victim, TO_VICT);
-  } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_WAIST)) {
-    pos = (::number(0, 1) ? WEAR_LEG_L : WEAR_LEG_R);
-    dam_type = DAMAGE_HEADBUTT_LEG;
-    act("$n headbutts $N, slamming $s head into $N's leg.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S leg.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your leg.", FALSE, this, 0,
-      victim, TO_VICT);
-  } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_BODY)) {
-    pos = WEAR_WAIST;
-    dam_type = DAMAGE_HEADBUTT_CROTCH;
-    act("$n headbutts $N, slamming $s head into $N's crotch.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S crotch.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your crotch.", FALSE, this, 0,
-      victim, TO_VICT);
-    victim->addToWait(combatRound(0.25));
-  } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_ARMS)) {
-    pos = WEAR_BODY;
-    dam_type = DAMAGE_HEADBUTT_BODY;
-    act("$n headbutts $N, slamming $s head into $N's solar plexus.", FALSE,
-      this, 0, victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S solar plexus.", FALSE,
-      this, 0, victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your solar plexus.", FALSE,
-      this, 0, victim, TO_VICT);
-    victim->addToWait(combatRound(0.25));
-  } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_NECK)) {
-    pos = WEAR_NECK;
-    dam_type = DAMAGE_HEADBUTT_THROAT;
-    act("$n headbutts $N, slamming $s head into $N's throat.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S throat.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your throat.", FALSE, this, 0,
-      victim, TO_VICT);
-    victim->addToWait(combatRound(0.25));
-  } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_HEAD)) {
-    pos = WEAR_HEAD;
-    dam_type = DAMAGE_HEADBUTT_JAW;
-    act("$n headbutts $N, slamming $s head into $N's jaw.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S jaw.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your jaw.", FALSE, this, 0,
-      victim, TO_VICT);
-    victim->addToWait(combatRound(0.25));
   } else {
-    pos = WEAR_HEAD;
-    dam_type = DAMAGE_HEADBUTT_SKULL;
-    act("$n headbutts $N, slamming $s head into $N's skull.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You headbutt $N, slamming your head into $S skull.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n headbutts you, slamming $s head into your skull.", FALSE, this, 0,
-      victim, TO_VICT);
-    victim->addToWait(combatRound(0.25));
+    static constexpr const char* headbutt_msg = "%s headbutt %s, slamming %s head into %s %s.";
+
+    const char* target_area;
+    bool causes_wait = false;
+
+    if (hgt < victim->getPartMinHeight(ITEM_WEAR_LEGS)) {
+      pos = (::number(0, 1) ? WEAR_FOOT_L : WEAR_FOOT_R);
+      dam_type = DAMAGE_HEADBUTT_FOOT;
+      target_area = "foot";
+    } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_WAIST)) {
+      pos = (::number(0, 1) ? WEAR_LEG_L : WEAR_LEG_R);
+      dam_type = DAMAGE_HEADBUTT_LEG;
+      target_area = "leg";
+    } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_BODY)) {
+      pos = WEAR_WAIST;
+      dam_type = DAMAGE_HEADBUTT_CROTCH;
+      target_area = "crotch";
+      causes_wait = true;
+    } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_ARMS)) {
+      pos = WEAR_BODY;
+      dam_type = DAMAGE_HEADBUTT_BODY;
+      target_area = "solar plexus";
+      causes_wait = true;
+    } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_NECK)) {
+      pos = WEAR_NECK;
+      dam_type = DAMAGE_HEADBUTT_THROAT;
+      target_area = "throat";
+      causes_wait = true;
+    } else if (hgt < victim->getPartMinHeight(ITEM_WEAR_HEAD)) {
+      pos = WEAR_HEAD;
+      dam_type = DAMAGE_HEADBUTT_JAW;
+      target_area = "jaw";
+      causes_wait = true;
+    } else {
+      pos = WEAR_HEAD;
+      dam_type = DAMAGE_HEADBUTT_SKULL;
+      target_area = "skull";
+      causes_wait = true;
+    }
+
+    act(format(headbutt_msg) % "$n" % "$N" % "$s" % "$N's" % target_area, FALSE, this, 0, victim, TO_NOTVICT);
+    act(format(headbutt_msg) % "You" % "$N" % "your" % "$S" % target_area, FALSE, this, 0, victim, TO_CHAR);
+    act(format(headbutt_msg) % "$n" % "you" % "$s" % "your" % target_area, FALSE, this, 0, victim, TO_VICT);
+
+    if (causes_wait) {
+      victim->addToWait(combatRound(0.25));
+    }
   }
 
   TObj* item = dynamic_cast<TObj*>(victim->equipment[pos]);
@@ -186,27 +167,31 @@ int TBeing::headbuttHit(TBeing* victim) {
   item = dynamic_cast<TObj*>(equipment[WEAR_HEAD]);
   if (!item) {
     rc = damageLimb(this, WEAR_HEAD, 0, &h_dam);
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_VICT)){
       return DELETE_THIS;
-  } else {
-    if (item->isSpiked() || item->isObjStat(ITEM_SPIKED))
+    }
+    if (this->affectedBySpell(SPELL_THORNFLESH)){
       spikeddam = (int)(dam * 0.15);
+    }
+  } else {
+    if (item->isSpiked()){
+      spikeddam = (int)(dam * 0.25);
+    }
+
     if (dentItem(victim, item, 1, WEAR_HEAD) == DELETE_ITEM) {
       delete item;
       item = NULL;
     }
   }
 
+  // Apply spike damage if present
   if (spikeddam) {
-    act("The spikes on your $o sink into $N.", FALSE, this, item, victim,
-      TO_CHAR);
-    act("The spikes on $n's $o sink into $N.", FALSE, this, item, victim,
-      TO_NOTVICT);
-    act("The spikes on $n's $o sink into you.", FALSE, this, item, victim,
-      TO_VICT);
     if ((rc = reconcileDamage(victim, spikeddam, TYPE_STAB)) == -1)
       return DELETE_VICT;
   }
+
+  // Use impactSpec to handle all impact effects (spikes, thorns, hardness)
+  impactSpec(this, victim, WEAR_HEAD, pos);
   if ((rc = reconcileDamage(victim, dam, dam_type)) == -1)
     return DELETE_VICT;
 

--- a/code/code/cmd/cmd_kick.cc
+++ b/code/code/cmd/cmd_kick.cc
@@ -10,6 +10,7 @@
 #include "being.h"
 #include "enum.h"
 #include "combat.h"
+#include "obj_general_weapon.h"
 
 bool TBeing::canKick(TBeing* victim, silentTypeT silent) {
   if (checkBusy())
@@ -210,9 +211,11 @@ static int kickHit(TBeing* caster, TBeing* victim, int score, int level,
   dam =
     caster->getSkillDam(victim, skill, level, caster->getAdvLearning(skill));
 
+  // Map kick location to target limb
   TObj* item;
   switch (slot_i) {
-    case KICK_WAIST:
+    case KICK_WAIST: {
+      slot = WEAR_WAIST;
       limb_dam = (level / 5) + 1;
       act("$n kicks $N in the crotch, yowch!.", FALSE, caster, 0, victim,
         TO_NOTVICT);
@@ -242,7 +245,9 @@ static int kickHit(TBeing* caster, TBeing* victim, int score, int level,
         item = NULL;
       }
       break;
-    case KICK_BODY:
+    }
+    case KICK_BODY: {
+      slot = WEAR_BODY;
       act("$n kicks $N in the solar plexus.", FALSE, caster, 0, victim,
         TO_NOTVICT);
       act(
@@ -253,7 +258,9 @@ static int kickHit(TBeing* caster, TBeing* victim, int score, int level,
       dam += 1;
       dam_type = DAMAGE_KICK_SOLAR;
       break;
-    case KICK_HEAD:
+    }
+    case KICK_HEAD: {
+      slot = WEAR_HEAD;
       act("$n gives $N a boot to the head!", FALSE, caster, 0, victim,
         TO_NOTVICT);
       act("You're kicked in the head by $n!", FALSE, caster, 0, victim,
@@ -265,13 +272,14 @@ static int kickHit(TBeing* caster, TBeing* victim, int score, int level,
       victim->addToWait(combatRound(0.5));
       dam_type = DAMAGE_KICK_HEAD;
       break;
-    case KICK_LEG:
+    }
+    case KICK_LEG: {
+      slot = wearSlotT(::number(WEAR_LEG_R, WEAR_LEG_L));
       limb_dam = (level / 5) + 1;
       act("$n kicks $N in the shin.", FALSE, caster, 0, victim, TO_NOTVICT);
       act("You're kicked in the shin by $n.   Ouch!", FALSE, caster, 0, victim,
         TO_VICT);
       act("Your kick hits $N in the shin.", FALSE, caster, 0, victim, TO_CHAR);
-      slot = wearSlotT(::number(WEAR_LEG_R, WEAR_LEG_L));
       item = dynamic_cast<TObj*>(victim->equipment[slot]);
       if (!item) {
         rc = caster->damageLimb(victim, slot, NULL, &limb_dam);
@@ -284,28 +292,20 @@ static int kickHit(TBeing* caster, TBeing* victim, int score, int level,
       }
       dam_type = DAMAGE_KICK_SHIN;
       break;
-    case KICK_NONE:
+    }
+    case KICK_NONE: {
+      slot = WEAR_BODY; // Default to body for non-humanoids
       act("$n kicks $N in the side.", FALSE, caster, 0, victim, TO_NOTVICT);
       act("You're kicked in the side by $n.   Ouch!", FALSE, caster, 0, victim,
         TO_VICT);
       act("Your kick hits $N in the side.", FALSE, caster, 0, victim, TO_CHAR);
       dam_type = DAMAGE_KICK_SIDE;
       break;
+    }
   }
 
-  item = dynamic_cast<TObj*>(caster->equipment[caster->getPrimaryFoot()]);
-  if (item)
-    if (item->isSpiked() || item->isObjStat(ITEM_SPIKED)) {
-      act("The spikes on your $o sink into $N.", FALSE, caster, item, victim,
-        TO_CHAR);
-      act("The spikes on $n's $o sink into $N.", FALSE, caster, item, victim,
-        TO_NOTVICT);
-      act("The spikes on $n's $o sink into you.", FALSE, caster, item, victim,
-        TO_VICT);
-
-      if (caster->reconcileDamage(victim, (int)(dam * 0.15), TYPE_STAB) == -1)
-        return DELETE_VICT;
-    }
+  // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
+  impactSpec(caster, victim, caster->getPrimaryFoot(), slot);
 
   if (caster->reconcileDamage(victim, dam, dam_type) == -1)
     return DELETE_VICT;

--- a/code/code/cmd/cmd_kneestrike.cc
+++ b/code/code/cmd/cmd_kneestrike.cc
@@ -6,6 +6,7 @@
 
 #include "handler.h"
 #include "extern.h"
+#include "obj_general_weapon.h"
 #include "room.h"
 #include "being.h"
 #include "enum.h"
@@ -132,20 +133,10 @@ int TBeing::kneestrikeMiss(TBeing* v, int type) {
       sendTo("Ooof! That knocked some wind out of you.\n\r");
       cantHit += v->loseRound(0.25);
       addToWait(combatRound(0.25));
-      TObj* item;
-      if ((item = dynamic_cast<TObj*>(v->equipment[v->getPrimaryFoot()]))) {
-        if (item->isSpiked() || item->isObjStat(ITEM_SPIKED)) {
-          act("The spikes on your $o sink into $N's side.", FALSE, v, item,
-            this, TO_CHAR);
-          act("The spikes on $n's $o sink into $N's side.", FALSE, v, item,
-            this, TO_NOTVICT);
-          act("The spikes on $n's $o sink into your side, OW!", FALSE, v, item,
-            this, TO_VICT);
 
-          if (v->reconcileDamage(this, (int)(dam * 0.15), TYPE_STAB) == -1)
-            return DELETE_THIS;
-        }
-      }
+      // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
+      impactSpec(v, this, v->getPrimaryFoot(), WEAR_BODY);
+
       if (v->reconcileDamage(this, dam, DAMAGE_KICK_HEAD) == -1)
         return DELETE_THIS;
     } break;
@@ -158,15 +149,12 @@ int TBeing::kneestrikeMiss(TBeing* v, int type) {
 
 int TBeing::kneestrikeHit(TBeing* victim) {
   int rc = 0;
-  TObj* item;
-  int h_dam = 1;
   int caster_hgt, victim_hgt;
   int i;
   wearSlotT pos = WEAR_NOWHERE;
   wearSlotT caster_pos = WEAR_NOWHERE;
   int crit;
   //  int lev = c->getSkillLevel(SKILL_KNEESTRIKE);
-  int spikeddam = 0;
   int dam = getSkillDam(victim, SKILL_KNEESTRIKE,
     getSkillLevel(SKILL_KNEESTRIKE), getAdvLearning(SKILL_KNEESTRIKE));
 
@@ -354,34 +342,10 @@ int TBeing::kneestrikeHit(TBeing* victim) {
   // advance learning gave increased success, this seems bad idea
   //  dam += c->getAdvLearning(SKILL_KNEESTRIKE)/10;
 
-  // apply damage to caster if no leg eq
+  // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
+  // This includes automatic hardness-based damage to equipment/limbs
   caster_pos = (::number(0, 1) ? WEAR_LEG_L : WEAR_LEG_R);
-  if (!(item = dynamic_cast<TObj*>(equipment[caster_pos]))) {
-    rc = damageLimb(this, caster_pos, 0, &h_dam);
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_THIS;
-  } else if (item->isSpiked() || item->isObjStat(ITEM_SPIKED)) {
-    spikeddam = (int)(dam * 0.15);
-
-    act("The spikes on your $o sink into $N.", FALSE, this, item, victim,
-      TO_CHAR);
-    act("The spikes on $n's $o sink into $N.", FALSE, this, item, victim,
-      TO_NOTVICT);
-    act("The spikes on $n's $o sink into you.", FALSE, this, item, victim,
-      TO_VICT);
-
-  } else {
-    // apply damage to victim if no eq on targetted spot
-    if (!(item = dynamic_cast<TObj*>(victim->equipment[pos]))) {
-      rc = damageLimb(victim, pos, 0, &h_dam);
-      if (IS_SET_DELETE(rc, DELETE_VICT))
-        return DELETE_VICT;
-    }
-  }
-
-  if (spikeddam)
-    if ((rc = reconcileDamage(victim, spikeddam, TYPE_STAB)) == -1)
-      return DELETE_VICT;
+  impactSpec(this, victim, caster_pos, pos);
   if ((rc = reconcileDamage(victim, dam, dam_type)) == -1)
     return DELETE_VICT;
 

--- a/code/code/cmd/cmd_slam.cc
+++ b/code/code/cmd/cmd_slam.cc
@@ -2,6 +2,7 @@
 #include "being.h"
 #include "combat.h"
 #include "obj_base_weapon.h"
+#include "obj_general_weapon.h"
 
 int TBeing::doSlam(const char* argument, TBeing* vict) {
   int rc;
@@ -173,6 +174,10 @@ int TBeing::slamSuccess(TBeing* victim) {
   // Reconcile damage
   if (reconcileDamage(victim, dam, damageType) == -1)
     return DELETE_VICT;
+
+  // Apply impact effects from weapon contact
+  wearSlotT targetLimb = victim->getPartHit(this, TRUE);
+  impactSpec(this, victim, getPrimaryHand(), targetLimb);
 
   return true;
 }

--- a/code/code/cmd/cmd_stomp.cc
+++ b/code/code/cmd/cmd_stomp.cc
@@ -8,6 +8,8 @@
 #include "being.h"
 #include "enum.h"
 #include "combat.h"
+#include "obj.h"
+#include "obj_general_weapon.h"
 
 bool TBeing::canStomp(TBeing* victim, silentTypeT silent) {
   if (checkBusy())
@@ -103,10 +105,8 @@ int TBeing::stompMiss(TBeing* victim) {
 }
 
 int TBeing::stompHit(TBeing* victim) {
-  int h_dam;
   int height, targ_height;
-  int rc;
-
+  wearSlotT targetLimb;
   int dam = getSkillDam(victim, SKILL_STOMP, getSkillLevel(SKILL_STOMP),
     getAdvLearning(SKILL_STOMP));
 
@@ -128,17 +128,9 @@ int TBeing::stompHit(TBeing* victim) {
         "descending toward you!",
         FALSE, this, 0, victim, TO_VICT, ANSI_RED);
 
-      TObj* item = dynamic_cast<TObj*>(victim->equipment[WEAR_HEAD]);
-      if (!item) {
-        h_dam = 1 + dam / 5;
-        rc = damageLimb(victim, WEAR_HEAD, 0, &h_dam);
-        if (IS_SET_DELETE(rc, DELETE_VICT))
-          return DELETE_VICT;
-      } else if (dentItem(victim, item, 1, getPrimaryFoot()) == DELETE_ITEM) {
-        delete item;
-        item = NULL;
-      }
+      targetLimb = WEAR_HEAD;
     } else {
+      // Stomping toes
       act("$n lifts $s leg high, stomping $N's toes hard!", FALSE, this, 0,
         victim, TO_NOTVICT);
       act("You lift your leg high and stomp $N's toes hard.", FALSE, this, 0,
@@ -147,19 +139,18 @@ int TBeing::stompHit(TBeing* victim) {
         TO_VICT, ANSI_RED);
 
       dam /= 5;
-
-      TObj* item = dynamic_cast<TObj*>(victim->equipment[WEAR_FOOT_L]);
-      if (!item) {
-        h_dam = 1 + dam / 4;
-        rc = damageLimb(victim, WEAR_FOOT_L, 0, &h_dam);
-        if (IS_SET_DELETE(rc, DELETE_VICT))
-          return DELETE_VICT;
-      } else if (dentItem(victim, item, 1, getPrimaryFoot()) == DELETE_ITEM) {
-        delete item;
-        item = NULL;
+      targetLimb = WEAR_FOOT_L;
+      if (percentChance(50)) {
+        targetLimb = WEAR_FOOT_R;
       }
     }
   } else {
+    // Victim is not standing
+    targetLimb = WEAR_BACK;
+    if (percentChance(50)) {
+      targetLimb = WEAR_BODY;
+    }
+
     act("$n lifts $s leg high, stomping $N while $E is down.", FALSE, this, 0,
       victim, TO_NOTVICT);
     act("You lift your leg high and stomp $N hard while $E is down.", FALSE,
@@ -167,6 +158,10 @@ int TBeing::stompHit(TBeing* victim) {
     act("$n stomps you hard while you are down!", FALSE, this, 0, victim,
       TO_VICT, ANSI_RED);
   }
+
+  // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
+  impactSpec(this, victim, getPrimaryFoot(), targetLimb);
+
   if (reconcileDamage(victim, dam, SKILL_STOMP) == -1)
     return DELETE_VICT;
 

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -957,6 +957,9 @@ class TBeing : public TThing {
     void rawBlind(int, int, saveTypeT);
     int rawSleep(int, int, int, saveTypeT);
     int rawBleed(wearSlotT, int, silentTypeT, checkImmunityT);
+    int maxBleedVitalPart(wearSlotT limb, int duration);
+    int incrementBleedStack(wearSlotT limb, int newDuration);
+    int incrementBruiseStack(wearSlotT limb, int newDuration);
     int rawBruise(wearSlotT, int, silentTypeT, checkImmunityT);
     int dropPool(int, liqTypeT);
     int dropBloodLimb(wearSlotT);
@@ -1496,7 +1499,7 @@ class TBeing : public TThing {
     bool canCounterMove(int);
     bool canFocusedAvoidance(int);
     int trySpringleap(TBeing*);
-    bool maybeDestroyLimb(wearSlotT part_hit, TBeing* v,
+      bool maybeDestroyLimb(wearSlotT part_hit, TBeing* v,
       const TBaseWeapon* weapon, spellNumT attackType);
     int damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
       int* dam);

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -1265,11 +1265,12 @@ int TBeing::damageHand(TBeing* v, wearSlotT part_hit) {
     else
       hardness = 0;
   } else {
-    if (v->getMaxLimbHealth(part_hit))
-      hardness = material_nums[v->getMaterial(part_hit)].hardness *
-                 v->getCurLimbHealth(part_hit) / v->getMaxLimbHealth(part_hit);
-    else
+    if (v->getMaxLimbHealth(part_hit)) {
+      int baseHardness = getHardnessSpec(v, part_hit);
+      hardness = baseHardness * v->getCurLimbHealth(part_hit) / v->getMaxLimbHealth(part_hit);
+    } else {
       hardness = 0;
+    }
   }
   if (::number(1, 100) < hardness) {
     if (!::number(0, getCurLimbHealth(getPrimaryHold()))) {

--- a/code/code/misc/extern.h
+++ b/code/code/misc/extern.h
@@ -306,6 +306,7 @@ extern sstring talenDisplay(int);
 extern sstring volumeDisplay(int);
 extern TThing* unequip_char_for_save(TBeing* ch, wearSlotT pos);
 extern bool isVitalPart(wearSlotT);
+extern int getHardnessSpec(const TBeing*, wearSlotT);
 extern bool hideThisSpell(spellNumT);
 extern void test_fight_death(TBeing*, TBeing*, int);
 extern sstring shutdown_or_reboot();

--- a/code/code/misc/info.cc
+++ b/code/code/misc/info.cc
@@ -4740,6 +4740,9 @@ void TBeing::describeOtherFeatures(const TGenWeapon* obj, int learn) const {
   }
 
   if (hasClass(CLASS_THIEF) || isImmortal()) {
+    if (obj->isObjStat(ITEM_SPIKED))
+      sendTo(COLOR_OBJECTS,
+        format("%s seems to have spikes on it.\n\r") % sstring(capbuf).cap());
     if (obj->canCudgel())
       sendTo(COLOR_OBJECTS,
         format("%s seems small enough to be used for cudgeling.\n\r") %

--- a/code/code/misc/magicutils.cc
+++ b/code/code/misc/magicutils.cc
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <algorithm>
 
+#include "ansi.h"
 #include "extern.h"
 #include "handler.h"
 #include "room.h"
@@ -1596,6 +1597,124 @@ int TBeing::rawBleed(wearSlotT pos, int duration, silentTypeT silent,
     updateDuration, followupAction);
 }
 
+
+int TBeing::incrementBleedStack(wearSlotT limb, int newDuration) {
+  int maxStacks = 5;
+  // Check for an existing bleeding affect on this limb
+  affectedData* existingBleed = 
+    affected ? affected->find_if([limb](affectedData* aff) {
+      return aff->modifier == DISEASE_BLEEDING && aff->level == limb;
+    })
+             : nullptr;
+             
+  if (!existingBleed) {
+    // No existing bleed found. Not sure how this would happen, but just in case
+    return false;
+  }
+  
+  //increment stack count if not at max, and increase duration
+  if (existingBleed->modifier2 < maxStacks) {
+    existingBleed->modifier2++;
+    act(format("The flesh on your %s is torn open!") % describeBodySlot(limb), 
+        false, this, nullptr, nullptr, TO_CHAR, ANSI_RED);
+    act(format("The flesh on $n's %s is torn open!") % describeBodySlot(limb), 
+        false, this, nullptr, nullptr, TO_ROOM, ANSI_RED);
+    if (existingBleed->duration < newDuration) {
+      existingBleed->duration = newDuration;
+    }
+  }
+
+  if (existingBleed->modifier2 >= maxStacks) {
+    const sstring limbName = describeBodySlot(limb);
+    if (!isVitalPart(limb) && limb != WEAR_WAIST) {
+      // For non-vital parts, sever the limb
+      act(format("The wound on your %s gushes blood violently as the limb is severed!") % 
+         limbName, false, this, nullptr, nullptr, TO_CHAR, ANSI_RED_BOLD);
+
+      act(format("The wound on $n's %s gushes blood violently as the limb is severed!") % 
+         limbName, false, this, nullptr, nullptr, TO_ROOM, ANSI_RED_BOLD);
+         
+      makePartMissing(limb, isLimbFlags(limb, PART_LEPROSED | PART_GANGRENOUS), nullptr);
+         
+      const wearSlotT newBleedLocation = findNextAttachedBodyPart(limb);
+      const sstring bleedLocationDesc = describeBodySlot(newBleedLocation);
+     
+      // Check if the next attached body part is already bleeding
+      affectedData* existingBleed = 
+       affected ? affected->find_if([newBleedLocation](affectedData* aff) {
+         return aff && aff->modifier == DISEASE_BLEEDING && aff->level == newBleedLocation;
+       }) : nullptr;
+       
+      if (existingBleed) {
+        // If already bleeding, increment the stack
+        if (existingBleed->modifier2 < maxStacks) {
+          existingBleed->modifier2++;
+        }
+        // Ensure it's a permanent bleed
+        existingBleed->duration = PERMANENT_DURATION;
+      } else {
+        // If not already bleeding, start a new bleed
+        rawBleed(newBleedLocation, PERMANENT_DURATION, SILENT_YES, CHECK_IMMUNITY_YES);
+      }
+       
+      act(format("Blood gushes from your %s!") % bleedLocationDesc, 
+         false, this, nullptr, nullptr, TO_CHAR, ANSI_RED);
+      act(format("Blood gushes from $n's %s!") % bleedLocationDesc, 
+         false, this, nullptr, nullptr, TO_ROOM, ANSI_RED);
+    } else {
+      maxBleedVitalPart(limb, newDuration);
+    }
+  }
+  return true;
+}
+
+
+int TBeing::incrementBruiseStack(wearSlotT limb, int newDuration) {
+  int maxStacks = 5;
+  // Check for an existing bruise affect on this limb
+  affectedData* existingBruise = 
+    affected ? affected->find_if([limb](affectedData* aff) {
+      return aff->modifier == DISEASE_BRUISED && aff->level == limb;
+    })
+             : nullptr;
+             
+  if (!existingBruise) {
+    // No existing bruise found. Not sure how this would happen, but just in case
+    return false;
+  }
+  
+  // Increment stack count if not at max, and increase duration
+  if (existingBruise->modifier2 < maxStacks) {
+    existingBruise->modifier2++;
+    act(format("The bruising on your %s worsens.") % describeBodySlot(limb), 
+        false, this, nullptr, nullptr, TO_CHAR, ANSI_PURPLE);
+    act(format("The bruising on $n's %s worsens.") % describeBodySlot(limb), 
+        false, this, nullptr, nullptr, TO_ROOM, ANSI_PURPLE);
+    
+    if (existingBruise->duration < newDuration) {
+      existingBruise->duration = newDuration;
+    }
+  }
+
+  if (existingBruise->modifier2 >= maxStacks && !isVitalPart(limb)) {
+    const sstring limbName = describeBodySlot(limb);
+    
+    // No need to manually pulverize the limb - that happens automatically in
+    // the hurtLimb function once a limb is reduced to 0 HP. So for bruise
+    // stacks, simply apply enough damage to instantly bring the limb to 0 HP.
+    act(format("Your severely bruised %s is utterly ruined!") % limbName, 
+        false, this, nullptr, nullptr, TO_CHAR, ANSI_PURPLE_BOLD);
+    act(format("$n's severely bruised %s is utterly ruined!") % limbName, 
+        false, this, nullptr, nullptr, TO_ROOM, ANSI_PURPLE_BOLD);
+    
+    int rc = hurtLimb(getCurLimbHealth(limb), limb);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+  }
+  
+  return true;
+}
+
 int TBeing::rawInfect(wearSlotT pos, int duration, silentTypeT silent,
   checkImmunityT immcheck, int level) {
   const long modifier2 = level ? level : GetMaxLevel();
@@ -2212,4 +2331,41 @@ int lycanthropeTransform(TBeing* ch) {
     "You hear a chilling wolf howl in the distance.\n\r", mob->in_room);
 
   return TRUE;
+}
+
+// Handle the effects when a vital body part reaches maximum bleeding stacks
+int TBeing::maxBleedVitalPart(wearSlotT limb, int duration) {
+  // Show choking/aspiration messages
+  act(format("The blood from your %s makes it hard to draw breath!") % describeBodySlot(limb), 
+     false, this, nullptr, nullptr, TO_CHAR, ANSI_RED_BOLD);
+  act(format("$n looks panicked as blood from their %s fills $s mouth!") % describeBodySlot(limb), 
+     false, this, nullptr, nullptr, TO_ROOM, ANSI_RED_BOLD);
+     
+  // Check if they already have aspiration
+  affectedData* existingAspiration = 
+    affected ? affected->find_if([](affectedData* aff) {
+      return aff->modifier == DISEASE_ASPIRATION;
+    }) : nullptr;
+    
+  if (existingAspiration) {
+    // Update the duration if the new duration is longer
+    if (existingAspiration->duration < duration) {
+      existingAspiration->duration = duration;
+    }
+  } else {
+    // If they don't have aspiration, add it
+    affectedData aff;
+    aff.type = AFFECT_DISEASE;
+    aff.level = limb;  // Store the source of bleeding
+    aff.duration = duration;
+    aff.location = APPLY_NONE;
+    aff.modifier = DISEASE_ASPIRATION;
+    aff.modifier2 = 0;  // Severity will be calculated in disease_aspiration
+    aff.bitvector = 0;
+    
+    affectTo(&aff);
+    disease_start(this, &aff);
+  }
+  
+  return true;
 }

--- a/code/code/misc/thing.cc
+++ b/code/code/misc/thing.cc
@@ -79,7 +79,8 @@ bool TThing::inLethargica() const {
 }
 
 bool TThing::isSpiked() const {
-  if (isname("spiked", name))
+  const TObj* obj = dynamic_cast<const TObj*>(this);
+  if (isname("spiked", name) || (isname("studded", name) && percentChance(30))|| (isname("barbed", name) && percentChance(30)) || (obj && obj->isObjStat(ITEM_SPIKED)))
     return TRUE;
   return FALSE;
 }

--- a/code/code/misc/thing.h
+++ b/code/code/misc/thing.h
@@ -353,6 +353,7 @@ class TThing {
     virtual int useMe(TBeing*, const char*);
     virtual void findVialAttune(TVial**, int*) {}
     virtual void getBestVial(TVial**) {}
+    virtual int getHardnessSpec(const TBeing*, wearSlotT) const { return 0; }
     virtual int damageMe(TBeing*, TBeing*, wearSlotT) { return FALSE; }
     virtual int sharpenerValueMe(const TBeing*, TMonster*) const;
     virtual int sharpenerGiveMe(TBeing*, TMonster*);

--- a/code/code/obj/obj_base_weapon.cc
+++ b/code/code/obj/obj_base_weapon.cc
@@ -396,6 +396,38 @@ void TBaseWeapon::changeObjValue3(TBeing* ch) {
   ch->sendTo(format(VT_CURSPOS) % 10 % 1);
   ch->sendTo("Enter new value.\n\r--> ");
 }
+  
+int getHardnessSpec(const TBeing* ch, wearSlotT limb) {
+  if (!ch || limb == WEAR_NOWHERE) {
+    return 0;
+  }
+
+  int hardness = material_nums[ch->getMaterial(limb)].hardness;
+  
+  if (ch->affectedBySpell(SPELL_THORNFLESH)) {
+    hardness = material_nums[MAT_WOOD].hardness;
+  }
+  
+  if (ch->affectedBySpell(SPELL_STONE_SKIN)) {
+    hardness = material_nums[MAT_STONE].hardness;
+  }
+  
+  if (ch->doesKnowSkill(SKILL_IRON_FLESH)) {
+    int ironFleshHardness = (ch->getSkillValue(SKILL_IRON_FLESH) * material_nums[MAT_IRON].hardness);
+    if (ironFleshHardness > hardness) {
+      hardness = ironFleshHardness;
+    }
+  }
+  
+  if ((limb == WEAR_HAND_R || limb == WEAR_HAND_L) && ch->doesKnowSkill(SKILL_IRON_FIST)) {
+    int ironFistHardness = (ch->getSkillValue(SKILL_IRON_FIST) * material_nums[MAT_IRON].hardness);
+    if (ironFistHardness > hardness) {
+      hardness = ironFistHardness;
+    }
+  }
+  
+  return hardness;
+}
 
 int TBaseWeapon::damageMe(TBeing* ch, TBeing* v, wearSlotT part_hit) {
   int hardness;

--- a/code/code/obj/obj_general_weapon.cc
+++ b/code/code/obj/obj_general_weapon.cc
@@ -4,9 +4,12 @@
 #include "shop.h"
 #include "shopowned.h"
 #include "liquids.h"
+#include "spells.h"
 #include "toggle.h"
 #include "extern.h"
 #include "being.h"
+#include "materials.h"
+
 
 TGenWeapon::TGenWeapon() : TBaseWeapon() {
   for (int i = 0; i < 3; ++i) {
@@ -164,4 +167,282 @@ bool TGenWeapon::canBackstab() const {
 
 bool TGenWeapon::canStab() const {
   return isPierceWeapon() && getVolume() <= 2000;
+}
+
+bool TGenWeapon::hasSpikes() const { return isObjStat(ITEM_SPIKED); }
+
+int thornsHit(TBeing* victim, TBeing* ch, wearSlotT chLimb, wearSlotT vicLimb) {
+  // Check for valid parameters
+  if (!victim || vicLimb == WEAR_NOWHERE || !ch->affectedBySpell(SPELL_THORNFLESH)) {
+    return false;
+  }
+
+  if (victim->isLimbFlags(vicLimb, PART_MISSING)) {
+    return false;
+  }
+
+  if (victim->isUndead() || victim->isImmune(IMMUNE_BLEED, vicLimb)) {
+    // No bleeding for undead or immune creatures
+    return false;
+  }
+  // Check for victim's limb hardness against attacker's limb hardness
+  int vicLimbHardness = getHardnessSpec(victim, vicLimb);
+  
+  // Access wood hardness directly from the material_nums array
+  // This matches how describeMaterial accesses hardness
+  int chLimbHardness = material_nums[MAT_WOOD].hardness;
+  
+  // If character has Iron Flesh skill, it can enhance the thorns' effectiveness
+  if (ch->doesKnowSkill(SKILL_IRON_FLESH)) {
+    int ironFleshHardness = (ch->getSkillValue(SKILL_IRON_FLESH) * 85/100);
+    if (ironFleshHardness > chLimbHardness) {
+      chLimbHardness = ironFleshHardness;
+    }
+  }
+  
+  // Calculate chance based on hardness difference
+  int hardnessDiff = chLimbHardness - vicLimbHardness;
+  
+  // Only proceed if attacker's hardness is higher AND random check passes
+  if (hardnessDiff <= 0) {
+    return false;
+  }
+  
+  // Use hardness difference as percentage chance
+  if (!::percentChance(hardnessDiff)) {
+    return false;
+  }
+  
+  if (victim->isLimbFlags(vicLimb, PART_BLEEDING)) {
+    static constexpr const char* bleeding_msg =
+      "Blood spatters as the thorns on %s %s sink into %s bleeding %s!";
+
+    sstring chBodyPart = ch->describeBodySlot(chLimb);
+    sstring vicBodyPart = victim->describeBodySlot(vicLimb);
+    act(format(bleeding_msg) % "your" % chBodyPart % "$N's" % vicBodyPart,
+        FALSE, ch, nullptr, victim, TO_CHAR);
+    act(format(bleeding_msg) % "$n's" % chBodyPart % "$N's" % vicBodyPart,
+        FALSE, ch, nullptr, victim, TO_NOTVICT);
+    act(format(bleeding_msg) % "$n's" % chBodyPart % "your" % vicBodyPart,
+        FALSE, ch, nullptr, victim, TO_VICT);
+
+    // Increment the bleed stack
+    victim->incrementBleedStack(vicLimb, 250);
+  } else {
+    static constexpr const char* wound_msg =
+      "The thorns on %s %s tear open a <R>bloody wound<1> in %s %s!";
+
+    sstring chBodyPart = ch->describeBodySlot(chLimb);
+    sstring vicBodyPart = victim->describeBodySlot(vicLimb);
+    act(format(wound_msg) % "your" % chBodyPart % "$N's" % vicBodyPart,
+        FALSE, ch, nullptr, victim, TO_CHAR);
+    act(format(wound_msg) % "$n's" % chBodyPart % "$N's" % vicBodyPart,
+        FALSE, ch, nullptr, victim, TO_NOTVICT);
+    act(format(wound_msg) % "$n's" % chBodyPart % "your" % vicBodyPart,
+        FALSE, ch, nullptr, victim, TO_VICT);
+
+    victim->rawBleed(vicLimb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+  }
+
+  return true;
+}
+
+int hardHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT vicLimb, wearSlotT chLimb) {
+  TObj *weap = dynamic_cast<TObj*>(ch->equipment[chLimb]);
+  TObj *vicEq = dynamic_cast<TObj*>(victim->equipment[vicLimb]);
+  int vicHard = vicEq ? material_nums[vicEq->getMaterial()].hardness : 0;
+  int weapHard = weap ? material_nums[weap->getMaterial()].hardness : 0;
+  if (!weap) {
+    weapHard = getHardnessSpec(ch, chLimb);
+  }
+  
+  if (!vicEq) {
+    vicHard = getHardnessSpec(victim, vicLimb);
+  }
+    
+  int hardChance = (weapHard - vicHard);
+  if ((percentChance(hardChance)) && !victim->isTough()) {
+      int eqDamage = (weapHard-vicHard)/10;
+      // Case 1: Weapon hits victim's equipment
+    if (weap && vicEq) {
+      static constexpr const char* weap_vs_eq_msg =
+        "%s $p strikes %s $P with a solid impact!";
+
+      act(format(weap_vs_eq_msg) % "Your" % "$N's", FALSE, ch, weap, vicEq, TO_CHAR);
+      act(format(weap_vs_eq_msg) % "$n's" % "your", FALSE, ch, weap, vicEq, TO_VICT);
+      act(format(weap_vs_eq_msg) % "$n's" % "$N's", FALSE, ch, weap, vicEq, TO_NOTVICT);
+      vicEq->damageItem(eqDamage);
+        if (vicEq->getStructPoints() <= 0) {
+         vicEq->makeScraps();
+        delete vicEq;
+        vicEq = nullptr;
+      }
+    }
+    // Case 2: Weapon hits victim's body part
+    else if (weap && !vicEq) {
+      static constexpr const char* weap_vs_body_msg =
+        "%s $p strikes %s %s with a solid impact!";
+
+      sstring bodyPart = victim->describeBodySlot(vicLimb);
+      act(format(weap_vs_body_msg) % "Your" % "$N's" % bodyPart, FALSE, ch, weap, victim, TO_CHAR);
+      act(format(weap_vs_body_msg) % "$n's" % "your" % bodyPart, FALSE, ch, weap, victim, TO_VICT);
+      act(format(weap_vs_body_msg) % "$n's" % "$N's" % bodyPart, FALSE, ch, weap, victim, TO_NOTVICT);
+      if (victim->isLimbFlags(vicLimb, PART_BRUISED)) {
+        victim->incrementBruiseStack(vicLimb, 100);
+      } else {
+        victim->rawBruise(vicLimb, 100, SILENT_NO, CHECK_IMMUNITY_NO);
+      }
+    }
+    // Case 3: Body part hits victim's equipment
+    else if (!weap && vicEq) {
+      static constexpr const char* body_vs_eq_msg =
+        "%s %s strikes %s $p with a solid impact!";
+
+      sstring bodyPart = ch->describeBodySlot(chLimb);
+      act(format(body_vs_eq_msg) % "Your" % bodyPart % "$N's", FALSE, ch, vicEq, victim, TO_CHAR);
+      act(format(body_vs_eq_msg) % "$n's" % bodyPart % "your", FALSE, ch, vicEq, victim, TO_VICT);
+      act(format(body_vs_eq_msg) % "$n's" % bodyPart % "$N's", FALSE, ch, vicEq, victim, TO_NOTVICT);
+      vicEq->damageItem(eqDamage);
+      if (vicEq->getStructPoints() <= 0) {
+        vicEq->makeScraps();
+        delete vicEq;
+      }
+    }
+    // Case 4: Body part hits victim's body part
+    else {
+      static constexpr const char* body_vs_body_msg =
+        "%s %s strikes %s %s with a solid impact!";
+
+      sstring attackerPart = ch->describeBodySlot(chLimb);
+      sstring victimPart = victim->describeBodySlot(vicLimb);
+      act(format(body_vs_body_msg) % "Your" % attackerPart % "$N's" % victimPart, FALSE, ch, nullptr, victim, TO_CHAR);
+      act(format(body_vs_body_msg) % "$n's" % attackerPart % "your" % victimPart, FALSE, ch, nullptr, victim, TO_VICT);
+      act(format(body_vs_body_msg) % "$n's" % attackerPart % "$N's" % victimPart, FALSE, ch, nullptr, victim, TO_NOTVICT);
+      if (victim->isLimbFlags(vicLimb, PART_BRUISED)) {
+        victim->incrementBruiseStack(vicLimb, 100);
+      } else {
+        victim->rawBruise(vicLimb, 100, SILENT_NO, CHECK_IMMUNITY_NO);
+      }
+    }
+    
+  }
+  return true;  
+}
+int spikesBreak(TBeing* victim, TBeing* ch, TObj* obj) {
+  int dam = ::number(1, 4);
+  if (!obj)
+    return false;
+
+  if ((obj->isObjStat(ITEM_SPIKED)) && percentChance(25) && victim->isTough()) {
+    static constexpr const char* catch_msg = "$n's $o catches on $N's $o!";
+    static constexpr const char* spikes_break_msg = "Some spikes break off, damaging $n's $o!";
+
+    obj->addToStructPoints(-dam);
+    obj->addToMaxStructPoints(-1);
+    act(format(catch_msg) % "Your" % "$N", FALSE, ch, obj, victim, TO_CHAR);
+    act(format(catch_msg) % "$n's" % "$N", FALSE, ch, obj, victim, TO_NOTVICT);
+    act(format(catch_msg) % "$n's" % "$N", FALSE, ch, obj, victim, TO_VICT);
+    act(format(spikes_break_msg) % "$n's", FALSE, ch, obj, nullptr, TO_ROOM, ANSI_GRAY);
+    act(format(spikes_break_msg) % "your", FALSE, ch, obj, nullptr, TO_CHAR, ANSI_GRAY);
+
+    if (obj->getMaxStructPoints() <= 0) {
+      obj->makeScraps();
+      return true;
+    }
+
+    if (auto* weapon = dynamic_cast<TGenWeapon*>(obj)) {
+      static constexpr const char* mars_edge_msg = "The impact mars the edge of %s $o!";
+
+      weapon->addToCurSharp(-dam);
+      weapon->addToMaxSharp(-1);
+      act(format(mars_edge_msg) % "$n's", FALSE, ch, obj, nullptr, TO_ROOM);
+      act(format(mars_edge_msg) % "your", FALSE, ch, obj, nullptr, TO_CHAR);
+
+      if (weapon->getMaxSharp() <= 0) {
+        weapon->makeScraps();
+        return true;
+      }
+    }
+
+    if (percentChance(25)) {
+      static constexpr const char* less_dangerous_msg = "%s $p looks less dangerous now.";
+
+      obj->remObjStat(ITEM_SPIKED);
+      act(format(less_dangerous_msg) % "$n's", FALSE, ch, obj, nullptr, TO_ROOM, ANSI_GRAY);
+      act(format(less_dangerous_msg) % "Your", FALSE, ch, obj, nullptr, TO_CHAR, ANSI_GRAY);
+    }
+    return true;
+  }
+  return false;
+}
+
+int impactSpec(TBeing* ch, TBeing* victim, wearSlotT damSource, wearSlotT pos) {
+  // Get the object at the damage source (if any)
+  TObj* obj = dynamic_cast<TObj*>(ch->equipment[damSource]);
+
+  if (obj) {
+    // There is equipment on damSource
+    if (obj->isSpiked()) {
+      // Equipment has spikes - use spikesHit
+      return spikesHit(victim, ch, obj, pos);
+    }
+      // Equipment has no spikes - use hardHit
+      return hardHit(victim, ch, obj, pos, damSource);
+    
+  } else {
+    // No equipment on damSource
+    if (ch->affectedBySpell(SPELL_THORNFLESH)) {
+      // Has thornflesh - use thornsHit
+      return thornsHit(victim, ch, damSource, pos);
+    }
+      // No thornflesh - use hardHit
+      return hardHit(victim, ch, nullptr, pos, damSource);
+    
+  }
+}
+
+int spikesHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT limb) {
+  // Check for valid parameters
+  if (!victim || limb == WEAR_NOWHERE) {
+    return false;
+  }
+
+  if (!obj->isObjStat(ITEM_SPIKED) && !obj->isSpiked()) {
+    return false;
+  }
+
+  if (victim->isLimbFlags(limb, PART_MISSING)) {
+    return false;
+  }
+
+  if (victim->isUndead() || victim->isImmune(IMMUNE_BLEED, limb)) {
+    // No bleeding for undead or immune creatures
+    return false;
+  }
+
+  if (victim->isLimbFlags(limb, PART_BLEEDING)) {
+    static constexpr const char* spikes_bleeding_msg =
+      "Blood spatters as the spikes on %s $o sink into %s bleeding %s!";
+
+    sstring vicBodyPart = victim->describeBodySlot(limb);
+    act(format(spikes_bleeding_msg) % "your" % "$N's" % vicBodyPart, FALSE, ch, obj, victim, TO_CHAR);
+    act(format(spikes_bleeding_msg) % "$n's" % "$N's" % vicBodyPart, FALSE, ch, obj, victim, TO_NOTVICT);
+    act(format(spikes_bleeding_msg) % "$n's" % "your" % vicBodyPart, FALSE, ch, obj, victim, TO_VICT);
+
+    // Increment the bleed stack
+    victim->incrementBleedStack(limb, 250);
+  } else {
+    static constexpr const char* spikes_wound_msg =
+      "The spikes on $p tear open a <R>bloody wound<1> in %s %s!";
+
+    sstring vicBodyPart = victim->describeBodySlot(limb);
+    act(format(spikes_wound_msg) % "$N's" % vicBodyPart, FALSE, ch, obj, victim, TO_CHAR);
+    act(format(spikes_wound_msg) % "$N's" % vicBodyPart, FALSE, ch, obj, victim, TO_NOTVICT);
+    act(format(spikes_wound_msg) % "your" % vicBodyPart, FALSE, ch, obj, victim, TO_VICT);
+
+    victim->rawBleed(limb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+  }
+  
+  spikesBreak(victim, ch, obj);
+  return true;
 }

--- a/code/code/obj/obj_general_weapon.h
+++ b/code/code/obj/obj_general_weapon.h
@@ -34,9 +34,16 @@ class TGenWeapon : public TBaseWeapon {
     virtual bool canCudgel() const;
     virtual bool canBackstab() const;
     virtual bool canStab() const;
+    virtual bool hasSpikes() const;
 
     TGenWeapon();
     TGenWeapon(const TGenWeapon& a);
     TGenWeapon& operator=(const TGenWeapon& a);
     virtual ~TGenWeapon();
 };
+
+int impactSpec(TBeing* ch, TBeing* victim, wearSlotT damSource, wearSlotT pos);
+int spikesHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT limb);
+int spikesBreak(TBeing* victim, TBeing* ch, TObj* obj);
+int thornsHit(TBeing* victim, TBeing* ch, wearSlotT chLimb, wearSlotT vicLimb);
+int hardHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT vicLimb, wearSlotT chLimb);


### PR DESCRIPTION
refactoring melee skills to use the same function that handles the application of bleeding and bruising

because these deal with material hardness, i also made a function getHardnessSpec, that can fetch special cases where effective wearSlotT hardness might be different. e.g. stoneskin and ironbody. this can be seen as just a logical reckoning of what ironbody is supposed to represent, but wasn't considering.

the umbrella function of impactSpec actually handles bleeding/bruising through determining which of 3 functions ought to be applied for the melee skill: spikesHit, thornsHit, and hardHit. spikesHit and thornsHit deal in the application of bleeding and can be seen as sister functions. most importantly, they now treat bleeding with the same logic that Cirius' combat update, which can stack bleeding effects. it does so through the function incrementBleeds.

spikesHit has interaction with the ITEM_SPIKED flag but tends to be more reliable in the application of bleeds. thornsHit relies on a naked wearSlotT and probably represents a pretty niche class interaction, but is otherwise similar to spikesHit in how it interacts with bleeding.

hardHit makes a comparison of hardness between the actor and the target and determines whether or not a limb is damaged and a bruise created.

the warrior skills were refactored to fit into the application of impactSpec, but no functionality was altered, except in the case of Grapple.

i found some odd logic that was making grapple very difficult to succeed, which in turn made it overly punishing to warriors using it.
<img width="1266" height="109" alt="Screenshot 2025-07-30 182918" src="https://github.com/user-attachments/assets/a726ea91-4d45-4607-b492-0c28ca02c5c9" />
<img width="1287" height="101" alt="Screenshot 2025-07-30 182955" src="https://github.com/user-attachments/assets/dc84ad3f-3465-48d1-a7bc-a08fd15d566e" />
<img width="1226" height="105" alt="Screenshot 2025-07-30 183209" src="https://github.com/user-attachments/assets/4b22a985-b981-4998-a200-04be7808c6f9" />
<img width="1154" height="228" alt="Screenshot 2025-07-30 184042" src="https://github.com/user-attachments/assets/608b85fa-2a42-4c97-9788-74e4ea51726d" />
<img width="1706" height="172" alt="Screenshot 2025-07-30 184924" src="https://github.com/user-attachments/assets/b46ec27f-b06e-4481-8a92-8c1d31894a97" />
<img width="1527" height="156" alt="Screenshot 2025-07-30 190322" src="https://github.com/user-attachments/assets/72497ee6-4891-4f4a-8648-5360454ab18b" />
<img width="1105" height="254" alt="Screenshot 2025-07-30 232527" src="https://github.com/user-attachments/assets/79230511-d683-4c08-80c4-6b79b35c729f" />
