### PR TITLE
Add llvm package to Dockerfile to fix sanitizer stack traces in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
 ENV UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=0
 
+# Include llvm for symbolizer support in sanitizer error reports. Otherwise, sanitizer stack traces will be mostly useless.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update && \
   TZ=utc apt-get install --yes --no-install-recommends \
   ca-certificates \
   gdb \
+  llvm \
   libboost-atomic1.83.0 \
   libboost-filesystem1.83.0 \
   libboost-program-options1.83.0 \


### PR DESCRIPTION
ASan/UBSan need llvm-symbolizer to provide line numbers in stack traces. Without, the stack traces simply show addresses, making them fairly useless for debugging. llvm-symbolizer is part of the llvm package on Debian-based systems. Adds ~50MB to the final image size, but well worth it for the improved debugging info.

We could use the much smaller binutils package for addr2line instead, but llvm-symbolizer tends to provide better results when compiling with clang, especially when using ThinLTO as we are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build to include symbolizer support for sanitizer reports, improving debug output and diagnostic information during failure analysis. This change enhances error reporting and makes sanitizer stack traces more actionable without altering runtime behavior or public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->