### PR TITLE
Update potions of learning to work with multiclass

### DIFF
--- a/code/code/misc/other.cc
+++ b/code/code/misc/other.cc
@@ -2646,7 +2646,6 @@ int doLiqSpell(TBeing* ch, TBeing* vict, liqTypeT liq, int amt) {
       for (classIndT Class = MIN_CLASS_IND; Class < MAX_CLASSES; Class++) {
         if (vict->hasClass(1 << Class)) {
           vict->addPracs(amt, Class);
-          break;
         }
       }
 


### PR DESCRIPTION
Simply removes the early break so that potions of learning add practices for every class a character has instead of just the first one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed learning potions to apply their benefits to all character classes instead of only the first matching class, allowing for more comprehensive practice gains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->