### PR TITLE
Fix division by zero in expectedPracs() for high-XP players

### DIFF
--- a/code/code/misc/limits.cc
+++ b/code/code/misc/limits.cc
@@ -756,12 +756,15 @@ void TPerson::fixPracs() {
   if (isImmortal())
     return;
 
-  for (i = 1; i < 127; i++) {
+  for (i = 1; i <= 127; i++) {
     if (getExpClassLevel(i) > getMaxExp()) {
       level = i - 1;
       break;
     }
   }
+  // exp exceeds all levels up to 127, cap at 127
+  if (!level)
+    level = 127;
 
   for (Class = MIN_CLASS_IND; Class < MAX_CLASSES; Class++) {
     if (hasClass(1 << Class))
@@ -862,17 +865,21 @@ short TBeing::expectedPracs() {
     if (!hasClass(1 << Class))
       continue;
     // find level based on experience
-    for (i = 1; i < 127; i++) {
+    for (i = 1; i <= 127; i++) {
       if (getExpClassLevel(i) > getMaxExp()) {
         level = i - 1;
         break;
       }
     }
-    if (!level)
-      vlogf(LOG_BUG, "Level exceeded 127 in expectedPracs.");
-    lvlStart = getExpClassLevel(level);
-    lvlEnd = getExpClassLevel(level + 1);
-    fraction = (getMaxExp() - lvlStart) / (lvlEnd - lvlStart);
+    if (!level) {
+      // exp exceeds all levels up to 127, cap at 127 with full fraction
+      level = 127;
+      fraction = 1.0;
+    } else {
+      lvlStart = getExpClassLevel(level);
+      lvlEnd = getExpClassLevel(level + 1);
+      fraction = (getMaxExp() - lvlStart) / (lvlEnd - lvlStart);
+    }
     double advancedlevel = 30.0 / getIntModForPracs();
     /*
        vlogf(LOG_MAROR, format("level is %d, exp is %f, fraction is %f,


### PR DESCRIPTION
## Summary

Fixes #677 — `TBeing::expectedPracs()` and `TPerson::fixPracs()` trigger undefined behavior (division by zero, inf-to-short cast) when a player's XP exceeds the level range searched by the virtual level loop.

## Root Cause

Both functions search for a "virtual level" matching the player's XP by iterating levels 1–126. When a player has enough XP to exceed all 126 levels (e.g. Jabroni with ~10 trillion XP), the loop exits without `break`ing and `level` remains `0`. This causes:

1. `getExpClassLevel(0)` and `getExpClassLevel(1)` both return `0`, so `lvlEnd - lvlStart = 0` → **division by zero**
2. The resulting `inf` propagates through the pracs accumulation and is cast to `short` → **undefined behavior**

## Fix

Rather than raising the loop bound arbitrarily (which just kicks the can down the road), we:

1. Extended the loop to check through level 127 (`i <= 127`), since 127 is the absolute max level for any being in the game (including mobs)
2. Added a fallthrough guard: if XP exceeds even level 127, cap the virtual level at 127 instead of leaving it at 0
3. In `expectedPracs()`, when capped, set `fraction = 1.0` (fully completed level) to avoid the division entirely

This matches the original intent of the code — the 127 bound was always meant as a cap, it just didn't handle the case where a player's XP actually exceeded it.

## Testing Checklist

- [x] Set a test character's XP to a very large value (e.g. `set <char> exp 10000000000000`)
- [x] Log the character out (rent) and back in — verify no UB sanitizer warnings in logs
- [x] Run `pracinfo <char>` as an immortal — verify it returns a sane value
- [x] Set XP to a value just under `getExpClassLevel(127)` — verify normal level resolution works
- [x] Set XP to a value just over `getExpClassLevel(127)` — verify the cap path is hit cleanly
- [x] Verify normal players (XP well within range) are unaffected by logging in/out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed level progression and experience boundary handling to properly support maximum level advancement. The experience system now correctly computes practice point allocation across all experience tiers, including the highest levels, ensuring consistent results without edge-case errors or unexpected fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->