### PR TITLE
removed improper deletion of pointer

### DIFF
--- a/code/code/disc/disc_thief_murder.cc
+++ b/code/code/disc/disc_thief_murder.cc
@@ -156,8 +156,6 @@ int TBeing::backstabHit(TBeing* victim, TThing* obj, int modifier) {
 
         if (weapon && weapon->checkSpec(victim, CMD_BACKSTAB, "-special-",
                         this) == DELETE_VICT) {
-          delete victim;
-          victim = NULL;
           return DELETE_VICT;
         }
 
@@ -185,8 +183,6 @@ int TBeing::backstabHit(TBeing* victim, TThing* obj, int modifier) {
       getAdvLearning(SKILL_STABBING) >= 50) {
     int rc = doStab("", victim);
     if (IS_SET_DELETE(rc, DELETE_VICT)) {
-      delete victim;
-      victim = NULL;
       return DELETE_VICT;
     }
   }
@@ -501,8 +497,6 @@ int TBeing::throatSlitHit(TBeing* victim, TThing* obj, int modifier) {
 
         if (weapon && weapon->checkSpec(victim, CMD_SLIT, "-special-", this) ==
                         DELETE_VICT) {
-          delete victim;
-          victim = NULL;
           return DELETE_VICT;
         }
 


### PR DESCRIPTION
There was a bug within Backstab where Stab was called. if the 'victim' was killed by the Stab chained within Backstab, then 'victim' was being deleted manually, instead of allowing it to return DELETE_VICT.

The fix was simple, just to remove the manual deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with victim object handling during special backstab and throat slit attacks that was causing improper cleanup in certain combat scenarios.

* **Style**
  * Minor formatting adjustment for code consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->