### PR TITLE
altered the way taskGainExp gathers exp to prevent abuse and plevel

### DIFF
--- a/code/code/disc/disc_advanced_adventuring.cc
+++ b/code/code/disc/disc_advanced_adventuring.cc
@@ -119,10 +119,11 @@ int forage(TBeing* caster, short bKnown) {
       *caster->roomp += *obj;
       foodpile /= 3;
     }
-    
-    caster->gainTaskExp(0, 50.0);
+
+    // Foraging is a simple task with moderate difficulty
+    caster->gainTaskExp(0.5);
     caster->doSave(SILENT_YES);
-    
+
     aff.type = SKILL_FORAGE;
     aff.location = APPLY_NONE;
     aff.duration = 4 * Pulse::UPDATES_PER_MUDHOUR;
@@ -649,7 +650,7 @@ int determineSkinningItem(TBaseCorpse* corpse, int* amount, char* msg,
       case RACE_DINOSAUR:
       case RACE_FISH:
       case RACE_BIRD:
-      case RACE_SNAKE: 
+      case RACE_SNAKE:
       case RACE_PRIMATE:
       case RACE_RODENT:
       case RACE_FISHMAN:

--- a/code/code/disc/disc_thief_looting.cc
+++ b/code/code/disc/disc_thief_looting.cc
@@ -113,7 +113,9 @@ int detectSecret(TBeing* thief) {
                                  : "NO NAME. TELL A GOD"));
         act(buf, FALSE, thief, 0, 0, TO_ROOM);
         thief->setMove(max(0, (thief->getMove() - 30)));
-        thief->gainTaskExp(0, 50);
+
+        // Finding a secret door is a moderate difficulty task
+        thief->gainTaskExp(0.5);
         thief->doSave(SILENT_YES);
         return TRUE;
       }

--- a/code/code/misc/being.cc
+++ b/code/code/misc/being.cc
@@ -1680,31 +1680,32 @@ void TBeing::removeAllProtection() {
 
 }
 
