### PR TITLE
Migrate player affects from charfile to database

### DIFF
--- a/_Setup-data/sql_tables/sneezy/player_affect.sql
+++ b/_Setup-data/sql_tables/sneezy/player_affect.sql
@@ -1,0 +1,45 @@
+-- SneezyMUD player affects table
+-- Stores character buffs/debuffs/spell affects, replacing the fixed-size
+-- charFile array (MAX_AFFECT=25) with an unlimited DB-backed store.
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `player_affect`
+--
+
+DROP TABLE IF EXISTS `player_affect`;
+CREATE TABLE `player_affect` (
+  `id` bigint(20) unsigned NOT NULL auto_increment,
+  `player_id` bigint(20) unsigned NOT NULL,
+  `type` smallint(6) NOT NULL,
+  `level` tinyint(4) NOT NULL,
+  `duration` int(11) NOT NULL,
+  `renew` int(11) NOT NULL,
+  `modifier` bigint(20) NOT NULL,
+  `modifier2` bigint(20) NOT NULL,
+  `location` tinyint(3) unsigned NOT NULL,
+  `bitvector` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_player_affect_player` (`player_id`),
+  CONSTRAINT `fk_player_affect_player` FOREIGN KEY (`player_id`) REFERENCES `player` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

--- a/code/code/misc/person.h
+++ b/code/code/misc/person.h
@@ -67,6 +67,8 @@ class TPerson : public TBeing {
     void setDimensions();
     void setTitle(bool);
     void rentAffectTo(saveAffectedData*);
+    void saveAffectsToDB();
+    bool loadAffectsFromDB();
     void setSelectToggles(TBeing*, classIndT, silentTypeT);
     void advanceSelectDisciplines(classIndT, int, silentTypeT);
     void doLevelSkillsLearn(discNumT, int, int);

--- a/code/code/misc/player_data.cc
+++ b/code/code/misc/player_data.cc
@@ -420,10 +420,8 @@ void TPerson::storeToSt(charFile* st) {
     }
   }
 
-  if ((j >= MAX_AFFECT) && af && af->next)
-    vlogf(LOG_SILENT,
-      format("WARNING: (%s) OUT OF STORE ROOM FOR AFFECTED TYPES!!!") %
-        getName());
+  // Charfile overflow is no longer a concern — affects are saved to DB
+  // without a cap by saveAffectsToDB()
 
   // Save the discipline learning
   // unused disc_learning values should be 0 from charFile ctor
@@ -838,9 +836,13 @@ void TPerson::loadFromSt(charFile* st) {
   // armor spell.  I left it this way cause although duplicative, I forsee
   // someone changing things around and seperating the functions of load and
   // reset char
-  for (i = 0; i < MAX_AFFECT; i++) {
-    if (st->affected[i].type) {
-      rentAffectTo(&st->affected[i]);
+  if (!loadAffectsFromDB()) {
+    // No DB rows yet — fall back to charfile affects for characters who
+    // haven't saved since the migration to DB-backed affects
+    for (i = 0; i < MAX_AFFECT; i++) {
+      if (st->affected[i].type) {
+        rentAffectTo(&st->affected[i]);
+      }
     }
   }
 
@@ -889,6 +891,66 @@ void TPerson::rentAffectTo(saveAffectedData* af) {
     affectTo(&a, af->renew);
     return;
   }
+}
+
+void TPerson::saveAffectsToDB() {
+  // Runs within saveChar's TTransaction scope - shares the same DB_SNEEZY
+  // connection, so the DELETE + INSERTs are atomic with the other saves.
+  TDatabase db(DB_SNEEZY);
+  db.query("DELETE FROM player_affect WHERE player_id = %i", getPlayerID());
+
+  for (auto* af = affected; af; af = af->next) {
+    if (af->type == SKILL_SEEKWATER || af->type == SKILL_TRACK ||
+        af->type == SPELL_TRAIL_SEEK)
+      continue;
+
+    int mappedType = mapSpellnumToFile(af->type);
+    if (mappedType == -1)
+      continue;
+
+    long mappedModifier = applyTypeShouldBeSpellnum(af->location)
+                            ? static_cast<long>(mapSpellnumToFile(
+                                static_cast<spellNumT>(af->modifier)))
+                            : af->modifier;
+
+    // Build full query via boost::format to preserve 64-bit bitvector values
+    // (TDatabase %i truncates to int via va_arg)
+    sstring query =
+      (format("INSERT INTO player_affect "
+              "(player_id, type, level, duration, renew, modifier, modifier2, "
+              "location, bitvector) "
+              "VALUES (%i, %i, %i, %i, %i, %ld, %ld, %i, %lu)") %
+        getPlayerID() % mappedType % static_cast<int>(af->level) %
+        af->duration % af->renew % mappedModifier % af->modifier2 %
+        mapApplyToFile(af->location) % af->bitvector)
+        .str();
+    db.query(query.c_str());
+  }
+}
+
+bool TPerson::loadAffectsFromDB() {
+  TDatabase db(DB_SNEEZY);
+  db.query(
+    "SELECT type, level, duration, renew, modifier, modifier2, "
+    "location, bitvector FROM player_affect WHERE player_id = %i",
+    getPlayerID());
+
+  bool found = false;
+  while (db.fetchRow()) {
+    found = true;
+    saveAffectedData af;
+    af.type = convertTo<short>(db["type"]);
+    af.level = convertTo<int>(db["level"]);
+    af.duration = convertTo<int>(db["duration"]);
+    af.renew = convertTo<int>(db["renew"]);
+    af.modifier = convertTo<long>(db["modifier"]);
+    af.modifier2 = convertTo<long>(db["modifier2"]);
+    af.location = convertTo<int>(db["location"]);
+    af.bitvector = convertTo<uint64_t>(db["bitvector"]);
+    rentAffectTo(&af);
+  }
+
+  return found;
 }
 
 void TBeing::convertAbilities() {}
@@ -1031,6 +1093,9 @@ void TBeing::saveChar(int load_room) {
     vlogf(LOG_BUG, format("link failed in saveChar for %s") % realName);
 
   // Call these on tmp if exists to allow full saving of shapeshifted chars
+  if (auto* person = dynamic_cast<TPerson*>(tmp ? tmp : this))
+    person->saveAffectsToDB();
+
   if (tmp) {
     // save mobile followers
     tmp->saveFollowers(

--- a/code/code/sys/migrations.cc
+++ b/code/code/sys/migrations.cc
@@ -333,6 +333,23 @@ void runMigrations() {
         sneezy.query("ALTER TABLE shopownedrepair ADD FOREIGN KEY (shop_nr) "
                      "REFERENCES shopowned (shop_nr) ON DELETE CASCADE"));
     },
+    [&]() {
+      vlogf(LOG_MISC, "Creating player_affect table");
+      assert(sneezy.query(
+        "CREATE TABLE IF NOT EXISTS player_affect ("
+        "id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, "
+        "player_id BIGINT UNSIGNED NOT null, "
+        "type SMALLINT NOT null, "
+        "level TINYINT NOT null, "
+        "duration INT NOT null, "
+        "renew INT NOT null, "
+        "modifier BIGINT NOT null, "
+        "modifier2 BIGINT NOT null, "
+        "location TINYINT UNSIGNED NOT null, "
+        "bitvector BIGINT UNSIGNED NOT null, "
+        "CONSTRAINT fk_player_affect_player "
+        "FOREIGN KEY (player_id) REFERENCES player(id) ON DELETE CASCADE)"));
+    },
   };
 
   int oldVersion = getVersion(sneezy);

--- a/lib/txt/news.d/2026-03-14-spell-affect-persistence
+++ b/lib/txt/news.d/2026-03-14-spell-affect-persistence
@@ -1,0 +1,4 @@
+Previously, if you had too many enchantments active at once, some could be
+mysteriously forgotten when renting in. This should
+no longer happen. All of your active spells and effects will now
+be properly preserved no matter how many you have.


### PR DESCRIPTION
## Summary

- Moves character affect storage (buffs/debuffs/spells) from the fixed-size `charFile` array (`MAX_AFFECT=25`) to a new `player_affect` database table, removing the cap that caused silent affect loss on rent
- Adds DB migration, seed file, save/load paths, and a news entry

## Design decisions

- **File-mapped values in DB**: Affects are stored using the same `mapSpellnumToFile`/`mapApplyToFile` encoding as the charfile and `rent_obj_aff` table, maintaining consistency with existing serialization conventions
- **DELETE + INSERT on save**: Simpler than upserts, matches the rent pattern. Affects are a small set per character
- **DB-first load with charfile fallback**: On load, `player_affect` rows are checked first. If none exist, the charfile array is used. This handles characters who haven't saved since the migration without requiring a batch data migration
- **Charfile still written**: `storeToSt()` continues populating `chFile.affected[]` (capped at 25), so rolling back this change doesn't lose data for characters with ≤25 affects
- **No change to `MAX_AFFECT` or `charFile` struct**: The binary struct is untouched. The DB path simply has no cap
- **Skip unmappable affects**: Affects like `SKILL_CONS_GIANT` that have no file mapping are skipped during DB save rather than logging bogus-value warnings. These are runtime-only markers that don't need persistence
- **64-bit bitvector preservation**: The INSERT query is built via `boost::format` to preserve full `uint64_t` bitvector values, since `TDatabase`'s `%i` format truncates to `int` via `va_arg`. Some `AFF_*` flags (e.g. `AFF_FLIGHTWORTHY`, `AFF_FOCUS_ATTACK`) exceed 32 bits

## Test plan

- [x] Build succeeds (`make -C ../../ dev-rebuild`)
- [x] Migration runs on startup — check logs for "Creating player_affect table"
- [x] `DESCRIBE player_affect` in MariaDB shows expected schema
- [x] Log in an existing character — affects load from charfile (fallback path, no DB rows yet)
- [x] Cast buffs on a character, then rent out
- [x] `SELECT * FROM player_affect WHERE player_id = <id>` shows rows in the DB
- [x] Rent back in — verify all buffs are present (loaded from DB this time)
- [x] Rent out and back in again — affects persist correctly across multiple cycles
- [x] New character with no affects — loads cleanly, no errors
- [x] No `Bogus value` or `OUT OF STORE ROOM` warnings in logs during normal play

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Character spell effects and enchantments are now persisted to the database, so active affects survive renting, logging off, and server restarts.

* **Bug Fixes**
  * Resolved loss of active spells/buffs when loading characters with many effects.

* **Documentation**
  * Added a news entry announcing reliable persistence of spell affects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->