### PR TITLE
Adjust max loads for various holiday quest mobs so we don't lag the server

### DIFF
--- a/lib/zonefiles/1
+++ b/lib/zonefiles/1
@@ -404,9 +404,14 @@ O 0 1865 1 28860         Petrified in Undead Graveyard
 *G 1 803 9999             	blue potion
 
 * * Mid level pumpkin squashlings
-*M 0 29611 500 13700	pumpkin plant monster (level 25)
-*G 1 14148 9999		ghostly wand
+*M 0 29611 250 13700	pumpkin plant monster (level 25)
 *G 1 823 9999      vermillion potion
+*G 1 1647 9999		scroll (blast of fury)
+
+* * Mid level pumpkin squashlings
+*M 0 29611 250 13700	pumpkin plant monster (level 25)
+*G 1 823 9999      vermillion potion
+*G 1 1646 9999		scroll (acid blast)
 
 **********************************
 * END OF October holiday quest *


### PR DESCRIPTION
This changes the max load of various holiday quest mobs as it seems thousands of extra mobs might impact server performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced spawn quantities for low/mid/high pumpkin mobs, holiday minions, and reindeer (large 9999 counts lowered to 500/250) to limit simultaneous occurrences.
  * Added duplicated mid-level spawn groups and extra spawn blocks in seasonal zones, increasing occurrences of some scrolls and vermillion potions.
  * No other gameplay stats or non-spawn fields were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->