### PR TITLE
Fix double-counted immunity bonuses from passive skills

### DIFF
--- a/code/code/misc/oldrace.cc
+++ b/code/code/misc/oldrace.cc
@@ -26,14 +26,20 @@ void TBeing::setRacialStuff() {
     // if they are both positive, use the most positive
     // if they oppose, add the two (so they can cancel eath other out)
     byte amt = getMyRace()->getImmunities().getImmunity(itt);
+
+    // Use raw immune_arr instead of getImmunity() to avoid baking dynamic
+    // skill bonuses (dufali, divine_grace, etc.) into the stored value.
+    // getImmunity() adds those bonuses on-the-fly and they would be
+    // double-counted when getImmunity() is called again later.
+    short rawImm = immunities.immune_arr[itt];
     if (amt == 0)
-      amt = getImmunity(itt);
-    else if (amt < 0 && getImmunity(itt) < 0)
-      amt = min(amt, (byte)getImmunity(itt));
-    else if (amt > 0 && getImmunity(itt) > 0)
-      amt = max(amt, (byte)getImmunity(itt));
+      amt = rawImm;
+    else if (amt < 0 && rawImm < 0)
+      amt = min(amt, static_cast<byte>(rawImm));
+    else if (amt > 0 && rawImm > 0)
+      amt = max(amt, static_cast<byte>(rawImm));
     else
-      amt = max(min(100, amt + getImmunity(itt)), -100);
+      amt = max(min(100, amt + rawImm), -100);
 
     setImmunity(itt, amt);
   }


### PR DESCRIPTION
## Bug

Immunity values for types affected by passive skills (dufali, divine grace, iron skin, iron bones, iron will) were being **double-counted**, inflating the effective immunity far beyond intended values.

This was observable via the `stat` command — immunity percentages for affected types displayed at roughly 2x the expected value — but it was **not just a display bug**. The inflated values were used in actual gameplay calculations (combat damage reduction, spell resistance, etc.).

## Root Cause

`TBeing::getImmunity()` is designed as a two-layer system:

1. **`immune_arr[]`** — stored base values from race, equipment, and spell affects
2. **`getImmunity()`** — reads `immune_arr`, then adds **dynamic** bonuses from passive skills on the fly

The bug was in `setRacialStuff()`, called during every login via `resetChar()`. It used `getImmunity()` to read the character's "current" immunity when merging with racial values:

```cpp
byte amt = getMyRace()->getImmunities().getImmunity(itt);
if (amt == 0)
    amt = getImmunity(itt);  // BUG: includes dynamic skill bonuses
```

`getImmunity()` returns `immune_arr[type]` **plus** skill bonuses (dufali, divine grace, etc.). That merged result was then written back into `immune_arr` via `setImmunity()`. When `getImmunity()` was called again later (by combat, stat, spell checks, etc.), it added the skill bonuses **a second time** on top of the already-inflated stored value.

### Concrete Example

A character with dufali at 80%, no racial charm immunity, no equipment charm immunity:

| Step | `immune_arr[CHARM]` | `getImmunity(CHARM)` |
|------|--------------------:|---------------------:|
| After `affectTotal()` | 0 | 80 (0 + dufali) |
| After `setRacialStuff()` | **80** (baked in) | **160** → clamped to **100** |
| Expected | 0 | 80 |

## Affected Skills

- `SKILL_DIVINE_GRACE` — fear, paralysis, disease, bleed, charm, summon, heat
- `SKILL_DUFALI` — paralysis, charm, disease, poison
- `SKILL_IRON_SKIN` — skin condition, bleed
- `SKILL_IRON_BONES` — bone condition
- `SKILL_IRON_WILL` — nonmagic
- `TOG_IS_HEALTHY` quest bit — disease
- `AFFECT_WET` — heat, electricity, cold

## Fix

Changed `setRacialStuff()` to read `immunities.immune_arr[itt]` directly instead of calling `getImmunity(itt)`. This ensures only the stored base values (from equipment and spell affects) are used in the racial immunity merge — dynamic skill bonuses are never written into storage.

## Impact

Players with the affected skills will see their immunity values drop to the correct (intended) levels. Characters that previously showed 100% immunity to certain types may now show the actual intended value (e.g., 80% charm immunity from dufali instead of 100%).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed immunity value calculations to correctly handle combined bonuses without duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->