### PR TITLE
Fix item loading regressions from 80ed3dadf

### DIFF
--- a/code/code/misc/loadset.cc
+++ b/code/code/misc/loadset.cc
@@ -171,12 +171,14 @@ bool loadsetCheck(TBeing* ch, int vnum, int chance, wearSlotT slot,
       return false;
   }
 
-  // Scale load chance from zonefile by loadrate tweak value from db.
-  const auto realChance = static_cast<int>(
-    min(max(chance * tweakInfo[TWEAK_LOADRATE]->current, 0.0), 100.0));
+  // Imm loads always succeed; zone loads are scaled by loadrate tweak.
+  if (!isImmLoad) {
+    const auto realChance = static_cast<int>(
+      min(max(chance * tweakInfo[TWEAK_LOADRATE]->current, 0.0), 100.0));
 
-  if (!percentChance(realChance))
-    return false;
+    if (!percentChance(realChance))
+      return false;
+  }
 
   TObj* obj = isImmLoad || isPropLoad ? read_object(index, REAL)
                                       : read_object_buy_build(ch, index, REAL);

--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -1492,7 +1492,7 @@ void TBeing::doBoot(const sstring& arg) {
     for (int r = zone_table[z].bottom; r <= zone_table[z].top; ++r) {
       if (real_roomp(r)) {
         for (StuffIter it = real_roomp(r)->stuff.begin();
-             it != real_roomp(r)->stuff.end();) {
+          it != real_roomp(r)->stuff.end();) {
           t = *(it++);
 
           if ((obj = dynamic_cast<TObj*>(t))) {
@@ -2887,6 +2887,7 @@ int armorSetLoad::getArmor(int set, int slot) {
 // If this command is executing, the load chance has already succeeded.
 void runResetCmdE(zoneData& zd, resetCom& rs, resetFlag flags, bool&,
   TMonster*& mob, bool& objload, TObj*& obj, bool& last_cmd) {
+  obj = nullptr;
   const auto index = static_cast<size_t>(rs.arg1);
 
   if (index < 0 || index >= obj_index.size()) {
@@ -3495,30 +3496,24 @@ void runResetCmdZ(zoneData& zone, resetCom& rs, resetFlag flags, bool& mobload,
   }
 
   if (mob && mobload && rs.arg1 >= 0) {
-    const auto chance = static_cast<int>(
-      min(max(rs.arg2 * tweakInfo[TWEAK_LOADRATE]->current, 0.0), 100.0));
-
     for (wearSlotT i = MIN_WEAR; i < MAX_WEAR; i++)
       if (zone.armorSets.getArmor(rs.arg1, i) != 0)
-        loadsetCheck(mob, zone.armorSets.getArmor(rs.arg1, i), chance, i,
+        loadsetCheck(mob, zone.armorSets.getArmor(rs.arg1, i), rs.arg2, i,
           "(null... for now)");
   }
 }
 
 void runResetCmdY(zoneData&, resetCom& rs, resetFlag flags, bool& mobload,
   TMonster*& mob, bool&, TObj*&, bool& last_cmd) {
-  const auto chance = static_cast<int>(
-    min(max(rs.arg2 * tweakInfo[TWEAK_LOADRATE]->current, 0.0), 100.0));
-
   if (mob && IS_SET(flags, resetFlagFindLoadPotential)) {
-    mob->loadSetEquipment(rs.arg1, nullptr, chance, true);
+    mob->loadSetEquipment(rs.arg1, nullptr, rs.arg2, true);
     return;
   }
 
   if (!mob || !mobload)
     return;
 
-  mob->loadSetEquipment(rs.arg1, nullptr, chance);
+  mob->loadSetEquipment(rs.arg1, nullptr, rs.arg2);
   last_cmd = true;
 }
 
@@ -3612,14 +3607,9 @@ void runResetCmdJ(zoneData& zone, resetCom& rs, resetFlag flags, bool& mobload,
   if (mob && mobload && rs.arg1 >= 0) {
     for (wearSlotT slot = MIN_WEAR; slot < MAX_WEAR; slot++) {
       const int armorVnum = zone.armorSets.getArmor(rs.arg1, slot);
-      const int chance =
-        rs.arg2 >= 99
-          ? rs.arg2
-          : static_cast<int>(min(
-              max(rs.arg2 * tweakInfo[TWEAK_LOADRATE]->current, 0.0), 100.0));
 
       if (armorVnum != 0 &&
-          loadsetCheck(mob, armorVnum, chance, slot, "(null... for now)",
+          loadsetCheck(mob, armorVnum, rs.arg2, slot, "(null... for now)",
             (flags | resetFlagPropLoad))) {}
     }
   }


### PR DESCRIPTION
- Clear stale obj pointer at top of runResetCmdE to prevent re-adding  an already-parented object from a previous reset command, which caused assertion crashes in `TThing::operator+=`. Fixes https://github.com/sneezymud/sneezymud/issues/455 as well as the recent crashes we've been seeing due to failed assertions on item load:
```
2026|0205|05:51:20 :: a ghost of purity and hope loaded <b>a tiny vial of <k>smooth grey potion<1><1>. (max: 9999, cur: 92)
2026|0205|05:51:20 :: BUG: ASSERTION FAILED: TThing += : t.parent existed: vial tiny smooth grey potion smooth grey
```
- Remove duplicate loadRate tweak scaling from runResetCmdZ/Y/J callers since loadsetCheck already applies it (was effectively squaring the tweak factor)
- Bypass loadRate scaling and percentChance roll for imm loads (chance==101) in loadsetCheck so they always succeed as intended

Because the global tweak rate has been set to 1 since the original change went in, these load rate bugs haven't actually been having any effect, but now they're fixed in case that ever changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Immortal item loading behavior to bypass chance-based calculations
  * Streamlined load chance mechanics in reset command sequences
  * Improved parameter handling for equipment loading operations
  * Enhanced consistency across armor and weapon loading processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->