### PR TITLE
Fix error in `docker.yml` GitHub Action workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,7 @@ ARG CMAKE_PRESET
 RUN --mount=type=cache,target=/home/ubuntu/sneezymud/build \
   cd /home/ubuntu/sneezymud && \
   cmake --preset ${CMAKE_PRESET} && \
-  cmake --build --preset ${CMAKE_PRESET} && \
-  cp build/${CMAKE_PRESET}/code/code/sneezy code/sneezy
+  cmake --build --preset ${CMAKE_PRESET}
 
 FROM ubuntu:${UBUNTU_VERSION} AS run
 LABEL maintainer="SneezyMUD Development Team <https://discord.gg/F5zdYwWBzY>"

--- a/code/code/CMakeLists.txt
+++ b/code/code/CMakeLists.txt
@@ -49,10 +49,10 @@ target_link_libraries(sneezy
 )
 
 add_custom_command(TARGET sneezy POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    COMMAND ${CMAKE_COMMAND} -E rename
         "$<TARGET_FILE:sneezy>"
         "${CMAKE_SOURCE_DIR}/code/sneezy"
-    COMMENT "Symlinked code/sneezy -> $<TARGET_FILE:sneezy>"
+    COMMENT "Moved sneezy binary to code/sneezy"
 )
 
 if(SNEEZY_BUILD_LOWTOOLS)


### PR DESCRIPTION
I previously fixed a problem with the `Build and Test` workflow by having cmake symlink the final executable to `code/sneezy` in all builds, but that caused a new issue in the main `Build and Push` workflow where it failing due to trying to run `cp` on the symlink's source file. Having cmake just move the actual binary after the build instead of symlinking should fix both issues at the same time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to modify how the compiled binary is handled during construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->