### PR TITLE
Fix Discord notification step in Build and Push GitHub action

### DIFF
--- a/.github/scripts/notify_discord.py
+++ b/.github/scripts/notify_discord.py
@@ -40,6 +40,6 @@ req = urllib.request.Request(
         "content": msg,
         "allowed_mentions": {"roles": [admin_role_id]} if admin_role_id else {},
     }).encode(),
-    headers={"Content-Type": "application/json"},
+    headers={"Content-Type": "application/json", "User-Agent": "SneezyMUD-CI"},
 )
-urllib.request.urlopen(req)
+urllib.request.urlopen(req, timeout=10)


### PR DESCRIPTION
The HTTP request is being rejected because Discord automatically blocks the default user agent for Python's native HTTP request library for security reasons. Updating to a custom user agent should fix it.

Also adds a timeout to the request, just to prevent hangs if the response takes too long.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Discord webhook request handling with timeout and request header configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->