### PR TITLE
Fix "build and publish" action, take 2

### DIFF
--- a/code/code/CMakeLists.txt
+++ b/code/code/CMakeLists.txt
@@ -49,10 +49,10 @@ target_link_libraries(sneezy
 )
 
 add_custom_command(TARGET sneezy POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E rename
+    COMMAND ${CMAKE_COMMAND} -E copy
         "$<TARGET_FILE:sneezy>"
         "${CMAKE_SOURCE_DIR}/code/sneezy"
-    COMMENT "Moved sneezy binary to code/sneezy"
+    COMMENT "Copied sneezy binary to code/sneezy"
 )
 
 if(SNEEZY_BUILD_LOWTOOLS)


### PR DESCRIPTION
The rename operation to move the executable doesn't work across filesystems, so I had to change it to a copy. Confirmed this fixes it by testing it in my fork first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modified build configuration to copy the application binary to its deployment location instead of using a symbolic link during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->