### PR TITLE
devcontainer: fix MariaDB version issue and restore-backup script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,17 +9,22 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH="/usr/games:${PATH}"
 ENV TZ=UTC
 
+# Add MariaDB 12 official repository before the main install. Ubuntu Noble
+# ships 10.11, but production runs 12.x which uses per-table FK constraint
+# names (MDEV-28933). Restoring production backups requires matching the
+# server major version.
 RUN --mount=type=cache,target=/var/cache/apt \
+  apt-get update && \
+  apt-get install --yes --no-install-recommends ca-certificates curl && \
+  curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup | bash && \
   apt-get update && \
   apt-get install --yes --no-install-recommends \
   bash-completion \
   build-essential \
-  ca-certificates \
   ccache \
   clang \
   clangd \
   cmake \
-  curl \
   gdb \
   git \
   htop \

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -36,12 +36,16 @@ if ! [ -f /var/lib/mysql/.devcontainer-seeded ]; then
     exit 1
   fi
 
-  mariadb -e "CREATE DATABASE IF NOT EXISTS sneezy; CREATE DATABASE IF NOT EXISTS immortal;"
-  mariadb -e "CREATE USER IF NOT EXISTS 'ubuntu'@'localhost' IDENTIFIED VIA unix_socket;"
   # CREATE USER IF NOT EXISTS no-ops if the user exists with a different auth
   # method. ALTER USER ensures unix_socket auth regardless of prior state.
-  mariadb -e "ALTER USER 'ubuntu'@'localhost' IDENTIFIED VIA unix_socket;"
-  mariadb -e "GRANT ALL ON sneezy.* TO 'ubuntu'@'localhost'; GRANT ALL ON immortal.* TO 'ubuntu'@'localhost'; FLUSH PRIVILEGES;"
+  mariadb -e "
+    CREATE DATABASE IF NOT EXISTS sneezy;
+    CREATE DATABASE IF NOT EXISTS immortal;
+    CREATE USER IF NOT EXISTS 'ubuntu'@'localhost' IDENTIFIED VIA unix_socket;
+    ALTER USER 'ubuntu'@'localhost' IDENTIFIED VIA unix_socket;
+    GRANT ALL ON *.* TO 'ubuntu'@'localhost';
+    FLUSH PRIVILEGES;
+  "
 
   for db in immortal sneezy; do
     for phase in tables views data; do


### PR DESCRIPTION
Ubuntu Noble ships MariaDB 10.11, but production runs 12.x. MariaDB 12.1 introduced per-table FK constraint name scoping (MDEV-28933), which means auto-generated constraint names like "1", "2" can repeat across tables. Restoring a MariaDB 12 dump into 10.11 fails with errno 121 (duplicate constraint name) because 10.11 enforces per-database uniqueness.

Uses the rolling 12.x repo to stay in sync with production's mariadb:12 Docker image.

Also fixes a permission issue when restoring production SQL dumps in the devcontainer by simply granting all on *.* in the entrypoint script. Safe in the single-user, throwaway devcontainer environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment to use MariaDB 12 for improved production compatibility.
  * Simplified database initialization process in the development container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->