### PR TITLE
Fix compiler warnings surfaced by clang/cmake build

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -25,7 +25,7 @@ find_library(CRYPT_LIBRARY crypt REQUIRED)
 # nlohmann/json (header-only, bundled as submodule)
 # Located at code/libs/json/src
 add_library(nlohmann_json INTERFACE)
-target_include_directories(nlohmann_json INTERFACE
+target_include_directories(nlohmann_json SYSTEM INTERFACE
     ${CMAKE_SOURCE_DIR}/code/libs/json/src
 )
 add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)

--- a/code/code/cmd/cmd_show.cc
+++ b/code/code/cmd/cmd_show.cc
@@ -8,6 +8,7 @@
 
 #include <dirent.h>
 #include <stdio.h>
+#include <vector>
 
 #include "extern.h"
 #include "room.h"
@@ -161,11 +162,8 @@ unsigned long int showFreeMobObj(int shFrZoneNumber, sstring* sb,
 
   int shFrCountSize = (shFrTop - shFrBot + 1),
       shFrCountMax = (isMobileF ? mob_index.size() : obj_index.size());
-  bool shFrCountList[shFrCountSize];
+  std::vector<bool> shFrCountList(shFrCountSize, false);
   char tString[256];
-
-  for (int Runner = 0; Runner < shFrCountSize; Runner++)
-    shFrCountList[Runner] = false;
 
   shFrTotalCount[0] = shFrCountSize;
 

--- a/code/code/game/game_cards.cc
+++ b/code/code/game/game_cards.cc
@@ -9,6 +9,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include <stdio.h>
+#include <vector>
 
 #include "being.h"
 #include "games.h"
@@ -432,22 +433,22 @@ void TBeing::doSort(const char* arg) const {
     cnt = gEights.count(index_num);
     if (is_abbrev(arg, "ascending")) {
       if (cnt % 2) {
-        int tmp3[cnt + 1];
+        std::vector<int> tmp3(cnt + 1);
         for (i = 0; i < cnt; tmp3[i] = gHearts.hands[index_num][i], i++)
           ;
         tmp3[cnt] = 999999;
-        qsort(tmp3, cnt + 1, 4, cardnumComparAscend);
+        qsort(tmp3.data(), cnt + 1, 4, cardnumComparAscend);
         for (i = 0; i < cnt; gHearts.hands[index_num][i] = tmp3[i], i++)
           ;
       } else
         qsort(gHearts.hands[index_num], cnt, 4, cardnumComparAscend);
     } else {
       if (cnt % 2) {
-        int tmp4[cnt + 1];
+        std::vector<int> tmp4(cnt + 1);
         for (i = 0; i < cnt; tmp4[i] = gHearts.hands[index_num][i], i++)
           ;
         tmp4[cnt] = 0;
-        qsort(tmp4, cnt + 1, 4, cardnumComparDescend);
+        qsort(tmp4.data(), cnt + 1, 4, cardnumComparDescend);
         for (i = 0; i < cnt; gHearts.hands[index_num][i] = tmp4[i], i++)
           ;
       } else
@@ -461,11 +462,11 @@ void TBeing::doSort(const char* arg) const {
     if (is_abbrev(arg, "ascending")) {
       if (cnt % 2) {
         // Kludges rule
-        int tmp3[cnt + 1];
+        std::vector<int> tmp3(cnt + 1);
         for (i = 0; i < cnt; tmp3[i] = gHearts.hands[index_num][i], i++)
           ;
         tmp3[cnt] = 999999;
-        qsort(tmp3, cnt + 1, 4, cardnumComparAscend);
+        qsort(tmp3.data(), cnt + 1, 4, cardnumComparAscend);
         for (i = 0; i < cnt; gHearts.hands[index_num][i] = tmp3[i], i++)
           ;
       } else
@@ -473,11 +474,11 @@ void TBeing::doSort(const char* arg) const {
     } else {
       if (cnt % 2) {
         // Kludges rule
-        int tmp4[cnt + 1];
+        std::vector<int> tmp4(cnt + 1);
         for (i = 0; i < cnt; tmp4[i] = gHearts.hands[index_num][i], i++)
           ;
         tmp4[cnt] = 0;
-        qsort(tmp4, cnt + 1, 4, cardnumComparDescend);
+        qsort(tmp4.data(), cnt + 1, 4, cardnumComparDescend);
         for (i = 0; i < cnt; gHearts.hands[index_num][i] = tmp4[i], i++)
           ;
       } else

--- a/code/code/misc/create_mobs.cc
+++ b/code/code/misc/create_mobs.cc
@@ -2596,14 +2596,15 @@ static void change_mob_sstring_values(TBeing* ch, TMonster* tMob,
 
   unsigned int iter;
   for (iter = 0; iter < 6; iter++) {
+    // clang-format off
     const char* tMobStringValues[] = {
       "%s1%s) bamfin [diurnal/nocturnal enter world message\n\r%s<z>\n\r\n\r",
       "%s2%s) bamfout [diurnal/nocturnal leave world message\n\r%s<z>\n\r\n\r",
       "%s3%s) death cry [blood freezes message when mob dies]\n\r%s<z>\n\r\n\r",
-      "%s4%s) repop [when mob is added to the world "
-      "initially]\n\r%s<z>\n\r\n\r",
+      "%s4%s) repop [when mob is added to the world initially]\n\r%s<z>\n\r\n\r",
       "%s5%s) movein [message when mobile enters a room]\n\r%s<z>\n\r\n\r",
       "%s6%s) moveout [message when mobile leaves a room]\n\r%s<z>\n\r\n\r"};
+    // clang-format on
 
     const char* exd = NULL;
     if (tHas && tMob->ex_description) {

--- a/code/code/misc/create_rooms.cc
+++ b/code/code/misc/create_rooms.cc
@@ -1916,7 +1916,7 @@ static void ChangeExitSlopedStatus(TRoom* rp, TBeing* ch, const char* arg,
     case CHANGE_ROOM_DIR_SLOPED_SW:
       dir = DIR_SOUTHWEST;
       break;
-    case MAX_DIR:
+    case CHANGE_ROOM_EXIT:
       ChangeExitSlopedStatus(rp, ch, "", ENTER_CHECK);
     default:
       return;
@@ -2363,7 +2363,7 @@ static void ChangeExitCondition(TRoom* rp, TBeing* ch, const char* arg,
     case CHANGE_ROOM_CONDITION_SW:
       dir = DIR_SOUTHWEST;
       break;
-    case MAX_DIR:
+    case CHANGE_ROOM_EXIT:
       ChangeExitCondition(rp, ch, "", ENTER_CHECK);
       return;
     default:

--- a/code/code/misc/gaining.cc
+++ b/code/code/misc/gaining.cc
@@ -1451,7 +1451,7 @@ TRAININFO TrainerInfo[] = {
       CLASS_MAGE | CLASS_THIEF | CLASS_SHAMAN},
   {SPEC_TRAINER_OFFENSE, "offense", "about Offense", DISC_OFFENSE,
     CLASS_THIEF | CLASS_MONK},
-  {-1} /* required terminator */
+  {-1, "", "", DISC_NONE, 0} /* required terminator */
 };
 
 int CDGenericTrainer(TBeing* ch, cmdTypeT cmd, const char* arg, TMonster* me,

--- a/code/code/spec/spec_mobs.cc
+++ b/code/code/spec/spec_mobs.cc
@@ -539,13 +539,13 @@ int newbieEquipper(TBeing* ch, cmdTypeT cmd, const char* arg, TMonster* me,
       if (cmd == CMD_SAY)
         ch->doSay(arg);
       else if (cmd == CMD_WHISPER)
-        ch->doWhisper(arg); 
+        ch->doWhisper(arg);
       else
         ch->doAsk(arg);
       sprintf(tmp_buf, "%s You are not a mage or ranger.  I am not that charitable.", ch->getName());
       me->doTell(tmp_buf);
       return TRUE;
-    } else 
+    } else
       request = 4;
 #endif
 
@@ -4530,12 +4530,13 @@ int corpseMuncher(TBeing* ch, cmdTypeT cmd, const char*, TMonster* myself,
   TThing* t;
   TObj* obj = NULL;
   int found = 0, msg;
+  // clang-format off
   const char* munch[] = {
-    "$n stops eating, looks up at you and burps loudly, then resumes feasting "
-    "on $p.",
+    "$n stops eating, looks up at you and burps loudly, then resumes feasting on $p.",
     "<r>Blood<1> spatters about as $n bites deeply into $p.",
     "$n utters a low growl as $e rips a chunk of flesh off $p.",
     "$n stops to spit out a piece of <W>bone<1>, then resumes eating $p."};
+  // clang-format on
 
   if ((cmd != CMD_GENERIC_PULSE) || !ch->awake() || ch->fight())
     return FALSE;

--- a/code/code/sys/database.cc
+++ b/code/code/sys/database.cc
@@ -178,9 +178,11 @@ const sstring TDatabase::operator[](const sstring& s) const {
 bool TDatabase::query(const char* query, ...) {
   va_list ap;
   sstring buf;
-  int fromlen = 0, tolen = (32768 * 2) + 1;
+  constexpr int toBufferSize = (32768 * 2) + 1;
+  int fromlen = 0;
   const char* qsave = query;
-  char *from = NULL, to[tolen];
+  char* from = nullptr;
+  char to[toBufferSize];
   MYSQL_RES* restmp;
   TTiming t;
 
@@ -216,7 +218,7 @@ bool TDatabase::query(const char* query, ...) {
 
           // mysql_escape_string needs a buffer that is
           // (string * 2) + 1 in size to avoid overruns
-          if (((fromlen * 2) + 1) > tolen) {
+          if (((fromlen * 2) + 1) > toBufferSize) {
             vlogf(LOG_DB, format("query - buffer overrun on %s") % from);
             vlogf(LOG_DB, format("%s") % qsave);
             return FALSE;

--- a/code/code/sys/sstring.cc
+++ b/code/code/sys/sstring.cc
@@ -19,13 +19,13 @@ void br() { vlogf(LOG_BUG, "sstring::escape(): TODO implement"); }
 
 const sstring sstring::escape() const {
   sstring oBuf;
-  unsigned int MY_MAX_STRING_LENGTH = MAX_STRING_LENGTH * 2;
+  constexpr unsigned int maxEscapeLength = MAX_STRING_LENGTH * 2;
 
-  char buf[MY_MAX_STRING_LENGTH];
+  char buf[maxEscapeLength];
   TDatabase::escape_string_ugly(buf, c_str(), strlen(c_str()));
   oBuf = (sstring)buf;
 
-  if (oBuf.length() == MY_MAX_STRING_LENGTH - 1) {
+  if (oBuf.length() == maxEscapeLength - 1) {
     vlogf(LOG_BUG, "sstring::escape(): buffer reached MAX_STRING_LENGTH");
 
     // avoid formatting just to be safe
@@ -37,7 +37,7 @@ const sstring sstring::escape() const {
 
 const sstring sstring::ansiToAard() const {
   sstring oBuf;
-  unsigned int MY_MAX_STRING_LENGTH = MAX_STRING_LENGTH * 2;
+  constexpr unsigned int maxAardLength = MAX_STRING_LENGTH * 2;
 
   boost::regex e("(^|[^<])<.>");
   boost::sregex_iterator m((*this).begin(), (*this).end(), e);
@@ -252,11 +252,11 @@ const sstring sstring::ansiToAard() const {
   oBuf.inlineReplaceString(ANSI_WH_ON_PR, "@m");
   oBuf.inlineReplaceString(ANSI_WH_ON_RD, "@r");
 
-  if (oBuf.length() == MY_MAX_STRING_LENGTH - 1) {
-    vlogf(LOG_BUG, "sstring::escape(): buffer reached MAX_STRING_LENGTH");
+  if (oBuf.length() == maxAardLength - 1) {
+    vlogf(LOG_BUG, "sstring::ansiToAard(): buffer reached MAX_STRING_LENGTH");
 
     // avoid formatting just to be safe
-    vlogf(LOG_BUG, sstring("sstring::escape(): buffer=") + oBuf.substr(70));
+    vlogf(LOG_BUG, sstring("sstring::ansiToAard(): buffer=") + oBuf.substr(70));
   }
 
   return oBuf;

--- a/code/code/task/task_cook.h
+++ b/code/code/task/task_cook.h
@@ -35,7 +35,7 @@ recipeTypeT recipes[] = {
     {2, "rat stick", "rat on a stick", 14352, TASK_TRIVIAL},
     {3, "potatoes mashed", "side of mashed potatoes", 31773, TASK_TRIVIAL},
     {4, "salad side", "small side salad", 31774, TASK_TRIVIAL},
-    
+
     // Complete Meals (More complex preparation)
     {5, "steak dinner", "steak dinner", 31775, TASK_NORMAL},
     {6, "chicken fried", "fried chicken", 3324, TASK_EASY},
@@ -47,7 +47,7 @@ recipeTypeT recipes[] = {
     {10, "berry friendship bread", "berry friendship bread", 34705, TASK_NORMAL},
     {11, "pancake", "pancake", 34708, TASK_EASY},
     {12, "berry pancake", "berry pancake", 34709, TASK_NORMAL},
-    
+
     // Poisons (Dangerous ingredients, precise measurements)
     {13, "poison death camas", "vial death camas", 31008, TASK_DANGEROUS},
     {14, "poison destroying angel", "vial destroying angel", 31009, TASK_DANGEROUS},
@@ -62,7 +62,7 @@ recipeTypeT recipes[] = {
     {23, "poison infant", "vial infant", 31018, TASK_DANGEROUS},
     {24, "poison pea seed", "vial pea seed", 31019, TASK_DANGEROUS},
     {25, "poison acacia", "vial acacia", 31020, TASK_DANGEROUS},
-   
+
     // Water and holy water
     {26, "water skin regular", "regular water skin", 410, TASK_TRIVIAL},
     {27, "water skin large", "large water skin", 411, TASK_EASY},
@@ -165,17 +165,17 @@ ingredientTypeT ingredients[] = {
   {15, 2, 1, TYPE_VNUM, 13849}, // can of leeches
   {15, 3, 1, TYPE_VNUM, 34706}, // sugar
   {15, 4, 5, TYPE_LIQUID, LIQ_VODKA},  // grain alcohol
-  
-  // hemlock 
+
+  // hemlock
   {16, 1, 1, TYPE_VNUM, 31035},  // hemlock
   {16, 2, 1, TYPE_VNUM, 13849}, // can of leeches
   {16, 3, 1, TYPE_VNUM, 37139}, // honeysap
   {16, 4, 5, TYPE_LIQUID, LIQ_VODKA},  // grain alcohol
-   
+
   // monkshood
   {17, 1, 1, TYPE_VNUM, 31036},  // monkshood
   {17, 2, 1, TYPE_VNUM, 278}, // small egg
-  {17, 3, 1, TYPE_VNUM, 37140}, // jojupus 
+  {17, 3, 1, TYPE_VNUM, 37140}, // jojupus
   {17, 4, 5, TYPE_LIQUID, LIQ_VODKA},  // grain alcohol
 
   // glow fish
@@ -183,12 +183,12 @@ ingredientTypeT ingredients[] = {
   {18, 2, 1, TYPE_VNUM, 23654}, // pixie parts
   {18, 3, 1, TYPE_VNUM, 37141}, // ginseng
   {18, 4, 5, TYPE_LIQUID, LIQ_VODKA},  // grain alcohol
-  
+
   // scorpion
   {19, 1, 1, TYPE_VNUM, 31043},  // scorpion
   {19, 2, 1, TYPE_VNUM, 89}, // rat tail
   {19, 3, 1, TYPE_VNUM, 431}, // donut pastry
-  {19, 3, 1, TYPE_VNUM, 26896}, // donut glazed 
+  {19, 3, 1, TYPE_VNUM, 26896}, // donut glazed
   {19, 4, 5, TYPE_LIQUID, LIQ_VODKA},  // grain alcohol
 
   // violet fungus
@@ -198,7 +198,7 @@ ingredientTypeT ingredients[] = {
   {20, 4, 1, TYPE_VNUM, 7510},  // ancient wine
   {20, 4, 1, TYPE_VNUM, 7511},  // ancient wine
 
-  // devil ice 
+  // devil ice
   {21, 1, 1, TYPE_VNUM, 31038},  // devil ice
   {21, 2, 1, TYPE_VNUM, 10030}, // offal
   {21, 3, 1, TYPE_VNUM, 37143}, // snow locust
@@ -216,7 +216,7 @@ ingredientTypeT ingredients[] = {
   {23, 3, 1, TYPE_VNUM, 37145}, // ginseng
   {23, 4, 5, TYPE_LIQUID, LIQ_URINE},  // urine
 
-  // pea seed 
+  // pea seed
   {24, 1, 1, TYPE_VNUM, 31041},  // pea seed
   {24, 2, 1, TYPE_VNUM, 27237}, // moldy book
   {24, 3, 5, TYPE_LIQUID, LIQ_MILK}, // milk
@@ -278,6 +278,6 @@ ingredientTypeT ingredients[] = {
   {30, 3, 1, TYPE_VNUM, 514}, // holy symbol - mithril
 
 
-  {-1, -1, -1, -1}};
+  {-1, -1, -1, -1, -1}};
 
- 
+


### PR DESCRIPTION
Addresses low-severity warnings that appeared after the build system switch to clang and cmake. Changes are mechanical and don't affect runtime behavior.

-Wvla-cxx-extension (variable length arrays):
- Replace VLAs with std::vector (cmd_show, game_cards)
- Use constexpr for array size constants (database, sstring)

-Wenum-compare-switch (different enumeration types in switch):
- Fix enum type mismatch: MAX_DIR -> CHANGE_ROOM_EXIT (create_rooms) The original worked by numeric coincidence; both equal 10

-Wmissing-field-initializers:
- Complete missing field initializers (gaining, task_cook)

-Wstring-concatenation (false positives):
- Add clang-format off/on markers around string arrays that clang-format was splitting across lines (create_mobs, spec_mobs)

Other:
- Mark nlohmann/json as SYSTEM include to suppress third-party warnings
- Fix copy-paste error in log messages: escape() → ansiToAard() (sstring)

One Wstring-concatenation warning remains unfixed and will be addressed separately as it's an actual bug that requires more substantial changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements including memory management optimizations and modernization of declarations.
  * Minor text formatting improvements in editor interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->