### PR TITLE
update Telekinesis to give it parity with weapon retention

### DIFF
--- a/code/code/misc/crit_combat.cc
+++ b/code/code/misc/crit_combat.cc
@@ -183,7 +183,13 @@ int TBeing::critFailureChance(TBeing* v, TThing* weap, spellNumT w_type) {
             act(
               "Your grasp on $p loosens, but you shift position for a firmer "
               "grip.",
-              FALSE, this, weapon, NULL, TO_CHAR);
+              false, this, weapon, nullptr, TO_CHAR);
+          } else if (doesKnowSkill(SKILL_TELEKINESIS) &&
+                     bSuccess(SKILL_TELEKINESIS)) {
+            act(
+              "Your grasp on $p loosens, but you catch it with the power of "
+              "your mind!",
+              false, this, weapon, nullptr, TO_CHAR);
           } else if ((::number(0, agi) < (30 + getCond(DRUNK))) &&
                      weapon->canDrop()) {
             sprintf(buf,
@@ -214,7 +220,13 @@ int TBeing::critFailureChance(TBeing* v, TThing* weap, spellNumT w_type) {
             act(
               "Your grasp on $p loosens, but you shift position for a firmer "
               "grip.",
-              FALSE, this, weapon, NULL, TO_CHAR);
+              false, this, weapon, nullptr, TO_CHAR);
+          } else if (doesKnowSkill(SKILL_TELEKINESIS) &&
+                     bSuccess(SKILL_TELEKINESIS)) {
+            act(
+              "Your grasp on $p loosens, but you catch it with the power of "
+              "your mind!",
+              false, this, weapon, nullptr, TO_CHAR);
           } else {
             sprintf(buf,
               "You %slose%s your grip on $p and it %sfalls out of your "

--- a/lib/txt/news.d/2026-03-16-telekinesis-crit-fumble
+++ b/lib/txt/news.d/2026-03-16-telekinesis-crit-fumble
@@ -1,0 +1,3 @@
+Telekinesis now protects against dropping your weapon on a critical
+fumble, just like weapon retention does. Previously it only worked
+against disarm.


### PR DESCRIPTION
Small fix for telekinesis to give it parity with weapon retention



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telekinesis now prevents weapon drops during critical fumbles, expanding its protective capabilities beyond disarm effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->