### PR TITLE
GitHub Actions: add optional Discord notification when new builds are published and ready

### DIFF
--- a/.github/scripts/notify_discord.py
+++ b/.github/scripts/notify_discord.py
@@ -1,0 +1,45 @@
+"""Post a Discord notification when a new game image is published.
+
+Environment variables (set in workflow step):
+    DISCORD_NEW_BUILD_WEBHOOK_URL  - Discord webhook endpoint
+    DISCORD_ADMIN_ROLE_ID          - Discord role ID to mention (optional)
+    GH_TOKEN                       - GitHub token (for gh CLI auth)
+
+Environment variables (provided automatically by GitHub Actions runner):
+    GITHUB_REPOSITORY              - owner/repo (e.g. sneezymud/sneezymud)
+    GITHUB_SHA                     - commit SHA that triggered the build
+"""
+
+import json
+import os
+import subprocess
+import urllib.request
+
+repo = os.environ["GITHUB_REPOSITORY"]
+sha = os.environ["GITHUB_SHA"]
+webhook_url = os.environ["DISCORD_NEW_BUILD_WEBHOOK_URL"]
+
+admin_role_id = os.environ.get("DISCORD_ADMIN_ROLE_ID", "")
+
+mention = f"<@&{admin_role_id}> " if admin_role_id else ""
+msg = f"{mention}New game image available! Reboot to apply the update."
+try:
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/commits/{sha}/pulls", "--jq", ".[0] // empty"],
+        capture_output=True, text=True, check=True,
+    )
+    if result.stdout.strip():
+        pr = json.loads(result.stdout)
+        msg += f"\nSummary: {pr['title']} ({pr['html_url']})"
+except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
+    pass
+
+req = urllib.request.Request(
+    webhook_url,
+    data=json.dumps({
+        "content": msg,
+        "allowed_mentions": {"roles": [admin_role_id]} if admin_role_id else {},
+    }).encode(),
+    headers={"Content-Type": "application/json"},
+)
+urllib.request.urlopen(req)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   packages: write
+  pull-requests: read
 
 concurrency:
   group: docker-build-${{ github.ref_name }}
@@ -82,3 +83,12 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sneezymud:${{ github.sha }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Notify Discord
+        if: ${{ env.DISCORD_NEW_BUILD_WEBHOOK_URL != '' }}
+        continue-on-error: true
+        env:
+          DISCORD_NEW_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_NEW_BUILD_WEBHOOK_URL }}
+          DISCORD_ADMIN_ROLE_ID: ${{ vars.DISCORD_ADMIN_ROLE_ID }}
+          GH_TOKEN: ${{ github.token }}
+        run: python .github/scripts/notify_discord.py

--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ func-test/run_test.sh
 
 Pull requests run automated builds and tests via GitHub Actions. Merges to master are built and published automatically via GitHub Actions.
 
+> [!TIP]
+> On successful publish, a Discord notification is sent if the `DISCORD_NEW_BUILD_WEBHOOK_URL` repository secret is configured. The notification includes a link to the merged PR, useful for letting admins know when the game can be updated to a new version. Optionally set the `DISCORD_ADMIN_ROLE_ID` repository variable to mention a Discord role in the notification.
+
 ## Notable Directories
 
 ```


### PR DESCRIPTION
Updates the "Build and Push" GitHub Action workflow to optionally send a Discord notification upon completion. Just a little QoL update to make it easy to know when the game can be rebooted to apply new updates.

If the required secret and variable (for the webhook and role ID respectively) are configured in the repo's settings (I already added them to this repo), the associated Discord channel will get a message like:
```
@kitchen crew New game image available! Reboot to apply the update.
Summary: Add llvm package to Dockerfile to fix sanitizer stack traces in production (https://github.com/sneezymud/sneezymud/pull/627)
```
whenever a new image is successfully pushed and ready to apply.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated Discord notifications are sent when game images are successfully published to production, including merged pull request titles and links for reference.
  * Optional admin role mentions can be configured to alert designated teams of new releases.

* **Documentation**
  * Updated documentation with setup instructions for configuring Discord webhook notifications on successful build and deployment events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->