### PR TITLE
fix the cmd att per to not show a werid message for PLR_SAVE_QUEUED

### DIFF
--- a/code/code/misc/constants.cc
+++ b/code/code/misc/constants.cc
@@ -699,7 +699,7 @@ const char* const attr_player_bits[] = {"Brief", "Compact", "Wimpy",
   "Right-Handed", "AFK", "132 columns", "Solo quest", "Group quest", "",
   "Tell-an-immort-you-saw-this (unused1)", "God No-Shout",
   "Tell-an-immort-you-saw-this (NODIMD)",
-  "Tell-an-immort-you-saw-this (unused5)", "Killable", "Anonymous", "PG-13",
+  "", "Killable", "Anonymous", "PG-13",
   "\n"};
 
 const char* const prompt_mesg[] = {"near death", "horrid", "awful", "bad",


### PR DESCRIPTION
Simple fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an attribute configuration constant value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->