### PR TITLE
Make `sstring` class compatible with `std::string_view` and C++20's `std::format`

### DIFF
--- a/code/code/sys/sstring.h
+++ b/code/code/sys/sstring.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <boost/format.hpp>
+#include <format>
+#include <string>
+#include <string_view>
 
 extern boost::format format(const std::string&);
 
@@ -11,6 +14,7 @@ class sstring : public std::string {
     sstring(const char* str) : std::string(str ? str : "") {}
     sstring(const std::string& str) : std::string(str) {}
     sstring(boost::format& a) : std::string(a.str()) {}
+    sstring(std::string_view sv) : std::string(sv) {}
 
     const sstring& operator=(const boost::format& a);
     const sstring& operator+=(const boost::format& a);
@@ -151,6 +155,18 @@ class sstring : public std::string {
 
     // simple function; probably should just macro but what the hell
     void inlinePad(const char pad, int num) { resize(length() + num, pad); }
+};
+
+// std::format doesn't automatically work with classes that inherit from
+// std::string - it only knows how to format the types it has specializations
+// for. This formatter tells std::format "treat sstring like std::string" so
+// we can pass sstrings to std::format without explicit conversion.
+template <>
+struct std::formatter<sstring> : std::formatter<std::string> {
+    auto format(const sstring& s, std::format_context& ctx) const {
+      return std::formatter<std::string>::format(
+        static_cast<const std::string&>(s), ctx);
+    }
 };
 
 extern bool isvowel(const char c);


### PR DESCRIPTION
A simple PR to update our custom `sstring` class to allow it to be constructed from a `std::string_view`, and adding a `std::formatter` declaration for it so it so `sstring`s can be passed directly to `std::format` args without extra conversions first.

This doesn't change any functionality on its own - it simply allows future changes to utilize these features. I have a couple more PRs ready to submit that depend on these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved sstring class integration with standard formatting functions. Added support for string_view construction and formatter specialization, enabling direct sstring usage in formatting operations without explicit conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->