- double TBeing::gainTaskExp(int baseLevel, double scaleFactor) {
-   if (roomp && roomp->isRoomFlag(ROOM_ARENA))
-     return -1;
-     
-   if (isPking() || isImmortal())
-     return -1;
- 
-   if (scaleFactor <= 0.0) {
-     vlogf(LOG_BUG,
-       format("gainTaskExp called with non-positive scaleFactor: %f") % scaleFactor);
-     return -1;
-   }
-   
-   int lvl = baseLevel ? baseLevel : GetMaxLevel();
-   if (lvl > 15)
-     lvl -= 15;
-   else
-     lvl = 1;
+double TBeing::gainTaskExp(double difficulty) {
+  if (roomp && roomp->isRoomFlag(ROOM_ARENA))
+    return -1;
 
-  // 10% exp variance
-  double exp = mob_exp(lvl);
+  if (isPking() || isImmortal())
+    return -1;
+
+  if (difficulty <= 0.0) {
+    vlogf(LOG_BUG,
+      format("gainTaskExp called with non-positive difficulty: %f") % difficulty);
+    return -1;
+  }
+
+  int level = min((int)GetMaxLevel(), 20);  // Cap at level 20 for exp calculation
+
+  // Give roughly 1/15th of a level per task completion at max difficulty
+  double expNeeded = getExpClassLevel(level + 1) - getExpClassLevel(level);
+  double exp = (expNeeded / 15.0) * difficulty;
+
+  // Add some variance (±10%)
   exp *= (1.0 + ((::number(0, 20) - 10) / 100.0));
-  double finalExp = exp * scaleFactor;
 
-  gain_exp(this, finalExp, -1);
-  return finalExp;
+  // Ensure at least 1 exp
+  exp = max(1.0, exp);
+
+  gain_exp(this, exp, -1);
+  return exp;
 }
 

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -600,7 +600,7 @@ class TBeing : public TThing {
     void checkGuardiansLight();
     int checkAdvDefense();
     int doAdvDefense(TBeing*, TThing*, int*, int, wearSlotT);
-    
+
 
     // Postmaster
     void postmasterSendMail(const char*, TMonster*);
@@ -1793,7 +1793,7 @@ class TBeing : public TThing {
     void doCommand(const char*);
     int doAssist(const char*, TBeing*, bool flags = FALSE);
     void doRoll(TBeing*, dirTypeT);
-    double gainTaskExp(int baseLevel, double scaleFactor);
+    double gainTaskExp(double difficulty);
     void doRoll(TObj*, dirTypeT);
     void doRoll(const sstring&);
     void doEcho(const char*);

--- a/code/code/obj/obj_base_corpse.cc
+++ b/code/code/obj/obj_base_corpse.cc
@@ -261,7 +261,15 @@ int TBaseCorpse::dissectMe(TBeing* caster) {
     act(msg, FALSE, caster, obj, this, TO_CHAR);
     act(gl_msg, FALSE, caster, obj, this, TO_ROOM);
     log_object(obj);
-    caster->gainTaskExp(getCorpseLevel(), 30.0);
+
+    // Calculate difficulty based on corpse vs character level
+    int corpseLvl = min((int)getCorpseLevel(), 20);
+    int charLvl = min((int)caster->GetMaxLevel(), 20);
+    int effectiveCorpseLvl = min(corpseLvl, charLvl + 5);
+    double difficulty = 0.5 + ((effectiveCorpseLvl - charLvl) / 10.0);
+    difficulty = max(0.1, min(1.0, difficulty));
+
+    caster->gainTaskExp(difficulty);
     caster->doSave(SILENT_YES);
 
     return TRUE;

--- a/code/code/task/task_butcher.cc
+++ b/code/code/task/task_butcher.cc
@@ -216,7 +216,15 @@ int TThing::butcherPulse(TBeing* ch, TBaseCorpse* corpse) {
     steak->setDescr(buf);
 
     *ch += *steak;
-    ch->gainTaskExp(corpse->getCorpseLevel(), 30.0);
+
+    // Calculate difficulty based on corpse vs character level
+    int corpseLvl = min((int)corpse->getCorpseLevel(), 20);
+    int charLvl = min((int)ch->GetMaxLevel(), 20);
+    int effectiveCorpseLvl = min(corpseLvl, charLvl + 5);
+    double difficulty = 0.5 + ((effectiveCorpseLvl - charLvl) / 10.0);
+    difficulty = max(0.1, min(1.0, difficulty));
+
+    ch->gainTaskExp(difficulty);
     ch->doSave(SILENT_YES);
   }
   return FALSE;
@@ -281,7 +289,14 @@ int TTool::butcherPulse(TBeing* ch, TBaseCorpse* corpse) {
 #endif
   }
 
-  ch->gainTaskExp(corpse->getCorpseLevel(), 30.0);
+  // Calculate difficulty based on corpse vs character level
+  int corpseLvl = min((int)corpse->getCorpseLevel(), 20);
+  int charLvl = min((int)ch->GetMaxLevel(), 20);
+  int effectiveCorpseLvl = min(corpseLvl, charLvl + 5);
+  double difficulty = 0.5 + ((effectiveCorpseLvl - charLvl) / 10.0);
+  difficulty = max(0.1, min(1.0, difficulty));
+
+  ch->gainTaskExp(difficulty);
   ch->doSave(SILENT_YES);
   return FALSE;
 }
@@ -424,7 +439,15 @@ int bareHandsButcherPulse(TBeing* ch, TBaseCorpse* corpse) {
                     meats[whichmeat] % fromName);
 
     *ch += *steak;
-    ch->gainTaskExp(corpse->getCorpseLevel(), 30.0);
+
+    // Calculate difficulty based on corpse vs character level
+    int corpseLvl = min((int)corpse->getCorpseLevel(), 20);
+    int charLvl = min((int)ch->GetMaxLevel(), 20);
+    int effectiveCorpseLvl = min(corpseLvl, charLvl + 5);
+    double difficulty = 0.5 + ((effectiveCorpseLvl - charLvl) / 10.0);
+    difficulty = max(0.1, min(1.0, difficulty));
+
+    ch->gainTaskExp(difficulty);
     ch->doSave(SILENT_YES);
   }
   return FALSE;

--- a/code/code/task/task_cook.cc
+++ b/code/code/task/task_cook.cc
@@ -133,22 +133,23 @@ void TBeing::doCook(sstring arg) {
   start_task(this, pot, NULL, TASK_COOK, "", recipes[recipe_index].difficulty, inRoom(), recipe_index, 0, 5);
 }
 
-double getCookingDifficultyScale(taskDiffT diff) {
+double getCookingDifficulty(taskDiffT diff) {
   switch(diff) {
-    case TASK_HOPELESS:    return .80;   // Most exp - hardest task
-    case TASK_DANGEROUS:   return .65;
-    case TASK_DIFFICULT:   return .50;
-    case TASK_NORMAL:      return .35;
-    case TASK_EASY:        return .25;
-    case TASK_TRIVIAL:     return .20;   // Least exp - easiest task
-    default:               return .35;   // Normal as default
+    case TASK_TRIVIAL:     return 0.2;
+    case TASK_EASY:        return 0.35;
+    case TASK_NORMAL:      return 0.5;
+    case TASK_DIFFICULT:   return 0.65;
+    case TASK_DANGEROUS:   return 0.8;
+    case TASK_HOPELESS:    return 1.0;
+    case TASK_IMPOSSIBLE:  return 1.0;  // Same as hopeless
+    default:               return 0.5;  // Normal as default
   }
 }
 
 int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* pot) {
   int recipe_index = ch->task->status;
   const int MAX_TIME = 50; // Prevent infinite failure loop
-  
+
   // Basic validation
   if (recipe_index < 0 || recipes[recipe_index].recipe < 0) {
     ch->sendTo("Something went wrong with the recipe.\n\r");
@@ -165,7 +166,7 @@ int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* po
     if (!pot->stuff.empty()) {
       delete pot->stuff.front();
     }
-    
+
     return FALSE;
   }
 
@@ -176,7 +177,7 @@ int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* po
   if (ch->task->timeLeft < 0) {
     act("You finish cooking.", FALSE, ch, pot, 0, TO_CHAR);
     act("$n finishes cooking.", TRUE, ch, pot, 0, TO_ROOM);
-    
+
     // Verify the food object matches our recipe
     TObj* food = dynamic_cast<TObj*>(pot->stuff.front());
    if (!food || obj_index[food->number].virt != recipes[recipe_index].vnum) {
@@ -185,16 +186,13 @@ int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* po
       if (food) delete food;
       return FALSE;
     }
-    
+
     if (ch->bSuccess(ch->getSkillValue(SKILL_COOK), SKILL_COOK)) {
       ch->sendTo(format("You successfully prepare %s.\n\r") % recipes[recipe_index].name);
-      int diffValue = recipes[recipe_index].difficulty * 10;
-      if (diffValue <= 1)
-        diffValue = 5;
-      
-      // Apply difficulty scaling to experience gain
-      double scaleFactor = getCookingDifficultyScale(recipes[recipe_index].difficulty);
-      ch->gainTaskExp(diffValue, scaleFactor);
+
+      // Calculate difficulty and gain experience
+      double difficulty = getCookingDifficulty(recipes[recipe_index].difficulty);
+      ch->gainTaskExp(difficulty);
     } else {
       ch->sendTo("Your cooking attempt fails, ruining the ingredients.\n\r");
       if (recipes[recipe_index].difficulty >= TASK_DIFFICULT) {
@@ -206,13 +204,13 @@ int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* po
       }
       delete food;
       TObj* burnt = read_object(Obj::GENERIC_COMMODITY, VIRTUAL);
-      
+
       if (burnt) {
         burnt->setMaterial(MAT_POWDER);  // Ash
         *pot += *burnt;
       }
     }
-    
+
     ch->doSave(SILENT_YES);
     ch->stopTask();
     return FALSE;
@@ -228,7 +226,7 @@ int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* po
         if (ch->getSkillValue(SKILL_COOK) > 50) timeReduction++;
         if (ch->getSkillValue(SKILL_COOK) > 75) timeReduction++;
         ch->task->timeLeft -= timeReduction;
-        
+
         switch (ch->task->timeLeft) {
           case 2:
           case 1:
@@ -244,12 +242,12 @@ int task_cook(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*, TObj* po
       } else {
         // Higher difficulty = more time added on failure
         int penalty = (recipes[recipe_index].difficulty + 1) / 2;
-        
+
         if (ch->task->timeLeft < MAX_TIME) {
           ch->task->timeLeft += penalty;
           act("You make a mistake and ruin some of your work.", FALSE, ch, pot, 0, TO_CHAR);
           act("$n makes a mistake while cooking.", TRUE, ch, pot, 0, TO_ROOM);
-          
+
           if (recipes[recipe_index].difficulty >= TASK_DIFFICULT) {
             ch->sendTo("You burn yourself in the process!\n\r");
             int dam = 1 + number(recipes[recipe_index].difficulty, recipes[recipe_index].difficulty * 5);

--- a/code/code/task/task_fishing.cc
+++ b/code/code/task/task_fishing.cc
@@ -450,7 +450,8 @@ int task_fishing(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom* rp,
               (::number(5, 10) > rp->getFished())) {
             *ch += *fish;
 
-            ch->gainTaskExp(0, 50.0);
+            // Fishing is a simple task with moderate difficulty
+            ch->gainTaskExp(0.5);
             ch->doSave(SILENT_YES);
 
             if (awesomeFisher) {

--- a/code/code/task/task_logging.cc
+++ b/code/code/task/task_logging.cc
@@ -223,7 +223,8 @@ int task_logging(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom* rp,
               (log = harvest_a_log(rp))) {
             *rp += *log;
 
-            ch->gainTaskExp(0, 50.0);
+            // Logging is a simple task with moderate difficulty
+            ch->gainTaskExp(0.5);
             ch->doSave(SILENT_YES);
             act("You harvest $p.", FALSE, ch, log, 0, TO_CHAR);
             act("$n harvests $p.", TRUE, ch, log, 0, TO_ROOM);

--- a/code/code/task/task_picklock.cc
+++ b/code/code/task/task_picklock.cc
@@ -69,15 +69,17 @@ static void pick_pulse(TBeing* ch, TThing* pick) {
                   fname(exit->keyword))
         : sstring("$n picks the lock.");
     act(msg, true, ch, nullptr, nullptr, TO_ROOM);
-    
+
     ch->sendTo("The lock quickly yields to your skills.\n\r");
-    
-    double lockExp = 50.0 - ((exit->lock_difficulty / 100.0) * 40.0);
-    lockExp = max(10.0, min(50.0, lockExp));
-    
-    ch->gainTaskExp(0, lockExp);
+
+    // Calculate difficulty based on lock difficulty (0-100 scale)
+    // Convert to 0.0-1.0 range, with harder locks giving more exp
+    double difficulty = exit->lock_difficulty / 100.0;
+    difficulty = max(0.1, min(1.0, difficulty));
+
+    ch->gainTaskExp(difficulty);
     ch->doSave(SILENT_YES);
-    
+
     // now for unlocking the other side, too
     TRoom* other = real_roomp(exit->to_room);
     roomDirData* back;

--- a/code/code/task/task_plant.cc
+++ b/code/code/task/task_plant.cc
@@ -145,7 +145,7 @@ int TBeing::doSeedPlant(sstring arg) {
     if ((seeds = dynamic_cast<TTool*>(t))) {
       if (seeds->getToolType() == TOOL_SEED) {
         found = 1;
-        
+
         // Check for poisonous seeds
         switch(seeds->objVnum()) {
           case 31026:  // death camas
@@ -163,14 +163,14 @@ int TBeing::doSeedPlant(sstring arg) {
               aff.modifier = -25;
               aff.location = APPLY_STR;
               aff.bitvector = AFF_POISON;
-              
+
               aff2.type = AFFECT_DISEASE;
               aff2.level = 0;
               aff2.duration = aff.duration;
               aff2.modifier = DISEASE_POISON;
               aff2.location = APPLY_NONE;
               aff2.bitvector = AFF_POISON;
-              
+
               sendTo("The seeds contain a dangerous toxin that seeps into your skin!\n\r");
               affectTo(&aff);
               affectTo(&aff2);
@@ -229,7 +229,9 @@ int task_plant(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
   if (ch->task->timeLeft < 0) {
     act("You finish planting $p.", FALSE, ch, obj, 0, TO_CHAR);
     act("$n finishes planting $p.", TRUE, ch, obj, 0, TO_ROOM);
-    ch->gainTaskExp(0, 50);
+
+    // Planting is a simple task with moderate difficulty
+    ch->gainTaskExp(0.5);
     ch->doSave(SILENT_YES);
     ch->stopTask();
 
@@ -271,14 +273,14 @@ int task_plant(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
             aff.modifier = -25;
             aff.location = APPLY_STR;
             aff.bitvector = AFF_POISON;
-            
+
             aff2.type = AFFECT_DISEASE;
             aff2.level = 0;
             aff2.duration = aff.duration;
             aff2.modifier = DISEASE_POISON;
             aff2.location = APPLY_NONE;
             aff2.bitvector = AFF_POISON;
-            
+
             ch->affectTo(&aff);
             ch->affectTo(&aff2);
             disease_start(ch, &aff2);

--- a/code/code/task/task_skin.cc
+++ b/code/code/task/task_skin.cc
@@ -232,7 +232,14 @@ int TThing::skinPulse(TBeing* ch, TBaseCorpse* corpse) {
   } else
     *ch += *item;
 
-  ch->gainTaskExp(corpse->getCorpseLevel(), 30.0);
+  // Calculate difficulty based on corpse vs character level
+  int corpseLvl = min((int)corpse->getCorpseLevel(), 20);
+  int charLvl = min((int)ch->GetMaxLevel(), 20);
+  int effectiveCorpseLvl = min(corpseLvl, charLvl + 5);
+  double difficulty = 0.5 + ((effectiveCorpseLvl - charLvl) / 10.0);
+  difficulty = max(0.1, min(1.0, difficulty));
+
+  ch->gainTaskExp(difficulty);
   ch->doSave(SILENT_YES);
 
   return FALSE;
@@ -301,7 +308,15 @@ int TTool::skinPulse(TBeing* ch, TBaseCorpse* corpse) {
     act(gl_msg, FALSE, ch, item, corpse, TO_ROOM);
 
     *ch += *item;
-    ch->gainTaskExp(corpse->getCorpseLevel(), 30.0);
+
+    // Calculate difficulty based on corpse vs character level
+    int corpseLvl = min((int)corpse->getCorpseLevel(), 20);
+    int charLvl = min((int)ch->GetMaxLevel(), 20);
+    int effectiveCorpseLvl = min(corpseLvl, charLvl + 5);
+    double difficulty = 0.5 + ((effectiveCorpseLvl - charLvl) / 10.0);
+    difficulty = max(0.1, min(1.0, difficulty));
+
+    ch->gainTaskExp(difficulty);
     ch->doSave(SILENT_YES);
   }
 

--- a/code/code/task/task_whittle.cc
+++ b/code/code/task/task_whittle.cc
@@ -23,21 +23,21 @@ using std::min;
 
 std::map<unsigned long int, taskWhittleEntry> whittleItems;
 
-double getWhittleScaleFactor(whittleTypeT type) {
+double getWhittleDifficulty(whittleTypeT type) {
   switch(type) {
-    case WHITTLE_ERROR:        return .20;  // least exp
-    case WHITTLE_GENERAL:      return .25;
-    case WHITTLE_EASY:         return .30;
-    case WHITTLE_MEDIUM:       return .35;
-    case WHITTLE_STANDARD:     return .40;
-    case WHITTLE_HARD:         return .45;
-    case WHITTLE_TOUGH:        return .50;
-    case WHITTLE_DELICATE:     return .55;
-    case WHITTLE_INVOLVED:     return .60;
-    case WHITTLE_STRONG:       return .70;
-    case WHITTLE_TIMECONSUMING: return .80;
-    case WHITTLE_VALUABLE:     return .90;   // most exp
-    default:                   return .40;
+    case WHITTLE_ERROR:        return 0.2;
+    case WHITTLE_GENERAL:      return 0.25;
+    case WHITTLE_EASY:         return 0.3;
+    case WHITTLE_MEDIUM:       return 0.35;
+    case WHITTLE_STANDARD:     return 0.4;
+    case WHITTLE_HARD:         return 0.45;
+    case WHITTLE_TOUGH:        return 0.5;
+    case WHITTLE_DELICATE:     return 0.55;
+    case WHITTLE_INVOLVED:     return 0.6;
+    case WHITTLE_STRONG:       return 0.7;
+    case WHITTLE_TIMECONSUMING: return 0.8;
+    case WHITTLE_VALUABLE:     return 0.9;
+    default:                   return 0.4;
   }
 }
 
@@ -538,8 +538,10 @@ int task_whittleObject(TBeing* ch, sstring tStWood) {
     TThing* tThing;
     tThing = ch->task->obj;
     *ch += *tThing;
-    double scaleFactor = getWhittleScaleFactor(whittleItems[ch->task->flags].itemType);
-    ch->gainTaskExp(0, scaleFactor);
+
+    // Calculate difficulty based on whittle type
+    double difficulty = getWhittleDifficulty(whittleItems[ch->task->flags].itemType);
+    ch->gainTaskExp(difficulty);
     ch->doSave(SILENT_YES);
     ch->task->obj = NULL;
 


### PR DESCRIPTION
There were some outlier skills that were allowing for A LOT of exp gain via taskGainExp. The entire thing has been compressed to be nice and feasible for leveling up to level 20, after that, it plateaus.

Previously, butcher was basing the exp based on mob corpse level, which would let a low level pc gain a massive amount of exp from a single butchering of a high level mob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Rebalanced task experience rewards across gathering, crafting, and processing activities. Experience gains now dynamically scale based on activity difficulty and character progression rather than using fixed amounts. Updated activities include butchering, fishing, cooking, planting, logging, pickpocketing, skinning, and whittling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->