### PR TITLE
Refactor shaman mob spell selection: data-driven weighted pool

### DIFF
--- a/code/code/misc/ai_assignskills.cc
+++ b/code/code/misc/ai_assignskills.cc
@@ -223,7 +223,13 @@ void TBeing::assignSkills(classIndT Class, discNumT primDisc,
     shuffleContainer(favorites);
     bool raisedFavorite = false;
     for (unsigned int i = 0; i < favorites.size(); ++i) {
-      if (getDiscipline(favorites[i])->getLearnedness() < 70) {
+      CDiscipline* cd_fav = getDiscipline(favorites[i]);
+      if (!cd_fav) {
+        vlogf(LOG_BUG,
+          format("%s didn't have discipline %i.") % getName() % favorites[i]);
+        return;
+      }
+      if (cd_fav->getLearnedness() < 70) {
         raiseDiscOnce(favorites[i]);
         raisedFavorite = true;
         break;

--- a/code/code/misc/mobact.cc
+++ b/code/code/misc/mobact.cc
@@ -1881,7 +1881,7 @@ static const int SHAMAN_MIN_SKILL = 60;
 
 static const ShamanSpellEntry shamanSpellTable[] = {
   // SITUATIONAL spells — bypass tier filtering
-  {SPELL_CHASE_SPIRIT,    40, SHAMAN_SITUATIONAL, "$n utters the words, 'Spirits be gone from this pathetic one!'"},
+  {SPELL_CHASE_SPIRIT,    70, SHAMAN_SITUATIONAL, "$n utters the words, 'Spirits be gone from this pathetic one!'"},
   {SPELL_INTIMIDATE,      40, SHAMAN_SITUATIONAL, "$n utters the invokation, 'Go Away! Leave me the Hell Alone!'"},
   {SPELL_FLATULENCE,      20, SHAMAN_SITUATIONAL, "$n utters the invokation, 'He who smelt it, dealt it!'"},
   {SPELL_STUPIDITY,       10, SHAMAN_SITUATIONAL, "$n utters the invokation, 'DUUHHHHHHHHHHH!!!!!!!!!'"},
@@ -1889,19 +1889,16 @@ static const ShamanSpellEntry shamanSpellTable[] = {
 
   // OFFENSIVE spells — subject to tier filtering
   {SPELL_LIFE_LEECH,      20, SHAMAN_OFFENSIVE, "$n utters the invokation, 'I'm gonna suck you dry!!!'"},
-  {SPELL_LICH_TOUCH,      70, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Lich me, SUCKAH!!!'"},
-  {SPELL_RAZE,            70, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Rubbem Ow!'"},
+  {SPELL_LICH_TOUCH,      80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Lich me, SUCKAH!!!'"},
+  {SPELL_RAZE,            80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Rubbem Ow!'"},
   {SPELL_VAMPIRIC_TOUCH,  40, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Ahh!! The BLUUD!!!!!'"},
   {SPELL_SOUL_TWIST,      30, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Internal Pretzel!'"},
   {SPELL_SQUISH,          10, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Firsta you takka da dough like-a dis...'"},
-  {SPELL_DISTORT,         20, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Houngan\\'s Delight!'"},
-  {SPELL_STICKS_TO_SNAKES,10, SHAMAN_OFFENSIVE, "$n utters the invokation, 'I got a woody and I\\'m gonna use it!'"},
-  {SPELL_STORMY_SKIES,    20, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Weather! Do my deed!'"},
-  {SPELL_DEATHWAVE,       70, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Deadly Blackness!'"},
-  {SPELL_AQUATIC_BLAST,   50, SHAMAN_OFFENSIVE, "$n utters the invokation, 'River run DEEEEEEEEEEP!!!!'"},
-  {SPELL_BLOOD_BOIL,      50, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Bubble, bubble. BOILING BLOOD!!'"},
-  {SPELL_CARDIAC_STRESS,  70, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Don\\'t go breakin\\' my heart!'"},
-  {SPELL_HEALING_GRASP,   10, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Ahhh...that\\'s better...'"},
+  {SPELL_DISTORT,         20, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Houngan's Delight!'"},
+  {SPELL_DEATHWAVE,       80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Deadly Blackness!'"},
+  {SPELL_AQUATIC_BLAST,   60, SHAMAN_OFFENSIVE, "$n utters the invokation, 'River run DEEEEEEEEEEP!!!!'"},
+  {SPELL_BLOOD_BOIL,      60, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Bubble, bubble. BOILING BLOOD!!'"},
+  {SPELL_CARDIAC_STRESS,  80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Don't go breakin' my heart!'"},
 };
 
 static bool checkShamanSituational(TMonster& ch, TBeing& vict, spellNumT spell) {
@@ -1927,27 +1924,34 @@ static bool checkShamanSituational(TMonster& ch, TBeing& vict, spellNumT spell) 
       return ch.attackers >= 2 &&
              !vict.affectedBySpell(SPELL_DEATH_MIST);
     default:
-      return true;
+      return false;
   }
 }
 
+// To add a self-targeting spell (e.g. a self-heal or buff):
+// 1. Add it to shamanSpellTable as SHAMAN_SITUATIONAL
+// 2. Add a case to checkShamanSituational with the appropriate condition
+// 3. In the candidate-building loop below, set on_me = TRUE when that spell
+//    is selected. The shamanMove caller already handles the on_me branch.
 static spellNumT get_shaman_spell(TMonster& ch, TBeing& vict, bool& on_me) {
   on_me = FALSE;
 
   static const int TIER_WINDOW = 30;
 
-  // 1. Find the best offensive start value across all disciplines
-  int bestStart = 0;
+  // 1. Find the best offensive start value in the basic shaman discipline
+  int bestBasicStart = 0;
   for (const auto& entry : shamanSpellTable) {
     if (entry.category != SHAMAN_OFFENSIVE)
       continue;
+    if (discArray[entry.spell]->disc != DISC_SHAMAN)
+      continue;
     if (!ch.doesKnowSkill(entry.spell))
       continue;
-    if (ch.getSkillValue(entry.spell) <= SHAMAN_MIN_SKILL)
+    if (ch.getSkillValue(entry.spell) < SHAMAN_MIN_SKILL)
       continue;
     int start = discArray[entry.spell]->start;
-    if (start > bestStart)
-      bestStart = start;
+    if (start > bestBasicStart)
+      bestBasicStart = start;
   }
 
   // 2. Build candidate pool
@@ -1957,17 +1961,42 @@ static spellNumT get_shaman_spell(TMonster& ch, TBeing& vict, bool& on_me) {
   for (const auto& entry : shamanSpellTable) {
     if (!ch.doesKnowSkill(entry.spell))
       continue;
-    if (ch.getSkillValue(entry.spell) <= SHAMAN_MIN_SKILL)
+    if (ch.getSkillValue(entry.spell) < SHAMAN_MIN_SKILL)
       continue;
 
     if (entry.category == SHAMAN_SITUATIONAL) {
       if (checkShamanSituational(ch, vict, entry.spell))
         candidates.push_back({entry.spell, entry.weight, entry.message});
     } else {
-      // Tier filter: only include if within TIER_WINDOW of best
-      int start = discArray[entry.spell]->start;
-      if (start >= bestStart - TIER_WINDOW)
-        candidates.push_back({entry.spell, entry.weight, entry.message});
+      // Tier filter: only apply to basic shaman disc spells
+      if (discArray[entry.spell]->disc == DISC_SHAMAN) {
+        int start = discArray[entry.spell]->start;
+        if (start < bestBasicStart - TIER_WINDOW)
+          continue;
+      }
+      candidates.push_back({entry.spell, entry.weight, entry.message});
+    }
+  }
+
+  // 2b. Life-drain boost: when hurt, add the best known drain spell again
+  //     to increase its selection weight (may duplicate an existing entry)
+  if (ch.getHit() < ch.hitLimit() * 3 / 4) {
+    static const spellNumT drainSpells[] = {
+      SPELL_LICH_TOUCH, SPELL_VAMPIRIC_TOUCH, SPELL_LIFE_LEECH
+    };
+    for (auto spell : drainSpells) {
+      if (!ch.doesKnowSkill(spell))
+        continue;
+      if (ch.getSkillValue(spell) < SHAMAN_MIN_SKILL)
+        continue;
+      // find matching table entry for the message
+      for (const auto& entry : shamanSpellTable) {
+        if (entry.spell == spell) {
+          candidates.push_back({entry.spell, entry.weight, entry.message});
+          break;
+        }
+      }
+      break;  // only add the best one we know
     }
   }
 


### PR DESCRIPTION
## Summary

Replaces the `get_shaman_spell` function with a data-driven weighted candidate pool, fixing a broken level check and making spell selection much easier to understand and tune.

### Bug fixed

The old code compared mob level (1–50) against discipline `start` thresholds (1–100) — two completely different scales. The condition `cutoff < discArray[spell]->start` accidentally blocked most low-`start` spells for high-level mobs, funneling them into a tiny pool of high-`start` spells. Combined with a 10-retry loop in `shamanMove()`, this caused chase spirit to dominate when victims had common buffs.

### What changed

The old implementation was ~330 lines of if-chains across discipline-specific branches (`DISC_SHAMAN`, `DISC_SHAMAN_SPIDER`, `DISC_SHAMAN_FROG`, etc.), where spell weighting was done by duplicating entries (e.g. life_leech appeared 4 times) and each check had its own random roll that could fail, requiring the retry loop.

The new implementation:

- **Spell table**: A static array of structs defining every spell, its weight, category (offensive vs situational), and flavor text. Adding or tuning a spell is a one-line change.
- **Two categories**: Offensive spells are subject to tier filtering. Situational spells (chase spirit, intimidate, flatulence, stupidity, death mist) bypass tier filtering and enter the pool only when their specific trigger condition is met.
- **Tier filtering**: Scans all offensive spells the mob knows across ALL disciplines (not just one randomly-selected discipline), finds the best `start` value, and only includes offensive spells within a 30-point window. This means high-level mobs use their best spells without being locked to a single discipline, while low-level mobs with only basic spells still have a full pool.
- **Weighted random selection**: Single pick from the candidate pool — always returns a spell if any are eligible, no retry loop needed.
- **Uniform skill threshold**: `SHAMAN_MIN_SKILL = 60` — mobs must have >60% proficiency in a spell to consider casting it. The old code had inconsistent per-spell thresholds (0, 33, or 66) with no clear design rationale.

### Situational spell conditions (preserved from original)

- **Chase spirit**: victim has a dispellable buff (haste, celerite, etc.) and doesn't already have faerie fire/bind
- **Intimidate**: mob below 1/8 HP, not pissed, not a test fight mob
- **Flatulence / Death mist**: 2+ attackers (death mist also checks it's not already applied)
- **Stupidity**: victim not already affected
- **leech spells**:Best of lich touch, vampiric touch, life leech when below 75% life

### Assign Skills Change
One of the challenges of mid level shaman was that the method of assigning skills picked a favorite and learned up to 75% and the spread out the rest of the pracs amongst ALL available skills including things like weapon specialization and advanced adventuring. This led to shaman without any good spells in the mid levels as the powerful spells are at the top of the advanced discs.

The change here maxes the favorite disc and next spreads pracs amongst favorites up to 70% before moving on to round robining between all discs.

NOTE: This change impacts all classes. Therefore I made some tweaks to other class favorite discs as well. 

## Test plan

- [x] Build confirms no compile errors
- [x] Restore nightly backup to dev environment for testing with real mob data
- [x] Verify high-level shaman mobs use a variety of spells, not just chase spirit
- [x] Verify low-level shaman mobs with only basic spells still cast successfully
- [x] Verify situational spells trigger appropriately (chase spirit when victim buffed, flatulence with multiple attackers, etc.)
- [x] Verify mobs with multiple advanced disciplines draw from all of them, not just one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Shaman casting rebuilt into a single, data-driven selection: offensive vs situational spells are chosen via weighted candidates, simplifying prior special-case logic and calling selection once per turn.
* **New Features / Balance**
  * Shaman now injects extra life-drain options when injured.
  * Favored-skill progression adjusted for several classes to prioritize full mastery and broaden progression choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->