### PR TITLE
Optimize CI caching and disable LTO in release presets

### DIFF
--- a/.github/actions/cached-build/action.yml
+++ b/.github/actions/cached-build/action.yml
@@ -13,15 +13,19 @@ inputs:
 runs:
   using: composite
   steps:
-    # Compute a cache key from every file that affects the compiled binary.
-    # An exact key match means nothing changed since the last build, so we
-    # can skip compilation entirely (especially the slow linking step).
-    # A prefix match restores the most recent cache as a ccache seed, then
-    # rebuilds only what changed.
+    # Cache key is derived from every file that affects the compiled binary.
+    # Exact match → skip build entirely, use cached binary.
+    # Prefix match → restore ccache for faster recompilation.
+    #
+    # Keys are branch-scoped with a master fallback, so PRs seed from
+    # master on first push and hit their own cache on subsequent pushes, which
+    # should significantly speed up re-runs of the PR validation workflow on
+    # successive pushes.
     - name: Configure cache key
       shell: bash
       env:
-        CACHE_KEY_PREFIX: ${{ runner.os }}-cmake-${{ inputs.build-preset }}-master
+        BRANCH_KEY: ${{ github.head_ref || github.ref_name }}
+        CACHE_BASE: ${{ runner.os }}-cmake-${{ inputs.build-preset }}
         SOURCE_HASH: ${{ hashFiles(
           '**/CMakeLists.txt',
           'CMakePresets.json',
@@ -32,19 +36,21 @@ runs:
       run: |
         {
           echo "CMAKE_CACHE_PATHS<<EOF"
-          echo "build/"
+          echo "code/sneezy"
           echo "$HOME/.cache/ccache"
           echo "EOF"
-          echo "CACHE_KEY_PREFIX=${CACHE_KEY_PREFIX}"
-          echo "CACHE_KEY=${CACHE_KEY_PREFIX}-${SOURCE_HASH}"
+          echo "CACHE_KEY_PREFIX=${CACHE_BASE}-${BRANCH_KEY}"
+          echo "CACHE_KEY=${CACHE_BASE}-${BRANCH_KEY}-${SOURCE_HASH}"
+          echo "CACHE_MASTER_PREFIX=${CACHE_BASE}-master"
         } >> "$GITHUB_ENV"
 
-    # The actions/cache/restore action sets an output 'cache-hit' which is:
-    #   - 'true' (string) when the exact cache key matches
-    #   - 'false' (string) when only a restore-keys prefix matches
-    #   - unset (empty string) when no match is found at all
-    # We check != 'true' (not == 'false') so that both partial and no-match
-    # cases correctly fall through to the build steps.
+    # cache-hit is 'true' on exact match, 'false' on prefix match, '' on miss.
+    # We check != 'true' so both partial and no-match fall through to build.
+    #
+    # Only code/sneezy and ccache are cached. On exact hit, code/sneezy is
+    # restored to where the Dockerfile expects it. On partial hit, ccache
+    # seeds recompilation. (Ninja .o files aren't cached because fresh
+    # checkout timestamps make them appear stale — ccache handles this.)
     - name: Restore cached build objects
       id: cache
       uses: actions/cache/restore@v5
@@ -53,16 +59,7 @@ runs:
         key: ${{ env.CACHE_KEY }}
         restore-keys: |
           ${{ env.CACHE_KEY_PREFIX }}-
-
-    # On exact cache hit, just copy the previously cached binary to
-    # where the Dockerfile expects it to avoid re-linking for no reason.
-    - name: Restore binary from cache
-      if: steps.cache.outputs.cache-hit == 'true'
-      shell: bash
-      run: |
-        mkdir -p code
-        cp "build/${{ inputs.build-preset }}/code/code/sneezy" code/sneezy
-        chmod +x code/sneezy
+          ${{ env.CACHE_MASTER_PREFIX }}-
 
     - name: Install build prerequisites
       if: steps.cache.outputs.cache-hit != 'true'
@@ -90,8 +87,8 @@ runs:
         )
         .github/scripts/install-packages.sh "${packages[@]}"
 
-    # Uses ccache to only rebuild files that changed. Still has to re-link
-    # when there are any changes at all, which is the most time-consuming step.
+    # ccache provides incremental compilation. Linking is the slowest step
+    # and always runs in full when any source changes.
     - name: Build from source
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
@@ -102,7 +99,7 @@ runs:
         ccache --show-stats
 
     - name: Cache build artifacts
-      if: steps.cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       with:
         path: ${{ env.CMAKE_CACHE_PATHS }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,27 +56,25 @@
         {
             "name": "release-gcc",
             "displayName": "GCC Production",
-            "description": "Release build with GCC, -O2 + ASan + UBSan + LTO",
+            "description": "Release build with GCC, -O2 + ASan + UBSan",
             "inherits": "base-gcc",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_CXX_FLAGS_RELEASE": "-O2 -g",
                 "SNEEZY_ENABLE_ASAN": "ON",
-                "SNEEZY_ENABLE_UBSAN": "ON",
-                "SNEEZY_ENABLE_LTO": "ON"
+                "SNEEZY_ENABLE_UBSAN": "ON"
             }
         },
         {
             "name": "release-clang",
             "displayName": "Clang Production",
-            "description": "Release build with Clang, -O2 + ASan + UBSan + ThinLTO",
+            "description": "Release build with Clang, -O2 + ASan + UBSan",
             "inherits": "base-clang",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_CXX_FLAGS_RELEASE": "-O2 -g",
                 "SNEEZY_ENABLE_ASAN": "ON",
-                "SNEEZY_ENABLE_UBSAN": "ON",
-                "SNEEZY_ENABLE_LTO": "ON"
+                "SNEEZY_ENABLE_UBSAN": "ON"
             }
         },
         {


### PR DESCRIPTION
Cache only code/sneezy + ccache instead of the entire build/ directory. Ninja ignores cached .o files anyway (fresh checkout timestamps make them appear stale), so ccache is the only mechanism providing incremental compilation. This shrinks cache entries from ~1 GiB to ~300 MB, allowing more branch caches within the 10 GiB budget.

Make cache keys branch-scoped with a master fallback so PRs seed from master on first push and hit their own cache on subsequent pushes. All branches now save caches, not just master.

Disable LTO in release presets - it adds ~7 min of link time for no measurable benefit on an I/O-bound server already running with ASan/UBSan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI caching strategy for faster incremental builds with branch-scoped cache keys
  * Updated release build configuration to remove Link Time Optimization while preserving runtime security checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->