### PR TITLE
fixing problems with returning from shapeshift

### DIFF
--- a/code/code/misc/immortal.cc
+++ b/code/code/misc/immortal.cc
@@ -2116,9 +2116,9 @@ void TBeing::doReturn(const sstring& argument, wearSlotT limb, bool tell,
       *(real_roomp(Room::CS)) += *originalBody;
 
     SwitchStuff(this, originalBody);
-    originalBody->affectFrom(SPELL_POLYMORPH);
-    originalBody->affectFrom(SKILL_DISGUISE);
-    originalBody->affectFrom(SPELL_SHAPESHIFT);
+    affectFrom(SPELL_POLYMORPH);
+    affectFrom(SKILL_DISGUISE);
+    affectFrom(SPELL_SHAPESHIFT);
   }
 
   originalBody->desc = desc;

--- a/code/code/misc/periodic.cc
+++ b/code/code/misc/periodic.cc
@@ -766,7 +766,7 @@ int TBeing::updateAffects() {
     }
     if ((af->type == SPELL_POLYMORPH) || (af->type == SKILL_DISGUISE) ||
         (af->type == SPELL_SHAPESHIFT)) {
-      if (!desc->original) {
+      if (!desc || !desc->original) {
         affectRemove(af);
         continue;
       }
@@ -861,7 +861,7 @@ int TBeing::updateAffects() {
     }
   }
   if (shouldReturn) {
-    doReturn("", WEAR_NOWHERE, true);
+    doReturn("", WEAR_NOWHERE, true, false);
     return ALREADY_DELETED;
   }
   return 0;
@@ -1675,7 +1675,7 @@ int TBeing::updateHalfTickStuff() {
           (desc->original->polyed == POLY_TYPE_SHAPESHIFT)) {
         sendTo(
           "Your shape can not survive without a connection to nature.\n\r");
-        doReturn("", WEAR_NOWHERE, true);
+        doReturn("", WEAR_NOWHERE, true, false);
         return ALREADY_DELETED;
       }
     }


### PR DESCRIPTION
Two instances of returning to your original body were throwing crash bugs.

One was the spell's duration ending naturally. The other was while standing indoors, which is supposed to cause the spell to cease.

Using the 'return' command was not throwing the same error. So, through process of elimination and going back over some notes with Cirius from a few months ago, I was able to determine that the problem was a double deletion call. So now, it doesn't do that.

Spell works now. Furry cosplayers rejoice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of polymorph, disguise, and shapeshift transformation effects when returning to original form.
  * Refined transformation state management during form transitions to ensure proper effect removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->