### PR TITLE
add generic crit for non blunt/slash/pierce weapons

### DIFF
--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1437,6 +1437,7 @@ class TBeing : public TThing {
     int critPierce(TBeing*, TThing*, wearSlotT*, spellNumT, int*, int);
     int critSlash(TBeing*, TThing*, wearSlotT*, spellNumT, int*, int);
     int critBlunt(TBeing*, TThing*, wearSlotT*, spellNumT, int*, int);
+    int critGeneric(TBeing*, TThing*, wearSlotT*, spellNumT, int*, int);
     int numValidSlots();
     int checkShield(TBeing*, TThing*, wearSlotT, spellNumT, int);
     int getWeaponDam(const TBeing*, const TThing*, primaryTypeT) const;

--- a/code/code/misc/crit_combat.cc
+++ b/code/code/misc/crit_combat.cc
@@ -742,10 +742,10 @@ int TBeing::critSuccessChance(TBeing* victim, TThing* weapon,
     return critBlunt(victim, weapon, partHit, weaponDamageType, damage,
       critSeverity);
 
-  vlogf(LOG_BUG,
-    format("unknown weapon type in critSuccessChance (%i)") % weaponDamageType);
-
-  return 0;
+  // Generic crit for weapon types without a specific crit table (elemental,
+  // holy, etc). Provides double/triple damage without limb-specific effects.
+  return critGeneric(victim, weapon, partHit, weaponDamageType, damage,
+    critSeverity);
 }
 
 /* ------------------------------------------------------------
@@ -818,7 +818,7 @@ int TBeing::critBlunt(TBeing* v, TThing* weapon, wearSlotT* part_hit,
     buf = format("$n strikes $N exceptionally well, %s $S %s with $s %s.") %
           attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
           limbStr;
-    act(buf, TRUE, this, 0, v, TO_NOTVICT, ANSI_BLUE);
+    act(buf, false, this, 0, v, TO_NOTVICT, ANSI_BLUE);
 
     return (ONEHIT_MESS_CRIT_S);
   } else if (crit_num <= 66) {
@@ -833,12 +833,12 @@ int TBeing::critBlunt(TBeing* v, TThing* weapon, wearSlotT* part_hit,
     buf = format("$n critically strikes you, %s your %s with $s %s.") %
           attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
           limbStr;
-    act(buf, TRUE, this, 0, v, TO_VICT, ANSI_RED);
+    act(buf, false, this, 0, v, TO_VICT, ANSI_RED);
 
     buf = format("$n critically strikes $N, %s $S %s with $s %s.") %
           attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
           limbStr;
-    act(buf, TRUE, this, 0, v, TO_NOTVICT, ANSI_BLUE);
+    act(buf, false, this, 0, v, TO_NOTVICT, ANSI_BLUE);
 
     return (ONEHIT_MESS_CRIT_S);
   } else {
@@ -2749,4 +2749,71 @@ int TBeing::critPierce(TBeing* v, TThing* weapon, wearSlotT* part_hit,
     }
   }
   return 0;
+}
+
+/* ------------------------------------------------------------
+
+====Generic crit table====
+
+Generic crit for weapon types that don't have a specific crit table, such as
+elemental and holy damage types. Only provides damage multipliers without
+limb-specific effects.
+
+0-50: double damage
+51-100: triple damage
+
+------------------------------------------------------------ */
+int TBeing::critGeneric(TBeing* v, TThing* weapon, wearSlotT* part_hit,
+  spellNumT wtype, int* dam, int crit_num) {
+  int new_wtype = wtype - TYPE_HIT;
+  sstring limbStr = (weapon ? fname(weapon->name) : getMyRace()->getBodyLimbBlunt());
+
+  if (crit_num > 100) {
+    vlogf(LOG_BUG,
+      format("critGeneric called with crit_num>100 (%i)") % crit_num);
+    crit_num = 0;
+  }
+
+  if (crit_num <= 50) {
+    // double damage
+    *dam *= 2;
+
+    sstring buf =
+      format("You strike $N exceptionally well, %s $S %s with your %s!") %
+      attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
+      limbStr;
+    act(buf, false, this, 0, v, TO_CHAR, ANSI_ORANGE);
+
+    buf = format("$n strikes you exceptionally well, %s your %s with $s %s.") %
+          attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
+          limbStr;
+    act(buf, false, this, 0, v, TO_VICT, ANSI_RED);
+
+    buf = format("$n strikes $N exceptionally well, %s $S %s with $s %s.") %
+          attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
+          limbStr;
+    act(buf, false, this, 0, v, TO_NOTVICT, ANSI_BLUE);
+
+    return ONEHIT_MESS_CRIT_S;
+  }
+
+  // triple damage
+  *dam *= 3;
+
+  sstring buf = format("You critically strike $N, %s $S %s with your %s!") %
+                attack_hit_text[new_wtype].hitting %
+                v->describeBodySlot(*part_hit) % limbStr;
+  act(buf, false, this, 0, v, TO_CHAR, ANSI_ORANGE);
+
+  buf = format("$n critically strikes you, %s your %s with $s %s.") %
+        attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
+        limbStr;
+  act(buf, false, this, 0, v, TO_VICT, ANSI_RED);
+
+  buf = format("$n critically strikes $N, %s $S %s with $s %s.") %
+        attack_hit_text[new_wtype].hitting % v->describeBodySlot(*part_hit) %
+        limbStr;
+  act(buf, false, this, 0, v, TO_NOTVICT, ANSI_BLUE);
+
+  return ONEHIT_MESS_CRIT_S;
 }


### PR DESCRIPTION
This fixes an existing bug "unknown weapon type in critSuccessChance". This bug exists for weapon types that aren't blunt/pierce/slash so, air/fire/water/earth and holy. This is sufficiently generic and should support any new types that fall through the core more specific crits.

This includes 2X and 3X crits but not any special crits/crit kills like the more specific tables.

Note: this doesn't preclude us from adding more specific criteria tables for any of the other types later.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generic critical-hit handling added for weapon types that previously had no specific crit tables.
  * Critical hits now apply scaled damage: ~2× for lower thresholds and ~3× for higher thresholds.
  * Combat feedback improved with clearer critical-hit messages.

* **Bug Fixes**
  * Previously unsupported weapon cases now route through the generic crit path so crits can occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->