### PR TITLE
Add Discord notification when a new PR is opened

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -56,4 +56,4 @@ runs:
         DISCORD_NEW_BUILD_WEBHOOK_URL: ${{ inputs.discord-webhook-url }}
         DISCORD_ADMIN_ROLE_ID: ${{ inputs.discord-admin-role-id }}
         GH_TOKEN: ${{ github.token }}
-      run: python .github/scripts/notify_discord.py
+      run: python .github/scripts/notify_discord.py new-build

--- a/.github/scripts/notify_discord.py
+++ b/.github/scripts/notify_discord.py
@@ -1,13 +1,23 @@
-"""Post a Discord notification when a new game image is published.
+"""Post Discord notifications for CI events.
 
-Environment variables (set in workflow step):
+Usage:
+    python notify_discord.py new-build    # New game image published
+    python notify_discord.py new-pr       # New pull request opened
+
+Subcommand environment variables (set in workflow step):
+
+  new-build:
     DISCORD_NEW_BUILD_WEBHOOK_URL  - Discord webhook endpoint
     DISCORD_ADMIN_ROLE_ID          - Discord role ID to mention (optional)
     GH_TOKEN                       - GitHub token (for gh CLI auth)
 
+  new-pr:
+    DISCORD_PR_WEBHOOK_URL         - Discord webhook endpoint
+
 Environment variables (provided automatically by GitHub Actions runner):
     GITHUB_REPOSITORY              - owner/repo (e.g. sneezymud/sneezymud)
     GITHUB_SHA                     - commit SHA that triggered the build
+    GITHUB_EVENT_PATH              - path to JSON file with webhook event payload
 """
 
 import json
@@ -16,31 +26,63 @@ import subprocess
 import sys
 import urllib.request
 
-repo = os.environ["GITHUB_REPOSITORY"]
-sha = os.environ["GITHUB_SHA"]
-webhook_url = os.environ["DISCORD_NEW_BUILD_WEBHOOK_URL"]
 
-admin_role_id = os.environ.get("DISCORD_ADMIN_ROLE_ID", "")
-
-mention = f"<@&{admin_role_id}> " if admin_role_id else ""
-msg = f"{mention}New game image available! Reboot to apply the update."
-try:
-    result = subprocess.run(
-        ["gh", "api", f"repos/{repo}/commits/{sha}/pulls", "--jq", ".[0] // empty"],
-        capture_output=True, text=True, check=True,
+def send(webhook_url, content, mention_role_id=""):
+    """Send a message to a Discord webhook."""
+    req = urllib.request.Request(
+        webhook_url,
+        data=json.dumps({
+            "content": content,
+            "allowed_mentions": {"roles": [mention_role_id]} if mention_role_id else {},
+        }).encode(),
+        headers={"Content-Type": "application/json", "User-Agent": "SneezyMUD-CI"},
     )
-    if result.stdout.strip():
-        pr = json.loads(result.stdout)
-        msg += f"\nSummary: {pr['title']} (<{pr['html_url']}>)"
-except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as e:
-    print(f"Warning: could not fetch PR details: {e}", file=sys.stderr)
+    urllib.request.urlopen(req, timeout=10)
 
-req = urllib.request.Request(
-    webhook_url,
-    data=json.dumps({
-        "content": msg,
-        "allowed_mentions": {"roles": [admin_role_id]} if admin_role_id else {},
-    }).encode(),
-    headers={"Content-Type": "application/json", "User-Agent": "SneezyMUD-CI"},
-)
-urllib.request.urlopen(req, timeout=10)
+
+def new_build():
+    """Notify that a new game image is available."""
+    repo = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["GITHUB_SHA"]
+    webhook_url = os.environ["DISCORD_NEW_BUILD_WEBHOOK_URL"]
+    admin_role_id = os.environ.get("DISCORD_ADMIN_ROLE_ID", "")
+
+    mention = f"<@&{admin_role_id}> " if admin_role_id else ""
+    msg = f"{mention}New game image available! Reboot to apply the update."
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/commits/{sha}/pulls", "--jq", ".[0] // empty"],
+            capture_output=True, text=True, check=True,
+        )
+        if result.stdout.strip():
+            pr = json.loads(result.stdout)
+            msg += f"\nSummary: {pr['title']} (<{pr['html_url']}>)"
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as e:
+        print(f"Warning: could not fetch PR details: {e}", file=sys.stderr)
+
+    send(webhook_url, msg, admin_role_id)
+
+
+def new_pr():
+    """Notify that a new pull request was opened."""
+    webhook_url = os.environ["DISCORD_PR_WEBHOOK_URL"]
+
+    with open(os.environ["GITHUB_EVENT_PATH"]) as f:
+        pr = json.load(f)["pull_request"]
+
+    author = pr["user"]["login"]
+    msg = f"New PR from **{author}**: {pr['title']}\n<{pr['html_url']}>"
+
+    send(webhook_url, msg)
+
+
+commands = {
+    "new-build": new_build,
+    "new-pr": new_pr,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in commands:
+        print(f"Usage: {sys.argv[0]} <{'|'.join(commands)}>", file=sys.stderr)
+        sys.exit(1)
+    commands[sys.argv[1]]()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Notify Discord of new PR
+        if: github.event.action == 'opened' && env.DISCORD_PR_WEBHOOK_URL != ''
+        continue-on-error: true
+        env:
+          DISCORD_PR_WEBHOOK_URL: ${{ secrets.DISCORD_PR_WEBHOOK_URL }}
+        run: python .github/scripts/notify_discord.py new-pr
+
       # Categorize changed files so downstream steps can decide what to run.
       # Infrastructure = build system/packaging; gameplay = game code/data.
       #

--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ func-test/run_test.sh
 Pull requests run automated builds and tests via GitHub Actions. Merges to master are built and published automatically via GitHub Actions.
 
 > [!TIP]
-> On successful publish, a Discord notification is sent if the `DISCORD_NEW_BUILD_WEBHOOK_URL` repository secret is configured. The notification includes a link to the merged PR, useful for letting admins know when the game can be updated to a new version. Optionally set the `DISCORD_ADMIN_ROLE_ID` repository variable to mention a Discord role in the notification.
+> **Optional Discord notifications** can be enabled via repository secrets:
+> - **New PR opened:** Set `DISCORD_PR_WEBHOOK_URL` to notify when a pull request is first opened.
+> - **New build published:** Set `DISCORD_NEW_BUILD_WEBHOOK_URL` to notify when a new game image is available. Optionally set the `DISCORD_ADMIN_ROLE_ID` repository variable to mention a Discord role in the notification.
 
 ## Notable Directories
 


### PR DESCRIPTION
Generalize notify_discord.py into a subcommand-based script supporting both 'new-build' (existing) and 'new-pr' notifications. The new-pr notification reads PR details from GITHUB_EVENT_PATH and posts the title, author, and link to a configurable webhook.

Enabled by setting the DISCORD_PR_WEBHOOK_URL repository secret (already set).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord notifications now sent when pull requests are opened, in addition to build-published notifications.
  * Optional admin role mentions can be included in Discord messages.
  * PR notifications include PR author and link; build notifications can include PR summary when available.

* **Documentation**
  * README updated to document separate webhook configuration for PR and build notifications and the admin mention option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->