### PR TITLE
new messages for shaman buffs

### DIFF
--- a/code/code/disc/disc_shaman_armadillo.cc
+++ b/code/code/disc/disc_shaman_armadillo.cc
@@ -322,7 +322,7 @@ int shadowWalk(TBeing* caster, TBeing* victim, int level, short bKnown) {
 #if 0
   if (victim->affectedBySpell(SPELL_SHADOW_WALK)) {
     char buf[256];
-    act("You already walk among the shadows.", FALSE, caster, NULL, victim, 
+    act("You already walk among the shadows.", FALSE, caster, NULL, victim,
 TO_CHAR);
     caster->nothingHappens(SILENT_YES);
     return SPELL_FAIL;
@@ -392,7 +392,7 @@ int shadowWalk(TBeing* caster, TBeing* victim) {
 #if 0
   if (victim->affectedBySpell(SPELL_SHADOW_WALK)) {
     char buf[256];
-    act("You already are walking among the shadows.", FALSE, caster, NULL, victim, 
+    act("You already are walking among the shadows.", FALSE, caster, NULL, victim,
 TO_CHAR);
     return FALSE;
   }
@@ -413,9 +413,9 @@ int castShadowWalk(TBeing* caster, TBeing* victim) {
   int ret = shadowWalk(caster, victim, level, bKnown);
   if (ret == SPELL_SUCCESS) {
 #if 0
-    act("$n becomes dark and walks a little swifter!", FALSE, victim, NULL, NULL, 
+    act("$n becomes dark and walks a little swifter!", FALSE, victim, NULL, NULL,
 TO_ROOM, ANSI_GREEN);
-    act("You now walk among the shadows!", FALSE, victim, NULL, NULL, TO_CHAR, 
+    act("You now walk among the shadows!", FALSE, victim, NULL, NULL, TO_CHAR,
 ANSI_GREEN);
 #endif
   } else {
@@ -798,13 +798,13 @@ int djallasProtection(TBeing* caster, TBeing* victim, int level, short bKnown) {
         aff3.modifier2 = (level * 2);
         aff4.duration *= 2;
         aff4.modifier2 = (level * 2);
-        act("$n becomes one with the spirits.", FALSE, victim, NULL, NULL,
+        act("$n is greatly blessed with the protection of Djalla.", FALSE, victim, NULL, NULL,
           TO_ROOM, ANSI_GREEN);
         act("You have been greatly blessed with the protection of Djalla!",
           FALSE, victim, NULL, NULL, TO_CHAR, ANSI_GREEN);
         break;
       case CRIT_S_NONE:
-        act("$n becomes one with the spirits.", FALSE, victim, NULL, NULL,
+        act("$n is granted the protection of Djalla.", FALSE, victim, NULL, NULL,
           TO_ROOM, ANSI_GREEN);
         act("You have been granted the protection of Djalla!", FALSE, victim,
           NULL, NULL, TO_CHAR, ANSI_GREEN);
@@ -907,15 +907,15 @@ int legbasGuidance(TBeing* caster, TBeing* victim, int level, short bKnown) {
         aff3.modifier2 = (level * 2);
         aff4.duration *= 2;
         aff4.modifier2 = (level * 2);
-        act("$n becomes one with the spirits.", FALSE, victim, NULL, NULL,
+        act("$n is greatly blessed with the guidance of Legba.", FALSE, victim, NULL, NULL,
           TO_ROOM, ANSI_GREEN);
-        act("You have been greatly blessed with the protection of Legba!",
+        act("You have been greatly blessed with the guidance of Legba!",
           FALSE, victim, NULL, NULL, TO_CHAR, ANSI_GREEN);
         break;
       case CRIT_S_NONE:
-        act("$n becomes one with the spirits.", FALSE, victim, NULL, NULL,
+        act("$n is granted the guidance of Legba.", FALSE, victim, NULL, NULL,
           TO_ROOM, ANSI_GREEN);
-        act("You have been granted the protection of Legba!", FALSE, victim,
+        act("You have been granted the guidance of Legba!", FALSE, victim,
           NULL, NULL, TO_CHAR, ANSI_GREEN);
         break;
     }

--- a/code/code/misc/spell_info.cc
+++ b/code/code/misc/spell_info.cc
@@ -3072,8 +3072,8 @@ void buildSpellArray() {
   discArray[SPELL_LEGBA] =
     new spellInfo(SPELL_SHAMAN, DISC_SHAMAN, DISC_SHAMAN_ARMADILLO, STAT_INT,
       "legba's guidance", TASK_EASY, LAG_2, POSITION_CRAWLING, MANA_0,
-      LIFEFORCE_70, PRAY_0, TAR_FIGHT_SELF | TAR_CHAR_ROOM, SYMBOL_STRESS_0, "",
-      "", "", "", START_80, LEARN_10, START_DO_30, LEARN_DO_5, START_DO_NO,
+      LIFEFORCE_70, PRAY_0, TAR_FIGHT_SELF | TAR_CHAR_ROOM, SYMBOL_STRESS_0, "Legba's presence leaves you.",
+      "The presence of Legba leaves $n.", "Legba's presence feels far from you.", "", START_80, LEARN_10, START_DO_30, LEARN_DO_5, START_DO_NO,
       LEARN_DO_NO, LEARN_DIFF_SPELLS, 0.04,
       COMP_GESTURAL | COMP_GESTURAL_RANDOM | COMP_VERBAL | COMP_VERBAL_RANDOM |
         COMP_MATERIAL | COMP_MATERIAL_END | SPELL_TASKED,
@@ -3082,8 +3082,8 @@ void buildSpellArray() {
   discArray[SPELL_DJALLA] =
     new spellInfo(SPELL_SHAMAN, DISC_SHAMAN, DISC_SHAMAN_ARMADILLO, STAT_INT,
       "djalla's protection", TASK_EASY, LAG_2, POSITION_CRAWLING, MANA_0,
-      LIFEFORCE_60, PRAY_0, TAR_FIGHT_SELF | TAR_CHAR_ROOM, SYMBOL_STRESS_0, "",
-      "", "", "", START_75, LEARN_10, START_DO_30, LEARN_DO_5, START_DO_NO,
+      LIFEFORCE_60, PRAY_0, TAR_FIGHT_SELF | TAR_CHAR_ROOM, SYMBOL_STRESS_0, "Djalla's presence leaves you.",
+      "The presence of Djalla leaves $n.", "Djalla's presence feels far from you.", "", START_75, LEARN_10, START_DO_30, LEARN_DO_5, START_DO_NO,
       LEARN_DO_NO, LEARN_DIFF_SPELLS, 0.04,
       COMP_GESTURAL | COMP_GESTURAL_RANDOM | COMP_VERBAL | COMP_VERBAL_RANDOM |
         COMP_MATERIAL | COMP_MATERIAL_END | SPELL_TASKED,


### PR DESCRIPTION
Previously, the spells Djalla's Protection and Legba's Guidance had duplicate messages when the spell was cast and no fadeAway messages. This gives each of them minor flavor changes to differentiate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legba and Djalla shaman spells now feature custom narrative messages when their effects fade or conclude. Players and nearby characters receive immersive feedback text replacing previously blank descriptions, providing clearer spell status communication and enhancing overall gameplay experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->