### PR TITLE
Fix oversight in Dockerfile causing incorrect volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# useradd -r flag creates a system account, which is preferable when running as a service
-# useradd -m flag forces creation of home directory, which -r flag prevents by default
-RUN groupadd -r sneezy && useradd -r -g sneezy -m sneezy
+# Rename the default 'ubuntu' user (UID/GID 1000) to 'sneezy'.
+# UID 1000 must be preserved to match file ownership in the sneezy-mutable Docker volume.
+# The monitor service running on the host sets volume ownership to UID 1000, so the in-container user must match
+# or the game server will not have permission to read/write its data files.
+RUN usermod -l sneezy -d /home/sneezy -m ubuntu && groupmod -n sneezy ubuntu
 
 COPY --chown=sneezy:sneezy code/sneezy /home/sneezy/code/sneezy
 COPY --chown=sneezy:sneezy lib /home/sneezy/lib


### PR DESCRIPTION
When I made the previous change to the Dockerfile to revert the user inside the container back to `sneezy` I overlooked the fact that the Ubuntu container already includes a built-in 'ubuntu' user with UID 1000. Therefore the `sneezy` user was getting created with UID other than 1000. But the monitor service was configured to set the volume permissions to UID 1000, which led to the volume being owned by 'ubuntu' user instead of 'sneezy' user, and the game not being able to read or write to the volume.

Simply renaming the built-in `ubuntu` user to `sneezy` ensures that the `sneezy` user inside the container has UID 1000, matching the volume ownership set by the monitor service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker container build configuration to improve user and group management with enhanced file ownership and permission handling. Changes ensure proper UID/GID alignment for volumes and mounted storage, providing better consistency and reliability for containerized deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->