### PR TITLE
adding stumble and applying to skill failures

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -323,15 +323,10 @@ int TBeing::bashFail(TBeing* victim, spellNumT skill,
   }
 
   if (hasLegs()) {
-    int rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
-
-    sendTo(format("%sYou fall over.%s\n\r") % red() % norm());
-    act("$n falls over.", TRUE, this, 0, 0, TO_ROOM);
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -82,8 +82,6 @@ bool TBeing::canBodyslam(TBeing* victim, silentTypeT silent) {
 }
 
 int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
-  int rc;
-
   if (type == TYPE_DEX) {
     act("$N deftly avoids your bodyslam attempt.", FALSE, this, 0, victim,
       TO_CHAR);
@@ -99,45 +97,29 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     act("$N deftly counters $n's bodyslam attempt, and heaves $m to the $g.",
       FALSE, this, 0, victim, TO_NOTVICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else if (type == TYPE_STR) {
-    act("$n collapses as $e fails to pick $N up.", FALSE, this, 0, victim,
+    act("$n tries to bodyslam $N but fails to lift $M.", false, this, 0, victim,
       TO_NOTVICT);
-    act("Your strength gives out as you try to pick $N up for bodyslamming.",
-      FALSE, this, 0, victim, TO_CHAR);
-    act("$n's strength gives out as $e tries to pick you up for bodyslamming.",
-      FALSE, this, 0, victim, TO_VICT);
-
-    rc = crashLanding(POSITION_SITTING);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    sendTo(format("%sYou fall to the %s.%s\n\r") % blue() %
-           roomp->describeGround() % norm());
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
-      return rc;
-  } else {
-    act("$n tries to bodyslam $N, but ends up falling down.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You try to bodyslam $N, but end up falling on your face.", FALSE, this,
-      0, victim, TO_CHAR);
-    act("$n fails to bodyslam you, and tumbles to the $g.", FALSE, this, 0,
+    act("You try to bodyslam $N but fail to lift $M.", false, this, 0, victim,
+      TO_CHAR);
+    act("$n tries to bodyslam you but fails to lift you.", false, this, 0,
       victim, TO_VICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  } else {
+    int rc = stumble(victim);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_doorbash.cc
+++ b/code/code/cmd/cmd_doorbash.cc
@@ -25,7 +25,20 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
   sendTo("OUCH!  That REALLY Hurt!\n\r");
   sprintf(buf, "$n crashes against the %s with no effect.\n\r", doorname);
   act(buf, FALSE, this, 0, 0, TO_ROOM);
-  if (reconcileDamage(this, (::number(1, 10) * 2), DAMAGE_COLLISION) == -1)
+  TBeing* fightTarget = fight();
+  int rc = stumble(fightTarget);
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    return DELETE_THIS;
+  if (IS_SET_DELETE(rc, DELETE_VICT)) {
+    delete fightTarget;
+    fightTarget = nullptr;
+  }
+
+  int dam = ::number(1, 10) * 2;
+  if (isBrawny())
+    dam /= 2;
+  addToWait(combatRound(dam));
+  if (reconcileDamage(this, dam, DAMAGE_COLLISION) == -1)
     return DELETE_THIS;
 
   if (!isImmortal()) {
@@ -36,15 +49,6 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
     aff.bitvector = AFF_STUNNED;
     affectTo(&aff, -1);
   }
-
-#if 0
-  addToWait(combatRound(12));
-#else
-  int rc;
-  rc = crashLanding(POSITION_RESTING);
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-#endif
 
   return TRUE;
 }

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -52,26 +52,23 @@ bool TBeing::canHeadbutt(TBeing* victim, const silentTypeT silent) const {
 }
 
 int TBeing::headbuttMiss(TBeing* v) {
-  int rc;
-
   if (v->doesKnowSkill(SKILL_COUNTER_MOVE) || isCombatMode(ATTACK_BERSERK)) {
     // I don't understand this logic
     act("$N deftly avoids $n's headbutt.", FALSE, this, 0, v, TO_NOTVICT);
     act("$N deftly avoids your headbutt.", FALSE, this, 0, v, TO_CHAR);
     act("You deftly avoid $n's headbutt.", FALSE, this, 0, v, TO_VICT);
   } else {
-    act("$N avoids $n's headbutt.", FALSE, this, 0, v, TO_NOTVICT);
-    act("$N moves $S head, and you fall down as you miss your headbutt.", FALSE,
-      this, 0, v, TO_CHAR);
-    act("$n tries to headbutt you, but you dodge it.", FALSE, this, 0, v,
-      TO_VICT);
+    act("$N moves $S head out of the way, causing $n to miss.", false, this, 0,
+      v, TO_NOTVICT);
+    act("$N moves $S head out of the way, causing you to miss.", false, this, 0,
+      v, TO_CHAR);
+    act("You move your head out of the way, causing $n to miss.", false, this,
+      0, v, TO_VICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(v);
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
-
-    rc = trySpringleap(v);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
   reconcileDamage(v, 0, SKILL_HEADBUTT);

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -85,8 +85,6 @@ bool TBeing::canSpin(TBeing* victim, silentTypeT silent) {
 }
 
 int TBeing::spinMiss(TBeing* victim, skillMissT type) {
-  int rc;
-
   if (type == TYPE_DEX) {
     act("$N deftly avoids your attempt at spinning $M.", FALSE, this, 0, victim,
       TO_CHAR);
@@ -116,27 +114,23 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
     act("$N sticks out $S foot tripping $n to the $g.", FALSE, this, 0, victim,
       TO_NOTVICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
-    act("$n tries to spin $N, but ends up falling down.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You try to spin $N, but end up falling on your face.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n fails to spin you, and tumbles to the $g.", FALSE, this, 0, victim,
+    act("$n tries to spin $N but loses $s footing.", false, this, 0, victim,
+      TO_NOTVICT);
+    act("You try to spin $N but lose your footing.", false, this, 0, victim,
+      TO_CHAR);
+    act("$n tries to spin you but loses $s footing.", false, this, 0, victim,
       TO_VICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/disc/disc_monk_leverage.cc
+++ b/code/code/disc/disc_monk_leverage.cc
@@ -50,18 +50,18 @@ int TBeing::doHurl(const char* argument, TBeing* vict) {
 }
 
 int hurlMiss(TBeing* caster, TBeing* victim) {
-  int rc;
-
-  act("$n misses $s attempt at hurling $N and falls on $s butt!", FALSE, caster,
-    0, victim, TO_NOTVICT);
-  act("You fall as you attempt to hurl $N!", FALSE, caster, 0, victim, TO_CHAR);
-  act("You manage to avoid $n as $e tries to hurl you!", FALSE, caster, 0,
+  act("$n fails to hurl $N correctly and loses $s balance.", false, caster, 0,
+    victim, TO_NOTVICT);
+  act("You fail to hurl $N correctly and lose your balance.", false, caster, 0,
+    victim, TO_CHAR);
+  act("$n fails to hurl you correctly and loses $s balance.", false, caster, 0,
     victim, TO_VICT);
 
-  rc = caster->crashLanding(POSITION_SITTING);
+  int rc = caster->stumble(victim);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
 }
@@ -365,19 +365,18 @@ int TBeing::doShoulderThrow(const char* argument, TBeing* vict) {
 }
 
 int shoulderThrowMiss(TBeing* caster, TBeing* victim) {
-  int rc;
-
-  act("$n misses $s attempt at shoulder throwing $N and falls on $s butt!",
-    FALSE, caster, 0, victim, TO_NOTVICT);
-  act("You fall as you attempt to shoulder throw $N!", FALSE, caster, 0, victim,
+  act("$n clumsily fails to shoulder throw $N.", false, caster, 0, victim,
+    TO_NOTVICT);
+  act("You clumsily fail to shoulder throw $N.", false, caster, 0, victim,
     TO_CHAR);
-  act("You manage to avoid $n as $e tries to shoulder throw you!", FALSE,
-    caster, 0, victim, TO_VICT);
+  act("$n clumsily fails to shoulder throw you.", false, caster, 0, victim,
+    TO_VICT);
 
-  rc = caster->crashLanding(POSITION_SITTING);
+  int rc = caster->stumble(victim);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
   caster->reconcileDamage(victim, 0, SKILL_CHOP);
   return TRUE;
 }
@@ -573,19 +572,18 @@ int TBeing::doDefenestrate(const char* argument, TBeing* vict) {
 }
 
 int defenestrateMiss(TBeing* caster, TBeing* victim) {
-  int rc;
-
-  act("$n misses $s attempt at defenestrating $N and falls on $s butt!", FALSE,
-    caster, 0, victim, TO_NOTVICT);
-  act("You fall as you attempt to defenestrate $N!", FALSE, caster, 0, victim,
+  act("$n clumsily fails to throw $N out the window.", false, caster, 0, victim,
+    TO_NOTVICT);
+  act("You clumsily fail to throw $N out the window.", false, caster, 0, victim,
     TO_CHAR);
-  act("You manage to avoid $n as $e tries to defenestrate you!", FALSE, caster,
-    0, victim, TO_VICT);
+  act("$n clumsily fails to throw you out the window.", false, caster, 0,
+    victim, TO_VICT);
 
-  rc = caster->crashLanding(POSITION_SITTING);
+  int rc = caster->stumble(victim);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
 }

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1330,6 +1330,7 @@ class TBeing : public TThing {
     void doLand();
     int crashLanding(positionTypeT, bool force = FALSE, bool dam = TRUE,
       bool falling = false);
+    int stumble(TBeing* victim = nullptr);
     int doTurn(const char*, TBeing*);
     virtual void doMedit(const char*);
     void doPreen(sstring& argument);

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -2725,7 +2725,7 @@ void TBeing::doSit(const sstring& argument) {
   }
 #if 0
   int rc = triggerSpecial(this, CMD_OBJ_SATON, arg);
-  if (IS_SET_DELETE(rc, DELETE_THIS)) 
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
 
   if (rc)
@@ -3514,6 +3514,42 @@ int TBeing::crashLanding(positionTypeT pos, bool force, bool dam,
   }
 
   return TRUE;
+}
+
+int TBeing::stumble(TBeing* victim) {
+  if (!isAgile(0)) {
+    setPosition(POSITION_SITTING);
+    sendTo("You stumble and fall on your butt!\n\r");
+    act("$n stumbles and falls on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+    addToWait(combatRound(1));
+
+    int stumbleDam = dice(1, 4);
+
+    TBeing* springTarget = victim ? victim : fight();
+    if (springTarget) {
+      int rc = trySpringleap(springTarget);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      if (IS_SET_DELETE(rc, DELETE_VICT))
+        return DELETE_VICT;
+      if (rc)
+        stumbleDam /= 2;
+    }
+
+    if (reconcileDamage(this, stumbleDam, DAMAGE_FALL) == -1)
+      return DELETE_THIS;
+  } else {
+    setPosition(POSITION_STANDING);
+    if (isFlying()) {
+      sendTo("You stumble, but quickly recover your footing!\n\r");
+      act("$n stumbles, but quickly recovers!", true, this, nullptr, nullptr, TO_ROOM);
+    } else {
+      sendTo("You stumble, but catch yourself!\n\r");
+      act("$n stumbles, but catches $mself!", true, this, nullptr, nullptr, TO_ROOM);
+    }
+    addToWait(combatRound(1) / 2);
+  }
+  return FALSE;
 }
 
 int TBeing::doMortalGoto(const sstring& argument) {


### PR DESCRIPTION
This is part 1 (of 3) of the big Deikhan-on-a-Horse fix.

The content within is tested but doesn't start to get complicated until part 2, and doesn't start to add new features until part 3.

Part 1: Stumble

To break crashLanding up into digestible bits that can be utilized to more specific concerns, one of its uses needed to be converted to a new feature. Many special attack failure cases use crashLanding but they should be given a more fitting tool.

Introducing stumble(), a feature which accounts for falling down when you make a little whoopsie. The best part about stumble() is that it incentivizes the Agility stat, by allowing a warrior to stay standing even after a skill failure. This prevents a simple low-level Bash failure from becoming a dangerous skill to attempt at early levels. To that end, it also cuts down on the likelihood that a warrior/monk will get lost in the unending Springleap loop by failing a Bash but succeeding Springleap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified "stumble" outcome for missed melee and monk moves, producing clearer footing outcomes and timing changes.
* **Refactor**
  * Simplified and unified miss/fall flows for bash, bodyslam, headbutt, spin, doorbash and monk leverage moves.
  * Miss messages updated for clarity; door slam timing and damage calculation adjusted (including reduced impact for brawny targets).
* **Chores**
  * Minor messaging and flow cleanups across combat miss paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->