### PR TITLE
Refactor body-hits-ground chain; add knockOffMount and getRideMod

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -323,15 +323,10 @@ int TBeing::bashFail(TBeing* victim, spellNumT skill,
   }
 
   if (hasLegs()) {
-    int rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
-
-    sendTo(format("%sYou fall over.%s\n\r") % red() % norm());
-    act("$n falls over.", TRUE, this, 0, 0, TO_ROOM);
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -322,11 +322,9 @@ int TBeing::bashFail(TBeing* victim, spellNumT skill,
       victim, TO_VICT);
   }
 
-  if (hasLegs()) {
-    int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
-      return rc;
-  }
+  int rc = stumble(victim);
+  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
 
   reconcileDamage(victim, 0, skill);
   return FALSE;
@@ -355,14 +353,14 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   // Determine which limb gets hit - same logic for all damage types
   wearSlotT limb = WEAR_BODY;
   if (!this->isTanking()) {
-    limb = WEAR_BACK; 
+    limb = WEAR_BACK;
   }
   if (victim->isAgile(0)){
     limb = WEAR_ARM_R;
     if (percentChance(50)){
       limb = WEAR_ARM_L;
     }
-    
+
     if ((victim->getHeight()*2/3) > this->getHeight()) {
       limb = WEAR_LEG_R;
       if (percentChance(50)){

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -334,17 +334,10 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   TObj* itemInSecondaryHand) {
   const bool wasMounted = (victim->riding != nullptr);
 
-  if (wasMounted) {
-    act("You bash $N off $p!", false, this, victim->riding, victim, TO_CHAR);
-    act("$n bashes $N off $p!", false, this, victim->riding, victim,
-      TO_NOTVICT);
-    act("$n bashes you off $p!", false, this, victim->riding, victim, TO_VICT);
-  } else {
-    act("$n knocks $N on $S butt!", FALSE, this, 0, victim, TO_NOTVICT);
-    act("You send $N sprawling.", FALSE, this, 0, victim, TO_CHAR);
-    act("You tumble as $n knocks you over", FALSE, this, 0, victim, TO_VICT,
-      ANSI_BLUE);
-  }
+  // Describe the impact only — crashLanding/knockOffMount narrates the result.
+  act("You crash into $N!", false, this, nullptr, victim, TO_CHAR);
+  act("$n crashes into you!", false, this, nullptr, victim, TO_VICT, ANSI_BLUE);
+  act("$n crashes into $N!", false, this, nullptr, victim, TO_NOTVICT);
 
   int shieldDam =
     getSkillDam(victim, skill, getSkillLevel(skill), getAdvLearning(skill));

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -322,8 +322,8 @@ int TBeing::bashFail(TBeing* victim, spellNumT skill,
       victim, TO_VICT);
   }
 
-  int rc = stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  int rc = stumble();
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return rc;
 
   reconcileDamage(victim, 0, skill);
@@ -332,12 +332,13 @@ int TBeing::bashFail(TBeing* victim, spellNumT skill,
 
 int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   TObj* itemInSecondaryHand) {
-  if (victim->riding) {
-    act("You knock $N off $p.", FALSE, this, victim->riding, victim, TO_CHAR);
-    act("$n knocks $N off $p.", FALSE, this, victim->riding, victim,
+  const bool wasMounted = (victim->riding != nullptr);
+
+  if (wasMounted) {
+    act("You bash $N off $p!", false, this, victim->riding, victim, TO_CHAR);
+    act("$n bashes $N off $p!", false, this, victim->riding, victim,
       TO_NOTVICT);
-    act("$n knocks you off $p.", FALSE, this, victim->riding, victim, TO_VICT);
-    victim->dismount(POSITION_SITTING);
+    act("$n bashes you off $p!", false, this, victim->riding, victim, TO_VICT);
   } else {
     act("$n knocks $N on $S butt!", FALSE, this, 0, victim, TO_NOTVICT);
     act("You send $N sprawling.", FALSE, this, 0, victim, TO_CHAR);
@@ -355,20 +356,20 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   if (!this->isTanking()) {
     limb = WEAR_BACK;
   }
-  if (victim->isAgile(0)){
+  if (victim->isAgile(0)) {
     limb = WEAR_ARM_R;
-    if (percentChance(50)){
+    if (percentChance(50)) {
       limb = WEAR_ARM_L;
     }
 
-    if ((victim->getHeight()*2/3) > this->getHeight()) {
+    if ((victim->getHeight() * 2 / 3) > this->getHeight()) {
       limb = WEAR_LEG_R;
-      if (percentChance(50)){
+      if (percentChance(50)) {
         limb = WEAR_LEG_L;
       }
     }
   }
-  if (this->getHeight() > (3*victim->getHeight()/2)){
+  if (this->getHeight() > (3 * victim->getHeight() / 2)) {
     limb = WEAR_HEAD;
   }
 
@@ -389,17 +390,9 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   if (isLucky(levelLuckModifier(victim->GetMaxLevel())))
     distractionBonus++;
 
-  int rc = victim->crashLanding(POSITION_SITTING);
+  int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
-
-  rc = victim->trySpringleap(this);
-  if (IS_SET_DELETE(rc, DELETE_THIS) && IS_SET_DELETE(rc, DELETE_VICT))
-    return rc;
-  else if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_VICT;
-  else if (IS_SET_DELETE(rc, DELETE_VICT))
-    return DELETE_THIS;
 
   // see balance notes for bash:
   // the effect here should be strictly to prevent skill-use

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -383,7 +383,8 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   if (isLucky(levelLuckModifier(victim->GetMaxLevel())))
     distractionBonus++;
 
-  int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
+  int rc = wasMounted ? victim->knockOffMount(getSkillValue(skill) / 5)
+                      : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
 

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -324,9 +324,7 @@ int TBeing::bashFail(TBeing* victim, spellNumT skill,
 
   if (hasLegs()) {
     int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -112,11 +112,11 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
-    act("$n tries to bodyslam $N but can't get a grip.", false, this, 0, victim,
+    act("$n tries to bodyslam $N but loses $s footing.", false, this, 0, victim,
       TO_NOTVICT);
-    act("You try to bodyslam $N but can't get a grip.", false, this, 0, victim,
+    act("You try to bodyslam $N but lose your footing.", false, this, 0, victim,
       TO_CHAR);
-    act("$n tries to bodyslam you but can't get a grip.", false, this, 0,
+    act("$n tries to bodyslam you but loses $s footing.", false, this, 0,
       victim, TO_VICT);
 
     int rc = stumble(victim);

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -133,22 +133,27 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
 int TBeing::bodyslamHit(TBeing* victim) {
   const bool wasMounted = (victim->riding != nullptr);
 
+  // Setup: the lift attempt. Then a payoff line that varies by mount status.
+  // crashLanding/knockOffMount narrates the impact result afterward.
+  act("You grab $N around the middle, attempting to lift $M overhead!", false,
+    this, nullptr, victim, TO_CHAR);
+  act("$n grabs you around the middle, attempting to lift you overhead!", false,
+    this, nullptr, victim, TO_VICT, ANSI_RED);
+  act("$n grabs $N around the middle, attempting to lift $M overhead!", false,
+    this, nullptr, victim, TO_NOTVICT);
+
   if (wasMounted) {
-    act("You lift $N off $p and slam $M to the $g!", false, this,
-      victim->riding, victim, TO_CHAR);
-    act("$n lifts $N off $p and slams $M to the $g!", false, this,
-      victim->riding, victim, TO_NOTVICT);
-    act("$n lifts you off $p and slams you to the $g!", false, this,
-      victim->riding, victim, TO_VICT);
-  } else {
-    act("$n lifts $N over $s head and slams $M to the $g.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You lift $N over your head and slam $M to the $g.", FALSE, this, 0,
+    act("You pull $N from $p, throwing $M down!", false, this, victim->riding,
       victim, TO_CHAR);
-    act("You get a great view as $n lifts you over $s head.", FALSE, this, 0,
-      victim, TO_VICT);
-    act("Suddenly, the $g rushes upward and knocks the wind out of you!", FALSE,
-      this, 0, victim, TO_VICT, ANSI_RED);
+    act("$n pulls you from $p, throwing you down!", false, this, victim->riding,
+      victim, TO_VICT, ANSI_RED);
+    act("$n pulls $N from $p, throwing $M down!", false, this, victim->riding,
+      victim, TO_NOTVICT);
+  } else {
+    act("You throw $N down hard!", false, this, nullptr, victim, TO_CHAR);
+    act("$n throws you down hard!", false, this, nullptr, victim, TO_VICT,
+      ANSI_RED);
+    act("$n throws $N down hard!", false, this, nullptr, victim, TO_NOTVICT);
   }
 
   int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -82,8 +82,6 @@ bool TBeing::canBodyslam(TBeing* victim, silentTypeT silent) {
 }
 
 int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
-  int rc;
-
   if (type == TYPE_DEX) {
     act("$N deftly avoids your bodyslam attempt.", FALSE, this, 0, victim,
       TO_CHAR);
@@ -99,45 +97,29 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     act("$N deftly counters $n's bodyslam attempt, and heaves $m to the $g.",
       FALSE, this, 0, victim, TO_NOTVICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else if (type == TYPE_STR) {
-    act("$n collapses as $e fails to pick $N up.", FALSE, this, 0, victim,
+    act("$n tries to bodyslam $N but fails to lift $M.", false, this, 0, victim,
       TO_NOTVICT);
-    act("Your strength gives out as you try to pick $N up for bodyslamming.",
-      FALSE, this, 0, victim, TO_CHAR);
-    act("$n's strength gives out as $e tries to pick you up for bodyslamming.",
-      FALSE, this, 0, victim, TO_VICT);
-
-    rc = crashLanding(POSITION_SITTING);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    sendTo(format("%sYou fall to the %s.%s\n\r") % blue() %
-           roomp->describeGround() % norm());
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
-      return rc;
-  } else {
-    act("$n tries to bodyslam $N, but ends up falling down.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You try to bodyslam $N, but end up falling on your face.", FALSE, this,
-      0, victim, TO_CHAR);
-    act("$n fails to bodyslam you, and tumbles to the $g.", FALSE, this, 0,
+    act("You try to bodyslam $N but fail to lift $M.", false, this, 0, victim,
+      TO_CHAR);
+    act("$n tries to bodyslam you but fails to lift you.", false, this, 0,
       victim, TO_VICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  } else {
+    int rc = stumble(victim);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -90,12 +90,12 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     act("$N deftly avoids $n's bodyslam attempt.", FALSE, this, 0, victim,
       TO_NOTVICT);
   } else if (type == TYPE_MONK) {
-    act("$N deftly counters your attempt, throwing you to the $g.", FALSE, this,
-      0, victim, TO_CHAR, ANSI_RED);
-    act("You deftly counter $n's bodyslam attempt, and throw $m to the $g.",
-      FALSE, this, 0, victim, TO_VICT);
-    act("$N deftly counters $n's bodyslam attempt, and heaves $m to the $g.",
-      FALSE, this, 0, victim, TO_NOTVICT);
+    act("$N deftly counters your bodyslam, and throws you to the side.", false,
+      this, 0, victim, TO_CHAR, ANSI_RED);
+    act("You deftly counter $n's bodyslam, and throw $m to the side.", false,
+      this, 0, victim, TO_VICT);
+    act("$N deftly counters $n's bodyslam, and throws $m to the side.", false,
+      this, 0, victim, TO_NOTVICT);
 
     int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -142,23 +142,32 @@ int TBeing::bodyslamHit(TBeing* victim) {
   act("$n grabs $N around the middle, attempting to lift $M overhead!", false,
     this, nullptr, victim, TO_NOTVICT);
 
+  int rc;
   if (wasMounted) {
-    act("You pull $N from $p, throwing $M down!", false, this, victim->riding,
-      victim, TO_CHAR);
-    act("$n pulls you from $p, throwing you down!", false, this, victim->riding,
-      victim, TO_VICT, ANSI_RED);
-    act("$n pulls $N from $p, throwing $M down!", false, this, victim->riding,
-      victim, TO_NOTVICT);
+    TThing* mount =
+      victim->riding;  // capture before knockOffMount may dismount
+    rc = victim->knockOffMount(getSkillValue(SKILL_BODYSLAM) / 2);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_VICT;
+    // Only narrate the throw when the rider was actually dismounted; if they
+    // hung on, knockOffMount printed its own "hangs on tight" flavor.
+    if (!victim->riding) {
+      act("You pull $N from $p, throwing $M down!", false, this, mount, victim,
+        TO_CHAR);
+      act("$n pulls you from $p, throwing you down!", false, this, mount,
+        victim, TO_VICT, ANSI_RED);
+      act("$n pulls $N from $p, throwing $M down!", false, this, mount, victim,
+        TO_NOTVICT);
+    }
   } else {
     act("You throw $N down hard!", false, this, nullptr, victim, TO_CHAR);
     act("$n throws you down hard!", false, this, nullptr, victim, TO_VICT,
       ANSI_RED);
     act("$n throws $N down hard!", false, this, nullptr, victim, TO_NOTVICT);
+    rc = victim->crashLanding();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_VICT;
   }
-
-  int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_VICT;
 
   // see the balance notes for details on what's going on here.
   float wt = combatRound(discArray[SKILL_BODYSLAM]->lag);

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -98,9 +98,7 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
       FALSE, this, 0, victim, TO_NOTVICT);
 
     int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else if (type == TYPE_STR) {
     act("$n tries to bodyslam $N but fails to lift $M.", false, this, 0, victim,
@@ -111,15 +109,18 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
       victim, TO_VICT);
 
     int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
+    act("$n tries to bodyslam $N but can't get a grip.", false, this, 0, victim,
+      TO_NOTVICT);
+    act("You try to bodyslam $N but can't get a grip.", false, this, 0, victim,
+      TO_CHAR);
+    act("$n tries to bodyslam you but can't get a grip.", false, this, 0,
+      victim, TO_VICT);
+
     int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_bodyslam.cc
+++ b/code/code/cmd/cmd_bodyslam.cc
@@ -97,8 +97,8 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     act("$N deftly counters $n's bodyslam, and throws $m to the side.", false,
       this, 0, victim, TO_NOTVICT);
 
-    int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    int rc = stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
   } else if (type == TYPE_STR) {
     act("$n tries to bodyslam $N but fails to lift $M.", false, this, 0, victim,
@@ -108,8 +108,8 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     act("$n tries to bodyslam you but fails to lift you.", false, this, 0,
       victim, TO_VICT);
 
-    int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    int rc = stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
   } else {
     act("$n tries to bodyslam $N but loses $s footing.", false, this, 0, victim,
@@ -119,8 +119,8 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
     act("$n tries to bodyslam you but loses $s footing.", false, this, 0,
       victim, TO_VICT);
 
-    int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    int rc = stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
   }
 
@@ -131,9 +131,16 @@ int TBeing::bodyslamMiss(TBeing* victim, skillMissT type) {
 }
 
 int TBeing::bodyslamHit(TBeing* victim) {
-  int rc;
+  const bool wasMounted = (victim->riding != nullptr);
 
-  if (!victim->riding) {
+  if (wasMounted) {
+    act("You lift $N off $p and slam $M to the $g!", false, this,
+      victim->riding, victim, TO_CHAR);
+    act("$n lifts $N off $p and slams $M to the $g!", false, this,
+      victim->riding, victim, TO_NOTVICT);
+    act("$n lifts you off $p and slams you to the $g!", false, this,
+      victim->riding, victim, TO_VICT);
+  } else {
     act("$n lifts $N over $s head and slams $M to the $g.", FALSE, this, 0,
       victim, TO_NOTVICT);
     act("You lift $N over your head and slam $M to the $g.", FALSE, this, 0,
@@ -142,29 +149,11 @@ int TBeing::bodyslamHit(TBeing* victim) {
       victim, TO_VICT);
     act("Suddenly, the $g rushes upward and knocks the wind out of you!", FALSE,
       this, 0, victim, TO_VICT, ANSI_RED);
-  } else {
-    act("$n lifts $N off $S $o and slams $M to the $g.", FALSE, this,
-      victim->riding, victim, TO_NOTVICT);
-    act("You lift $N off $S $o and slam $M to the $g.", FALSE, this,
-      victim->riding, victim, TO_CHAR);
-    act("You get a great view as $n lifts you off your $o over $s head.", FALSE,
-      this, victim->riding, victim, TO_VICT);
-    act("Suddenly, the $g rushes upward and knocks the wind out of you!", FALSE,
-      this, victim->riding, victim, TO_VICT, ANSI_RED);
-    victim->dismount(POSITION_RESTING);
   }
 
-  rc = victim->crashLanding(POSITION_SITTING);
+  int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
-
-  rc = victim->trySpringleap(this);
-  if (IS_SET_DELETE(rc, DELETE_THIS) && IS_SET_DELETE(rc, DELETE_VICT))
-    return rc;
-  else if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_VICT;
-  else if (IS_SET_DELETE(rc, DELETE_VICT))
-    return DELETE_THIS;
 
   // see the balance notes for details on what's going on here.
   float wt = combatRound(discArray[SKILL_BODYSLAM]->lag);

--- a/code/code/cmd/cmd_doorbash.cc
+++ b/code/code/cmd/cmd_doorbash.cc
@@ -25,7 +25,20 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
   sendTo("OUCH!  That REALLY Hurt!\n\r");
   sprintf(buf, "$n crashes against the %s with no effect.\n\r", doorname);
   act(buf, FALSE, this, 0, 0, TO_ROOM);
-  if (reconcileDamage(this, (::number(1, 10) * 2), DAMAGE_COLLISION) == -1)
+  TBeing* fightTarget = fight();
+  int rc = stumble(fightTarget);
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    return DELETE_THIS;
+  if (IS_SET_DELETE(rc, DELETE_VICT)) {
+    delete fightTarget;
+    fightTarget = nullptr;
+  }
+
+  int dam = ::number(1, 10) * 2;
+  if (isBrawny())
+    dam /= 2;
+  addToWait(combatRound(dam));
+  if (reconcileDamage(this, dam, DAMAGE_COLLISION) == -1)
     return DELETE_THIS;
 
   if (!isImmortal()) {
@@ -36,15 +49,6 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
     aff.bitvector = AFF_STUNNED;
     affectTo(&aff, -1);
   }
-
-#if 0
-  addToWait(combatRound(12));
-#else
-  int rc;
-  rc = crashLanding(POSITION_RESTING);
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-#endif
 
   return TRUE;
 }

--- a/code/code/cmd/cmd_doorbash.cc
+++ b/code/code/cmd/cmd_doorbash.cc
@@ -25,15 +25,7 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
   sendTo("OUCH!  That REALLY Hurt!\n\r");
   sprintf(buf, "$n crashes against the %s with no effect.\n\r", doorname);
   act(buf, FALSE, this, 0, 0, TO_ROOM);
-  int rc = crashLanding(POSITION_SITTING);
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-
-  int dam = ::number(1, 10) * 2;
-  if (isBrawny())
-    dam /= 2;
-  addSkillLag(SKILL_DOORBASH, 0);
-  if (reconcileDamage(this, dam, DAMAGE_COLLISION) == -1)
+  if (reconcileDamage(this, (::number(1, 10) * 2), DAMAGE_COLLISION) == -1)
     return DELETE_THIS;
 
   if (!isImmortal()) {
@@ -44,6 +36,15 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
     aff.bitvector = AFF_STUNNED;
     affectTo(&aff, -1);
   }
+
+#if 0
+  addToWait(combatRound(12));
+#else
+  int rc;
+  rc = crashLanding(POSITION_RESTING);
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    return DELETE_THIS;
+#endif
 
   return TRUE;
 }

--- a/code/code/cmd/cmd_doorbash.cc
+++ b/code/code/cmd/cmd_doorbash.cc
@@ -25,19 +25,14 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
   sendTo("OUCH!  That REALLY Hurt!\n\r");
   sprintf(buf, "$n crashes against the %s with no effect.\n\r", doorname);
   act(buf, FALSE, this, 0, 0, TO_ROOM);
-  TBeing* fightTarget = fight();
-  int rc = stumble(fightTarget);
+  int rc = crashLanding(POSITION_SITTING);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-  if (IS_SET_DELETE(rc, DELETE_VICT)) {
-    delete fightTarget;
-    fightTarget = nullptr;
-  }
 
   int dam = ::number(1, 10) * 2;
   if (isBrawny())
     dam /= 2;
-  addToWait(combatRound(dam));
+  addSkillLag(SKILL_DOORBASH, 0);
   if (reconcileDamage(this, dam, DAMAGE_COLLISION) == -1)
     return DELETE_THIS;
 

--- a/code/code/cmd/cmd_doorbash.cc
+++ b/code/code/cmd/cmd_doorbash.cc
@@ -41,7 +41,7 @@ int TBeing::slamIntoWall(roomDirData* exitp) {
   addToWait(combatRound(12));
 #else
   int rc;
-  rc = crashLanding(POSITION_RESTING);
+  rc = crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
 #endif

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -75,12 +75,12 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
       !victim->awake()) {
     if (victim->canCounterMove(bKnown / 2)) {
       SV(skill);
-      act("$N blocks your grapple attempt and knocks you to the $g.", TRUE, c,
-        0, victim, TO_CHAR, ANSI_RED);
-      act("$N blocks $n's attempt to grapple, and knocks $m to the $g.", TRUE,
+      act("$N blocks your grapple attempt and knocks you off balance.", true,
+        c, 0, victim, TO_CHAR, ANSI_RED);
+      act("$N blocks $n's attempt to grapple, and knocks $m off balance.", true,
         c, 0, victim, TO_NOTVICT);
-      act("You evade $n's attempt to grapple, and knock $m to the $g.", TRUE, c,
-        0, victim, TO_VICT);
+      act("You evade $n's attempt to grapple, and knock $m off balance.", true,
+        c, 0, victim, TO_VICT);
       c->cantHit += c->loseRound(5 - (min(50, level) / 12));
 
       rc = c->stumble(victim);

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -186,14 +186,16 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
     c->cantHit += c->loseRound(5 - (min(level, 50) / 12));
     c->addToWait(combatRound(1));
 
+    act("You try to wrestle $N to the $g, but lose your hold.", true, c, 0,
+      victim, TO_CHAR);
+    act("$n tries to wrestle $N to the $g, but loses $s hold.", true, c, 0,
+      victim, TO_NOTVICT);
+    act("$n tries to wrestle you to the $g, but loses $s hold.", true, c, 0,
+      victim, TO_VICT);
+
     rc = c->stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
-
-    act("You try to wrestle $N to the $g, but end up falling on your butt.",
-      TRUE, c, 0, victim, TO_CHAR);
-    act("$n makes a nice wrestling move, but falls on $s butt.", TRUE, c, 0, 0,
-      TO_ROOM);
 
     if (!victim->fight()) {
       act("$N turns $S attention to $n", TRUE, c, 0, victim, TO_NOTVICT);

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -98,7 +98,7 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
       act("You evade $n's attempt to grapple.", TRUE, c, 0, victim, TO_VICT);
     } else {
       if (victim->riding) {
-        int kr = victim->knockOffMount();
+        int kr = victim->knockOffMount(c->getSkillValue(skill) / 4);
         if (IS_SET_DELETE(kr, DELETE_THIS))
           return DELETE_VICT;
         if (victim->riding) {

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -83,12 +83,7 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
         0, victim, TO_VICT);
       c->cantHit += c->loseRound(5 - (min(50, level) / 12));
 
-      rc = c->crashLanding(POSITION_SITTING);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return rc;
-
-      rc = c->trySpringleap(victim);
-      
+      rc = c->stumble(victim);
       if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
         return rc;
     } else if (victim->canFocusedAvoidance(bKnown / 2)) {
@@ -191,11 +186,7 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
     c->cantHit += c->loseRound(5 - (min(level, 50) / 12));
     c->addToWait(combatRound(1));
 
-    rc = c->crashLanding(POSITION_SITTING);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = c->trySpringleap(victim);
+    rc = c->stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
 

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -44,7 +44,9 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
     return FALSE;
   }
   if (victim->isFlying() && !c->isFlying()) {
-    c->sendTo("You can't grapple someone that is flying, unless you are also flying.\n\r");
+    c->sendTo(
+      "You can't grapple someone that is flying, unless you are also "
+      "flying.\n\r");
     return FALSE;
   }
 
@@ -69,22 +71,24 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
 
   if ((c->bSuccess(bKnown + percent, skill) &&
         // insure they can hit this critter
-        (i = c->specialAttack(victim, skill, 0, STAT_STR, STAT_DEX, STAT_BRA, STAT_AGI, false)) && i != GUARANTEED_FAILURE &&
+        (i = c->specialAttack(victim, skill, 0, STAT_STR, STAT_DEX, STAT_BRA,
+           STAT_AGI, false)) &&
+        i != GUARANTEED_FAILURE &&
         // make sure they have reasonable training
         (percent < bKnown)) ||
       !victim->awake()) {
     if (victim->canCounterMove(bKnown / 2)) {
       SV(skill);
-      act("$N blocks your grapple attempt and knocks you off balance.", true,
-        c, 0, victim, TO_CHAR, ANSI_RED);
+      act("$N blocks your grapple attempt and knocks you off balance.", true, c,
+        0, victim, TO_CHAR, ANSI_RED);
       act("$N blocks $n's attempt to grapple, and knocks $m off balance.", true,
         c, 0, victim, TO_NOTVICT);
       act("You evade $n's attempt to grapple, and knock $m off balance.", true,
         c, 0, victim, TO_VICT);
       c->cantHit += c->loseRound(5 - (min(50, level) / 12));
 
-      rc = c->stumble(victim);
-      if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      rc = c->stumble();
+      if (IS_SET_DELETE(rc, DELETE_THIS))
         return rc;
     } else if (victim->canFocusedAvoidance(bKnown / 2)) {
       SV(skill);
@@ -94,11 +98,20 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
       act("You evade $n's attempt to grapple.", TRUE, c, 0, victim, TO_VICT);
     } else {
       if (victim->riding) {
-        act("You pull $N off $p.", FALSE, c, victim->riding, victim, TO_CHAR);
-        act("$n pulls $N off $p.", FALSE, c, victim->riding, victim,
-          TO_NOTVICT);
-        act("$n pulls you off $p.", FALSE, c, victim->riding, victim, TO_VICT);
-        victim->dismount(POSITION_STANDING);
+        int kr = victim->knockOffMount();
+        if (IS_SET_DELETE(kr, DELETE_THIS))
+          return DELETE_VICT;
+        if (victim->riding) {
+          // Hung on — grapple can't wrestle a mounted target down.
+          act("Your grapple slips as $N keeps $S seat.", true, c, 0, victim,
+            TO_CHAR);
+          act("$n's grapple slips as $N keeps $S seat.", true, c, 0, victim,
+            TO_NOTVICT);
+          act("$n grapples at you but slips as you keep your seat.", true, c, 0,
+            victim, TO_VICT);
+          c->cantHit += c->loseRound(2);
+          return true;
+        }
       }
       c->sendTo("You tie your opponent up, with an excellent maneuver.\n\r");
       act("$n wrestles $N to the $g with an excellent maneuver.", TRUE, c, 0,
@@ -113,26 +126,17 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
       if (c->reconcileDamage(victim, dam, SKILL_GRAPPLE) == -1)
         return DELETE_VICT;
 
-      rc = c->crashLanding(POSITION_SITTING);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return rc;
-
-      rc = c->trySpringleap(victim);
-      if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
-        return rc;
-
-      positionTypeT pinned = victim->isAgile(0) ? POSITION_SITTING : POSITION_RESTING;
-      rc = victim->crashLanding(pinned);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_VICT;
-
-      rc = victim->trySpringleap(c);
-      if (IS_SET_DELETE(rc, DELETE_THIS) && IS_SET_DELETE(rc, DELETE_VICT))
-        return rc;
-      else if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_VICT;
-      else if (IS_SET_DELETE(rc, DELETE_VICT))
-        return DELETE_THIS;
+      // Both end up pinned on the ground. Use setPosition + pin-specific
+      // flavor instead of crashLanding so the messages match the takedown
+      // context and the auto-springleap chain doesn't fire mid-pin.
+      c->setPosition(POSITION_SITTING);
+      victim->setPosition(POSITION_RESTING);
+      act("<g>You kneel over $N, pinning $M to the $g.<1>", true, c, nullptr,
+        victim, TO_CHAR);
+      act("<r>$n kneels over you, pinning you to the $g.<1>", true, c, nullptr,
+        victim, TO_VICT);
+      act("$n kneels over $N, pinning $M to the $g.", true, c, nullptr, victim,
+        TO_NOTVICT);
 
       if (!victim->fight()) {
         if (c->fight()) {
@@ -193,8 +197,8 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
     act("$n tries to wrestle you to the $g, but loses $s hold.", true, c, 0,
       victim, TO_VICT);
 
-    rc = c->stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    rc = c->stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
 
     if (!victim->fight()) {

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -52,26 +52,23 @@ bool TBeing::canHeadbutt(TBeing* victim, const silentTypeT silent) const {
 }
 
 int TBeing::headbuttMiss(TBeing* v) {
-  int rc;
-
   if (v->doesKnowSkill(SKILL_COUNTER_MOVE) || isCombatMode(ATTACK_BERSERK)) {
     // I don't understand this logic
     act("$N deftly avoids $n's headbutt.", FALSE, this, 0, v, TO_NOTVICT);
     act("$N deftly avoids your headbutt.", FALSE, this, 0, v, TO_CHAR);
     act("You deftly avoid $n's headbutt.", FALSE, this, 0, v, TO_VICT);
   } else {
-    act("$N avoids $n's headbutt.", FALSE, this, 0, v, TO_NOTVICT);
-    act("$N moves $S head, and you fall down as you miss your headbutt.", FALSE,
-      this, 0, v, TO_CHAR);
-    act("$n tries to headbutt you, but you dodge it.", FALSE, this, 0, v,
-      TO_VICT);
+    act("$N moves $S head out of the way, causing $n to miss.", false, this, 0,
+      v, TO_NOTVICT);
+    act("$N moves $S head out of the way, causing you to miss.", false, this, 0,
+      v, TO_CHAR);
+    act("You move your head out of the way, causing $n to miss.", false, this,
+      0, v, TO_VICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(v);
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
-
-    rc = trySpringleap(v);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
   reconcileDamage(v, 0, SKILL_HEADBUTT);

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -66,9 +66,7 @@ int TBeing::headbuttMiss(TBeing* v) {
       0, v, TO_VICT);
 
     int rc = stumble(v);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
   reconcileDamage(v, 0, SKILL_HEADBUTT);

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -65,8 +65,8 @@ int TBeing::headbuttMiss(TBeing* v) {
     act("You move your head out of the way, causing $n to miss.", false, this,
       0, v, TO_VICT);
 
-    int rc = stumble(v);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    int rc = stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
   }
   reconcileDamage(v, 0, SKILL_HEADBUTT);
@@ -99,7 +99,8 @@ int TBeing::headbuttHit(TBeing* victim) {
 
     return TRUE;
   } else {
-    static constexpr const char* headbutt_msg = "%s headbutt %s, slamming %s head into %s %s.";
+    static constexpr const char* headbutt_msg =
+      "%s headbutt %s, slamming %s head into %s %s.";
 
     const char* target_area;
     bool causes_wait = false;
@@ -139,9 +140,12 @@ int TBeing::headbuttHit(TBeing* victim) {
       causes_wait = true;
     }
 
-    act(format(headbutt_msg) % "$n" % "$N" % "$s" % "$N's" % target_area, FALSE, this, 0, victim, TO_NOTVICT);
-    act(format(headbutt_msg) % "You" % "$N" % "your" % "$S" % target_area, FALSE, this, 0, victim, TO_CHAR);
-    act(format(headbutt_msg) % "$n" % "you" % "$s" % "your" % target_area, FALSE, this, 0, victim, TO_VICT);
+    act(format(headbutt_msg) % "$n" % "$N" % "$s" % "$N's" % target_area, FALSE,
+      this, 0, victim, TO_NOTVICT);
+    act(format(headbutt_msg) % "You" % "$N" % "your" % "$S" % target_area,
+      FALSE, this, 0, victim, TO_CHAR);
+    act(format(headbutt_msg) % "$n" % "you" % "$s" % "your" % target_area,
+      FALSE, this, 0, victim, TO_VICT);
 
     if (causes_wait) {
       victim->addToWait(combatRound(0.25));

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -210,7 +210,7 @@ int TBeing::doHeadbutt(const char* argument, TBeing* vict) {
   if (rc)
     addSkillLag(SKILL_HEADBUTT, rc);
 
-  if (IS_SET_ONLY(rc, DELETE_VICT)) {
+  if (IS_SET_DELETE(rc, DELETE_VICT)) {
     if (vict)
       return rc;
     delete v;

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -114,8 +114,8 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
     act("$N sticks out $S foot and trips $n, toppling $m.", false, this, 0,
       victim, TO_NOTVICT);
 
-    int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    int rc = stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
   } else {
     act("$n tries to spin $N but loses $s footing.", false, this, 0, victim,
@@ -125,8 +125,8 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
     act("$n tries to spin you but loses $s footing.", false, this, 0, victim,
       TO_VICT);
 
-    int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    int rc = stumble();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
       return rc;
   }
 
@@ -137,9 +137,16 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
 }
 
 int TBeing::spinHit(TBeing* victim) {
-  int rc;
+  const bool wasMounted = (victim->riding != nullptr);
 
-  if (!victim->riding) {
+  if (wasMounted) {
+    act("You grab $N's arm and rip $M off $p!", false, this, victim->riding,
+      victim, TO_CHAR);
+    act("$n grabs $N's arm and rips $M off $p!", false, this, victim->riding,
+      victim, TO_NOTVICT);
+    act("$n grabs your arm and rips you off $p!", false, this, victim->riding,
+      victim, TO_VICT);
+  } else {
     act("$n grabs $N's arm and spins $M!", FALSE, this, 0, victim, TO_NOTVICT);
     act("Now dizzy, $N trips and falls to the $g.", FALSE, this, 0, victim,
       TO_NOTVICT);
@@ -152,35 +159,11 @@ int TBeing::spinHit(TBeing* victim) {
       "As the world spins into a blur before your eyes you become "
       "dazed,\n\rand fall face first to the $g.",
       FALSE, this, 0, victim, TO_VICT, ANSI_RED);
-  } else {
-    act("$n grabs $N's arm and rips $M off of $S $o!", FALSE, this,
-      victim->riding, victim, TO_NOTVICT);
-    act("$N slams head first into the $g.", FALSE, this, victim->riding, victim,
-      TO_NOTVICT);
-    act("You grab $N's arm and pull $M off of $S $o!", FALSE, this,
-      victim->riding, victim, TO_CHAR);
-    act("$N slams head first into the $g.", FALSE, this, victim->riding, victim,
-      TO_CHAR);
-    act("$n suddenly grabs your arm and gives a hard yank!", FALSE, this,
-      victim->riding, victim, TO_VICT);
-    act("Suddenly, the $g rushes upward as you fall off of your $o.", FALSE,
-      this, victim->riding, victim, TO_VICT, ANSI_RED);
-    act("OOFFF!! Yuck, dirt tastes AWFUL!", FALSE, this, victim->riding, victim,
-      TO_VICT, ANSI_RED);
-    victim->dismount(POSITION_RESTING);
   }
 
-  rc = victim->crashLanding(POSITION_SITTING);
+  int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
-
-  rc = victim->trySpringleap(this);
-  if (IS_SET_DELETE(rc, DELETE_THIS) && IS_SET_DELETE(rc, DELETE_VICT))
-    return rc;
-  else if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_VICT;
-  else if (IS_SET_DELETE(rc, DELETE_VICT))
-    return DELETE_THIS;
 
   // see the balance notes for details on what's going on here.
   float wt = (combatRound(discArray[SKILL_SPIN]->lag) / 3);

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -139,27 +139,13 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
 int TBeing::spinHit(TBeing* victim) {
   const bool wasMounted = (victim->riding != nullptr);
 
-  if (wasMounted) {
-    act("You grab $N's arm and rip $M off $p!", false, this, victim->riding,
-      victim, TO_CHAR);
-    act("$n grabs $N's arm and rips $M off $p!", false, this, victim->riding,
-      victim, TO_NOTVICT);
-    act("$n grabs your arm and rips you off $p!", false, this, victim->riding,
-      victim, TO_VICT);
-  } else {
-    act("$n grabs $N's arm and spins $M!", FALSE, this, 0, victim, TO_NOTVICT);
-    act("Now dizzy, $N trips and falls to the $g.", FALSE, this, 0, victim,
-      TO_NOTVICT);
-    act("You grab $N's arm and spin $M HARD!", FALSE, this, 0, victim, TO_CHAR);
-    act("Now dizzy $N trips and falls to the $g.", FALSE, this, 0, victim,
-      TO_CHAR);
-    act("$n grabs you by the arm and spins you violently.", FALSE, this, 0,
-      victim, TO_VICT);
-    act(
-      "As the world spins into a blur before your eyes you become "
-      "dazed,\n\rand fall face first to the $g.",
-      FALSE, this, 0, victim, TO_VICT, ANSI_RED);
-  }
+  // Describe the wind-up only — crashLanding/knockOffMount narrates the result.
+  act("You take ahold of $N and pull hard!", false, this, nullptr, victim,
+    TO_CHAR);
+  act("$n takes ahold of you and pulls hard!", false, this, nullptr, victim,
+    TO_VICT, ANSI_RED);
+  act("$n takes ahold of $N and pulls hard!", false, this, nullptr, victim,
+    TO_NOTVICT);
 
   int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -147,7 +147,8 @@ int TBeing::spinHit(TBeing* victim) {
   act("$n takes ahold of $N and pulls hard!", false, this, nullptr, victim,
     TO_NOTVICT);
 
-  int rc = wasMounted ? victim->knockOffMount() : victim->crashLanding();
+  int rc = wasMounted ? victim->knockOffMount(getSkillValue(SKILL_SPIN) / 3)
+                      : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
 

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -85,8 +85,6 @@ bool TBeing::canSpin(TBeing* victim, silentTypeT silent) {
 }
 
 int TBeing::spinMiss(TBeing* victim, skillMissT type) {
-  int rc;
-
   if (type == TYPE_DEX) {
     act("$N deftly avoids your attempt at spinning $M.", FALSE, this, 0, victim,
       TO_CHAR);
@@ -116,27 +114,23 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
     act("$N sticks out $S foot tripping $n to the $g.", FALSE, this, 0, victim,
       TO_NOTVICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
-    act("$n tries to spin $N, but ends up falling down.", FALSE, this, 0,
-      victim, TO_NOTVICT);
-    act("You try to spin $N, but end up falling on your face.", FALSE, this, 0,
-      victim, TO_CHAR);
-    act("$n fails to spin you, and tumbles to the $g.", FALSE, this, 0, victim,
+    act("$n tries to spin $N but loses $s footing.", false, this, 0, victim,
+      TO_NOTVICT);
+    act("You try to spin $N but lose your footing.", false, this, 0, victim,
+      TO_CHAR);
+    act("$n tries to spin you but loses $s footing.", false, this, 0, victim,
       TO_VICT);
 
-    rc = crashLanding(POSITION_SITTING);
+    int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
-      return rc;
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -103,16 +103,16 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
   } else if (type == TYPE_MONK) {
     act("$N deftly counters your attempt at spinning $M.", FALSE, this, 0,
       victim, TO_CHAR, ANSI_RED);
-    act("You trip and land on the $g.", FALSE, this, 0, victim, TO_CHAR,
-      ANSI_RED);
+    act("$N sticks out $S foot and trips you, toppling you.", false, this, 0,
+      victim, TO_CHAR, ANSI_RED);
     act("You deftly counter $n's attempt at spinning you.", FALSE, this, 0,
       victim, TO_VICT);
-    act("You stick out your foot and trip $m to the $g.", FALSE, this, 0,
+    act("You stick out your foot and trip $m, toppling them.", false, this, 0,
       victim, TO_VICT);
     act("$N deftly counters $n's attempt at spinning $M.", FALSE, this, 0,
       victim, TO_NOTVICT);
-    act("$N sticks out $S foot tripping $n to the $g.", FALSE, this, 0, victim,
-      TO_NOTVICT);
+    act("$N sticks out $S foot and trips $n, toppling $m.", false, this, 0,
+      victim, TO_NOTVICT);
 
     int rc = stumble(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))

--- a/code/code/cmd/cmd_spin.cc
+++ b/code/code/cmd/cmd_spin.cc
@@ -115,9 +115,7 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
       TO_NOTVICT);
 
     int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
     act("$n tries to spin $N but loses $s footing.", false, this, 0, victim,
@@ -128,9 +126,7 @@ int TBeing::spinMiss(TBeing* victim, skillMissT type) {
       TO_VICT);
 
     int rc = stumble(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   }
 

--- a/code/code/cmd/cmd_trip.cc
+++ b/code/code/cmd/cmd_trip.cc
@@ -206,8 +206,8 @@ int TBeing::tripFail(TBeing* victim, spellNumT skill) {
   act("$n tries to trip you but you quickly hop over $s leg.", FALSE, this, 0,
     victim, TO_VICT);
 
-  int rc = stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  int rc = stumble();
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return rc;
 
   reconcileDamage(victim, 0, skill);
@@ -230,17 +230,9 @@ int TBeing::tripSuccess(TBeing* victim, spellNumT skill) {
   distNum = 1;
   if (isLucky(levelLuckModifier(victim->GetMaxLevel())))
     distNum++;
-  rc = victim->crashLanding(POSITION_SITTING);
+  rc = victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
-
-  rc = victim->trySpringleap(this);
-  if (IS_SET_DELETE(rc, DELETE_THIS) && IS_SET_DELETE(rc, DELETE_VICT))
-    return rc;
-  else if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_VICT;
-  else if (IS_SET_DELETE(rc, DELETE_VICT))
-    return DELETE_THIS;
 
   float wait = combatRound(discArray[SKILL_TRIP]->lag);
   addToMove(-5);

--- a/code/code/cmd/cmd_trip.cc
+++ b/code/code/cmd/cmd_trip.cc
@@ -199,8 +199,6 @@ static int trip(TBeing* c, TBeing* victim, spellNumT skill) {
 }
 
 int TBeing::tripFail(TBeing* victim, spellNumT skill) {
-  int rc;
-
   act("$n attempts to trip $N but $E quickly hops over $n's leg.", FALSE, this,
     0, victim, TO_NOTVICT);
   act("You attempt to trip $N but $E quickly hops over your leg.", FALSE, this,
@@ -208,19 +206,10 @@ int TBeing::tripFail(TBeing* victim, spellNumT skill) {
   act("$n tries to trip you but you quickly hop over $s leg.", FALSE, this, 0,
     victim, TO_VICT);
 
-  if (hasLegs()) {
-    rc = crashLanding(POSITION_SITTING);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
+  int rc = stumble(victim);
+  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
 
-    sendTo(
-      format("%sYou lose your balance and fall over.%s\n\r") % red() % norm());
-    act("<r>$n loses $s balance and falls over.<1>", TRUE, this, 0, 0, TO_ROOM);
-
-    rc = trySpringleap(victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
-      return rc;
-  }
   reconcileDamage(victim, 0, skill);
   return FALSE;
 }

--- a/code/code/disc/disc_monk_leverage.cc
+++ b/code/code/disc/disc_monk_leverage.cc
@@ -58,9 +58,7 @@ int hurlMiss(TBeing* caster, TBeing* victim) {
     victim, TO_VICT);
 
   int rc = caster->stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-  if (IS_SET_DELETE(rc, DELETE_VICT))
+  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
     return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
@@ -171,10 +169,8 @@ int TBeing::aiHurl(dirTypeT dr, TBeing* victim) {
     if (rc) {
       addSkillLag(SKILL_HURL, rc);
     }
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   }
 
   /*
@@ -318,10 +314,8 @@ int hurl(TBeing* caster, TBeing* victim, char* direction) {
       caster->addSkillLag(SKILL_HURL, rc);
     }
 
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   }
   return FALSE;
 }
@@ -377,9 +371,7 @@ int shoulderThrowMiss(TBeing* caster, TBeing* victim) {
     TO_VICT);
 
   int rc = caster->stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-  if (IS_SET_DELETE(rc, DELETE_VICT))
+  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
     return rc;
   caster->reconcileDamage(victim, 0, SKILL_CHOP);
   return TRUE;
@@ -532,10 +524,8 @@ int shoulderThrow(TBeing* caster, TBeing* victim) {
       return DELETE_THIS;
   } else {
     rc = shoulderThrowMiss(caster, victim);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   }
   return TRUE;
 }
@@ -586,9 +576,7 @@ int defenestrateMiss(TBeing* caster, TBeing* victim) {
     victim, TO_VICT);
 
   int rc = caster->stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-  if (IS_SET_DELETE(rc, DELETE_VICT))
+  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
     return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
@@ -802,10 +790,8 @@ int defenestrate(TBeing* caster, TBeing* victim, sstring direction) {
       caster->addSkillLag(SKILL_DEFENESTRATE, rc);
     }
 
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   }
   return FALSE;
 }

--- a/code/code/disc/disc_monk_leverage.cc
+++ b/code/code/disc/disc_monk_leverage.cc
@@ -173,6 +173,8 @@ int TBeing::aiHurl(dirTypeT dr, TBeing* victim) {
     }
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_VICT;
   }
 
   /*
@@ -318,6 +320,8 @@ int hurl(TBeing* caster, TBeing* victim, char* direction) {
 
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_VICT;
   }
   return FALSE;
 }
@@ -530,6 +534,8 @@ int shoulderThrow(TBeing* caster, TBeing* victim) {
     rc = shoulderThrowMiss(caster, victim);
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_VICT;
   }
   return TRUE;
 }
@@ -798,6 +804,8 @@ int defenestrate(TBeing* caster, TBeing* victim, sstring direction) {
 
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_VICT))
+      return DELETE_VICT;
   }
   return FALSE;
 }

--- a/code/code/disc/disc_monk_leverage.cc
+++ b/code/code/disc/disc_monk_leverage.cc
@@ -57,8 +57,8 @@ int hurlMiss(TBeing* caster, TBeing* victim) {
   act("$n fails to hurl you correctly and loses $s balance.", false, caster, 0,
     victim, TO_VICT);
 
-  int rc = caster->stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  int rc = caster->stumble();
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
@@ -123,7 +123,7 @@ static int hurlHit(TBeing* caster, TBeing* victim, dirTypeT dr) {
 
     act("$N is hurled into the room!", TRUE, victim, 0, victim, TO_ROOM);
 
-    rc = victim->crashLanding(POSITION_SITTING);
+    rc = victim->crashLanding();
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_VICT;
 
@@ -362,8 +362,8 @@ int shoulderThrowMiss(TBeing* caster, TBeing* victim) {
   act("$n clumsily fails to shoulder throw you.", false, caster, 0, victim,
     TO_VICT);
 
-  int rc = caster->stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  int rc = caster->stumble();
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return rc;
   caster->reconcileDamage(victim, 0, SKILL_CHOP);
   return TRUE;
@@ -400,7 +400,7 @@ int shoulderThrowHit(TBeing* caster, TBeing* victim, int) {
   act("$N lands flat on $S back!", FALSE, caster, 0, victim, TO_CHAR);
   act("You land flat on your back!", FALSE, caster, 0, victim, TO_VICT);
 
-  rc = victim->crashLanding(POSITION_SITTING);
+  rc = victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
 
@@ -563,8 +563,8 @@ int defenestrateMiss(TBeing* caster, TBeing* victim) {
   act("$n clumsily fails to throw you out the window.", false, caster, 0,
     victim, TO_VICT);
 
-  int rc = caster->stumble(victim);
-  if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+  int rc = caster->stumble();
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
@@ -624,7 +624,7 @@ static int defenestrateHit(TBeing* caster, TBeing* victim, int to_room,
 
     act("$N is defenestrated into the room!", TRUE, victim, 0, victim, TO_ROOM);
 
-    rc = victim->crashLanding(POSITION_SITTING);
+    rc = victim->crashLanding();
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_VICT;
 
@@ -780,150 +780,45 @@ int defenestrate(TBeing* caster, TBeing* victim, sstring direction) {
   return FALSE;
 }
 
-// this function is meant to be called from brawling commands so monks
-// automatically springleap.  They can still force it thru doSpringleap
-int TBeing::trySpringleap(TBeing* vict) {
-  if (!doesKnowSkill(SKILL_SPRINGLEAP))
-    return FALSE;
-
-  return doSpringleap("", false, vict);
-}
-
-int TBeing::doSpringleap(sstring argument, bool should_lag, TBeing* vict) {
-  TBeing* victim;
-  sstring name_buf;
-  int rc;
-
+int TBeing::doSpringleap() {
   if (!doesKnowSkill(SKILL_SPRINGLEAP)) {
     sendTo("You don't know how.\n\r");
     return FALSE;
   }
-  one_argument(argument, name_buf);
 
-  if (!(victim = vict)) {
-    if (!(victim = get_char_room_vis(this, name_buf))) {
-      if (!(victim = fight())) {
-        sendTo("Springleap at whom?\n\r");
-        return FALSE;
-      }
-#if 0
-    } else if (!fight()) {
-      sendTo("You are not able to initiate combat with a springleap.\n\r");
-      return FALSE;
-#endif
-    }
+  if (getPosition() < POSITION_RESTING || getPosition() > POSITION_SITTING) {
+    sendTo("You're not in position for that!\n\r");
+    return false;
   }
-  if (!sameRoom(*victim)) {
-    sendTo("That person isn't around.\n\r");
-    return FALSE;
-  }
-  rc = springleap(this, victim, should_lag);
-  if (rc && should_lag)  // auto springleap doesn't lag
+
+  int rc = springleap();
+  if (rc)
     addSkillLag(SKILL_SPRINGLEAP, rc);
 
-  if (IS_SET_DELETE(rc, DELETE_VICT)) {
-    if (vict)
-      return rc;
-    delete victim;
-    victim = NULL;
-    REM_DELETE(rc, DELETE_VICT);
-  }
   return rc;
 }
 
-int springleap(TBeing* caster, TBeing* victim, bool should_lag) {
-  int i, d = 0;
-  int percent;
-  spellNumT iSkill = SKILL_SPRINGLEAP;
-
-  if (caster->checkPeaceful(
-        "You feel too peaceful to contemplate violence.\n\r"))
+int TBeing::springleap() {
+  if (!doesKnowSkill(SKILL_SPRINGLEAP))
     return FALSE;
 
-  if (!caster->doesKnowSkill(iSkill)) {
-    caster->sendTo("You don't know how to do that!\n\r");
-    return FALSE;
-  }
-
-  if (caster->getPosition() > POSITION_SITTING) {
-    caster->sendTo("You're not in position for that!\n\r");
-    return FALSE;
-  }
-
-  if (victim == caster) {
-    caster->sendTo("Aren't we funny today...\n\r");
-    return FALSE;
-  }
-
-  if (caster->noHarmCheck(victim))
+  if (getPosition() < POSITION_RESTING || getPosition() > POSITION_SITTING)
     return FALSE;
 
-  percent = 0;
-  int bKnown = caster->getSkillValue(SKILL_SPRINGLEAP);
-
-  act("$n does a really nifty move, and aims a leg towards $N.", FALSE, caster,
-    0, victim, TO_NOTVICT);
-  act("You leap off the $g at $N.", FALSE, caster, 0, victim, TO_CHAR);
-  act("$n leaps off the $g at you.", FALSE, caster, 0, victim, TO_VICT);
-  caster->reconcileHurt(victim, 0.04);
-
-  if (caster->bSuccess(bKnown + percent, SKILL_SPRINGLEAP)) {
-    if ((i = caster->specialAttack(victim, SKILL_SPRINGLEAP)) ||
-        (i == GUARANTEED_SUCCESS)) {
-      if (victim->getPosition() > POSITION_DEAD) {
-        if (!(d = caster->getActualDamage(victim, NULL,
-                caster->getSkillLevel(SKILL_SPRINGLEAP) >> 1, SKILL_KICK))) {
-          act(
-            "You attempt to kick $N but lose your balance and fall face down "
-            "in some mud that has suddenly appeared.",
-            FALSE, caster, NULL, victim, TO_CHAR);
-          act(
-            "When $n tries to kick you, you quickly make $m fall in some mud "
-            "you create.",
-            FALSE, caster, NULL, victim, TO_VICT);
-          act("$n falls face down in some mud created by $N.", FALSE, caster,
-            NULL, victim, TO_NOTVICT);
-        } else if (caster->willKill(victim, d, SKILL_KICK, TRUE)) {
-          act("Your kick at $N's face splits $S head open.", FALSE, caster,
-            NULL, victim, TO_CHAR);
-          act("$n aims a kick at your face which splits your head in two.",
-            FALSE, caster, NULL, victim, TO_VICT);
-          act("$n neatly kicks $N's head into pieces.", FALSE, caster, NULL,
-            victim, TO_NOTVICT);
-          iSkill = DAMAGE_KICK_HEAD;
-        } else {
-          act("Your kick hits $N in the solar plexus.", FALSE, caster, NULL,
-            victim, TO_CHAR);
-          act("You're hit in the solar plexus, wow, this is breathtaking!",
-            FALSE, caster, NULL, victim, TO_VICT);
-          act("$n kicks $N in the solar plexus, $N is rendered breathless.",
-            FALSE, caster, NULL, victim, TO_NOTVICT);
-        }
-      }
-      if (caster->reconcileDamage(victim, d, iSkill) == -1)
-        return DELETE_VICT;
-    } else {
-      act("You miss your kick at $N's groin, much to $S relief.", FALSE, caster,
-        NULL, victim, TO_CHAR);
-      act("$n misses a kick at your groin, you breathe lighter now.", FALSE,
-        caster, NULL, victim, TO_VICT);
-      act("$n misses a kick at $N's groin.", FALSE, caster, NULL, victim,
-        TO_NOTVICT);
-      caster->reconcileDamage(victim, 0, SKILL_SPRINGLEAP);
-    }
-    if (victim)
-      victim->addToWait(combatRound(1));
+  if (bSuccess(SKILL_SPRINGLEAP)) {
+    act("<g>You spring off the $g and land lightly on your feet.<1>", true,
+      this, nullptr, nullptr, TO_CHAR);
+    act("<g>$n springs off the $g and lands lightly on $s feet.<1>", true, this,
+      nullptr, nullptr, TO_ROOM);
+    setPosition(POSITION_STANDING);
+    updatePos();
   } else {
-    if (victim->getPosition() > POSITION_DEAD) {
-      caster->sendTo("You fall on your butt.\n\r");
-      act("$n falls on $s butt.", FALSE, caster, 0, 0, TO_ROOM);
-      if (caster->reconcileDamage(victim, 0, SKILL_SPRINGLEAP) == -1)
-        return DELETE_VICT;
-    }
-    return TRUE;
+    act("<r>You try to spring up, but flop back down.<1>", true, this, nullptr,
+      nullptr, TO_CHAR);
+    act("<r>$n tries to spring up, but flops back down.<1>", true, this,
+      nullptr, nullptr, TO_ROOM);
   }
-  caster->setPosition(POSITION_STANDING);
-  caster->updatePos();
+
   return TRUE;
 }
 

--- a/code/code/disc/disc_monk_leverage.cc
+++ b/code/code/disc/disc_monk_leverage.cc
@@ -150,20 +150,16 @@ int TBeing::aiHurl(dirTypeT dr, TBeing* victim) {
 
   if (victim->getPosition() <= POSITION_STUNNED) {
     rc = hurlHit(this, victim, dr);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else if ((i = specialAttack(victim, SKILL_HURL)) &&
              (i != GUARANTEED_FAILURE) && bSuccess(bKnown, SKILL_HURL)) {
     rc = hurlHit(this, victim, dr);
     if (rc) {
       addSkillLag(SKILL_HURL, rc);
     }
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else {
     rc = hurlMiss(this, victim);
     if (rc) {
@@ -292,10 +288,8 @@ int hurl(TBeing* caster, TBeing* victim, char* direction) {
 
   if (victim->getPosition() <= POSITION_STUNNED) {
     rc = hurlHit(caster, victim, dr);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else if ((i = caster->specialAttack(victim, SKILL_HURL)) &&
              (i != GUARANTEED_FAILURE) &&
              caster->bSuccess(bKnown + percent, SKILL_HURL)) {
@@ -304,10 +298,8 @@ int hurl(TBeing* caster, TBeing* victim, char* direction) {
       caster->addSkillLag(SKILL_HURL, rc);
     }
 
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else {
     rc = hurlMiss(caster, victim);
     if (rc) {
@@ -510,18 +502,14 @@ int shoulderThrow(TBeing* caster, TBeing* victim) {
 
   if (victim->getPosition() <= POSITION_STUNNED) {
     rc = shoulderThrowHit(caster, victim, bKnown + percent);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else if ((i = caster->specialAttack(victim, SKILL_SHOULDER_THROW)) &&
              (i != GUARANTEED_FAILURE) &&
              caster->bSuccess(bKnown + percent, SKILL_SHOULDER_THROW)) {
     rc = shoulderThrowHit(caster, victim, bKnown + percent);
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else {
     rc = shoulderThrowMiss(caster, victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
@@ -768,10 +756,8 @@ int defenestrate(TBeing* caster, TBeing* victim, sstring direction) {
 
   if (victim->getPosition() <= POSITION_STUNNED) {
     rc = defenestrateHit(caster, victim, window->getTarget(), window);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else if ((i = caster->specialAttack(victim, SKILL_DEFENESTRATE)) &&
              (i != GUARANTEED_FAILURE) &&
              caster->bSuccess(bKnown + percent, SKILL_DEFENESTRATE)) {
@@ -780,10 +766,8 @@ int defenestrate(TBeing* caster, TBeing* victim, sstring direction) {
       caster->addSkillLag(SKILL_DEFENESTRATE, rc);
     }
 
-    if (IS_SET_DELETE(rc, DELETE_VICT))
-      return DELETE_VICT;
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_THIS;
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else {
     rc = defenestrateMiss(caster, victim);
     if (rc) {

--- a/code/code/disc/disc_monk_leverage.cc
+++ b/code/code/disc/disc_monk_leverage.cc
@@ -50,18 +50,18 @@ int TBeing::doHurl(const char* argument, TBeing* vict) {
 }
 
 int hurlMiss(TBeing* caster, TBeing* victim) {
-  int rc;
-
-  act("$n misses $s attempt at hurling $N and falls on $s butt!", FALSE, caster,
-    0, victim, TO_NOTVICT);
-  act("You fall as you attempt to hurl $N!", FALSE, caster, 0, victim, TO_CHAR);
-  act("You manage to avoid $n as $e tries to hurl you!", FALSE, caster, 0,
+  act("$n fails to hurl $N correctly and loses $s balance.", false, caster, 0,
+    victim, TO_NOTVICT);
+  act("You fail to hurl $N correctly and lose your balance.", false, caster, 0,
+    victim, TO_CHAR);
+  act("$n fails to hurl you correctly and loses $s balance.", false, caster, 0,
     victim, TO_VICT);
 
-  rc = caster->crashLanding(POSITION_SITTING);
+  int rc = caster->stumble(victim);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
 }
@@ -365,19 +365,18 @@ int TBeing::doShoulderThrow(const char* argument, TBeing* vict) {
 }
 
 int shoulderThrowMiss(TBeing* caster, TBeing* victim) {
-  int rc;
-
-  act("$n misses $s attempt at shoulder throwing $N and falls on $s butt!",
-    FALSE, caster, 0, victim, TO_NOTVICT);
-  act("You fall as you attempt to shoulder throw $N!", FALSE, caster, 0, victim,
+  act("$n clumsily fails to shoulder throw $N.", false, caster, 0, victim,
+    TO_NOTVICT);
+  act("You clumsily fail to shoulder throw $N.", false, caster, 0, victim,
     TO_CHAR);
-  act("You manage to avoid $n as $e tries to shoulder throw you!", FALSE,
-    caster, 0, victim, TO_VICT);
+  act("$n clumsily fails to shoulder throw you.", false, caster, 0, victim,
+    TO_VICT);
 
-  rc = caster->crashLanding(POSITION_SITTING);
+  int rc = caster->stumble(victim);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
   caster->reconcileDamage(victim, 0, SKILL_CHOP);
   return TRUE;
 }
@@ -573,19 +572,18 @@ int TBeing::doDefenestrate(const char* argument, TBeing* vict) {
 }
 
 int defenestrateMiss(TBeing* caster, TBeing* victim) {
-  int rc;
-
-  act("$n misses $s attempt at defenestrating $N and falls on $s butt!", FALSE,
-    caster, 0, victim, TO_NOTVICT);
-  act("You fall as you attempt to defenestrate $N!", FALSE, caster, 0, victim,
+  act("$n clumsily fails to throw $N out the window.", false, caster, 0, victim,
+    TO_NOTVICT);
+  act("You clumsily fail to throw $N out the window.", false, caster, 0, victim,
     TO_CHAR);
-  act("You manage to avoid $n as $e tries to defenestrate you!", FALSE, caster,
-    0, victim, TO_VICT);
+  act("$n clumsily fails to throw you out the window.", false, caster, 0,
+    victim, TO_VICT);
 
-  rc = caster->crashLanding(POSITION_SITTING);
+  int rc = caster->stumble(victim);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
-
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    return rc;
   caster->reconcileDamage(victim, 0, SKILL_SHOULDER_THROW);
   return TRUE;
 }

--- a/code/code/disc/disc_monk_leverage.h
+++ b/code/code/disc/disc_monk_leverage.h
@@ -26,5 +26,3 @@ int shoulderThrow(TBeing*, TBeing*);
 int hurl(TBeing*, TBeing*, char*);
 int defenestrate(TBeing*, TBeing*, sstring);
 int bonebreak(TBeing*, TBeing*);
-int springleap(TBeing*, TBeing*, bool);
-

--- a/code/code/disc/disc_monk_mind_body.cc
+++ b/code/code/disc/disc_monk_mind_body.cc
@@ -52,7 +52,7 @@ int TBeing::doLeap(const sstring& arg) {
   if (!bSuccess(SKILL_CATLEAP)) {
     act("You don't make it very far.", FALSE, this, 0, 0, TO_CHAR);
     act("$n doesn't make it very far.", FALSE, this, 0, 0, TO_ROOM);
-    rc = crashLanding(POSITION_SITTING);
+    rc = crashLanding();
   } else {
     rc = doMove(getDirFromChar(arg));
   }
@@ -109,16 +109,13 @@ int TBeing::monkDodge(TBeing* v, TThing* weapon, int* dam, int w_type,
     }
 
     sprintf(buf, "You %s $n's %s at your %s.", type,
-      attack_hit_text[w_type].singular,
-      v->describeBodySlot(part_hit).c_str());
+      attack_hit_text[w_type].singular, v->describeBodySlot(part_hit).c_str());
     act(buf, FALSE, this, 0, v, TO_VICT, ANSI_CYAN);
     sprintf(buf, "$N %ss your %s at $S %s.", type,
-      attack_hit_text[w_type].singular,
-      v->describeBodySlot(part_hit).c_str());
+      attack_hit_text[w_type].singular, v->describeBodySlot(part_hit).c_str());
     act(buf, FALSE, this, 0, v, TO_CHAR, ANSI_CYAN);
     sprintf(buf, "$N %ss $n's %s at $S %s.", type,
-      attack_hit_text[w_type].singular,
-      v->describeBodySlot(part_hit).c_str());
+      attack_hit_text[w_type].singular, v->describeBodySlot(part_hit).c_str());
     act(buf, TRUE, this, 0, v, TO_NOTVICT);
 
     return TRUE;

--- a/code/code/disc/disc_psionics.cc
+++ b/code/code/disc/disc_psionics.cc
@@ -714,7 +714,7 @@ int TBeing::doPsycrush(const char* tString) {
 
 int kwaveDamage(TBeing* caster, TBeing* victim) {
   int rc = victim->crashLanding();
-  if (IS_SET_ONLY(rc, DELETE_VICT))
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
 
   float wt = combatRound(discArray[SKILL_KINETIC_WAVE]->lag);

--- a/code/code/disc/disc_psionics.cc
+++ b/code/code/disc/disc_psionics.cc
@@ -713,7 +713,7 @@ int TBeing::doPsycrush(const char* tString) {
 }
 
 int kwaveDamage(TBeing* caster, TBeing* victim) {
-  int rc = victim->crashLanding(POSITION_SITTING);
+  int rc = victim->crashLanding();
   if (IS_SET_ONLY(rc, DELETE_VICT))
     return DELETE_VICT;
 

--- a/code/code/disc/disc_thief_stealth.cc
+++ b/code/code/disc/disc_thief_stealth.cc
@@ -16,7 +16,6 @@
 #include "client.h"
 #include "spec_mobs.h"
 
-
 void TBeing::doTrack(const char* argument) {
   char namebuf[256], found = FALSE;
   int dist = 0, targrm, worked, skill;
@@ -803,7 +802,6 @@ int disguise(TBeing* caster, char* buffer) {
   return TRUE;
 }
 
-
 int TBeing::doSneak(const char* argument) {
   int rc = 0;
   char arg[80];
@@ -974,14 +972,20 @@ int subterfugeMiss(TBeing* thief, TBeing* victim) {
 
   if (!thief->fight()) {
     if (!thief->isAgile(0)) {
-      act("$n tries to put on a show for you and falls on $s face!", FALSE, thief, NULL, victim, TO_VICT);
-      act("$n tries to put on a show for $N and falls on $s face!", FALSE, thief, NULL, victim, TO_NOTVICT);
-      act("You try to put on a show for $N and fall on your face!", FALSE, thief, NULL, victim, TO_CHAR);
-      thief->crashLanding(POSITION_SITTING);
+      act("$n tries to put on a show for you and falls on $s face!", FALSE,
+        thief, NULL, victim, TO_VICT);
+      act("$n tries to put on a show for $N and falls on $s face!", FALSE,
+        thief, NULL, victim, TO_NOTVICT);
+      act("You try to put on a show for $N and fall on your face!", FALSE,
+        thief, NULL, victim, TO_CHAR);
+      thief->crashLanding();
     } else {
-      act("$n does a dumb little dance for you. $e has no talent!", FALSE, thief, NULL, victim, TO_VICT);
-      act("$n does a dumb little dance for $N. $e has no talent!", FALSE, thief, NULL, victim, TO_NOTVICT);
-      act("You do a dumb little dance for $N. You have no talent!", FALSE, thief, NULL, victim, TO_CHAR);
+      act("$n does a dumb little dance for you. $e has no talent!", FALSE,
+        thief, NULL, victim, TO_VICT);
+      act("$n does a dumb little dance for $N. $e has no talent!", FALSE, thief,
+        NULL, victim, TO_NOTVICT);
+      act("You do a dumb little dance for $N. You have no talent!", FALSE,
+        thief, NULL, victim, TO_CHAR);
     }
 
     thief->setCharFighting(victim);
@@ -998,13 +1002,19 @@ int subterfugePlayer(TBeing* thief, TBeing* victim) {
   if (victim->isCombatMode(ATTACK_BERSERK)) {
     victim->setCombatMode(ATTACK_NORMAL);
     victim->affectFrom(SKILL_BERSERK);
-    act("$N's berserker rage subsides as you calm $M down.", FALSE, thief, NULL, victim, TO_CHAR);
-    act("$n's subtle gestures and words calm your rage.", FALSE, thief, NULL, victim, TO_VICT);
-    act("$n somehow calms $N's berserker rage.", FALSE, thief, NULL, victim, TO_NOTVICT);
+    act("$N's berserker rage subsides as you calm $M down.", FALSE, thief, NULL,
+      victim, TO_CHAR);
+    act("$n's subtle gestures and words calm your rage.", FALSE, thief, NULL,
+      victim, TO_VICT);
+    act("$n somehow calms $N's berserker rage.", FALSE, thief, NULL, victim,
+      TO_NOTVICT);
   } else {
-    act("You put on a show to confuse $N.", FALSE, thief, NULL, victim, TO_CHAR);
-    act("$n puts on a show for you. It is a confusing performance!", FALSE, thief, NULL, victim, TO_VICT);
-    act("$n puts on a show for $N. It is a confusing performance!", FALSE, thief, NULL, victim, TO_NOTVICT);
+    act("You put on a show to confuse $N.", FALSE, thief, NULL, victim,
+      TO_CHAR);
+    act("$n puts on a show for you. It is a confusing performance!", FALSE,
+      thief, NULL, victim, TO_VICT);
+    act("$n puts on a show for $N. It is a confusing performance!", FALSE,
+      thief, NULL, victim, TO_NOTVICT);
     victim->addToWait(combatRound(1));
   }
 
@@ -1012,14 +1022,17 @@ int subterfugePlayer(TBeing* thief, TBeing* victim) {
 }
 
 int subterfugeHit(TBeing* thief, TBeing* victim) {
-// Mob success actions
-int level = thief->getSkillLevel(SKILL_SUBTERFUGE);
-level = (max (1, (level + (thief->getChaReaction()))));
+  // Mob success actions
+  int level = thief->getSkillLevel(SKILL_SUBTERFUGE);
+  level = (max(1, (level + (thief->getChaReaction()))));
 
-int advLearning = thief->getAdvLearning(SKILL_SUBTERFUGE);
-  act("$N seems pretty confused by your show!", FALSE, thief, NULL, victim, TO_CHAR, ANSI_ORANGE);
-  act("$n confuses $N with a show.", FALSE, thief, NULL, victim, TO_NOTVICT, ANSI_ORANGE);
-  act("$n confuses you with a show.", FALSE, thief, NULL, victim, TO_VICT, ANSI_ORANGE);
+  int advLearning = thief->getAdvLearning(SKILL_SUBTERFUGE);
+  act("$N seems pretty confused by your show!", FALSE, thief, NULL, victim,
+    TO_CHAR, ANSI_ORANGE);
+  act("$n confuses $N with a show.", FALSE, thief, NULL, victim, TO_NOTVICT,
+    ANSI_ORANGE);
+  act("$n confuses you with a show.", FALSE, thief, NULL, victim, TO_VICT,
+    ANSI_ORANGE);
 
   // Apply subterfuge affect for PER reduction
   affectedData af;
@@ -1054,55 +1067,65 @@ int advLearning = thief->getAdvLearning(SKILL_SUBTERFUGE);
   if (mob && level >= 75) {
     REMOVE_BIT(mob->specials.act, ACT_HUNTING);
     REMOVE_BIT(mob->specials.act, ACT_HATEFUL);
-    act("$N seems to forget why $E was so angry.", FALSE, thief, NULL, victim, TO_CHAR);
-    act("$N seems to forget why $E was so angry.", FALSE, thief, NULL, victim, TO_NOTVICT);
-    act("You seem to forget why you were so angry.", FALSE, thief, NULL, victim, TO_VICT);
+    act("$N seems to forget why $E was so angry.", FALSE, thief, NULL, victim,
+      TO_CHAR);
+    act("$N seems to forget why $E was so angry.", FALSE, thief, NULL, victim,
+      TO_NOTVICT);
+    act("You seem to forget why you were so angry.", FALSE, thief, NULL, victim,
+      TO_VICT);
   }
 
   // Tier 3: 20% advanced discipline - Remove thief/cityguard procs
   if (mob && advLearning >= 20) {
     if (IS_SET(mob->specials.act, ACT_NICE_THIEF)) {
-      act("$N seems to look a little less mischievous.", FALSE, thief, NULL, victim, TO_CHAR, ANSI_PURPLE_BOLD);
+      act("$N seems to look a little less mischievous.", FALSE, thief, NULL,
+        victim, TO_CHAR, ANSI_PURPLE_BOLD);
       REMOVE_BIT(mob->specials.act, ACT_NICE_THIEF);
     }
     if (IS_SET(mob->specials.act, ACT_GUARDIAN)) {
-      act("$N seems to look a little less watchful.", FALSE, thief, NULL, victim, TO_CHAR, ANSI_YELLOW);
+      act("$N seems to look a little less watchful.", FALSE, thief, NULL,
+        victim, TO_CHAR, ANSI_YELLOW);
       REMOVE_BIT(mob->specials.act, ACT_GUARDIAN);
     }
     if (IS_SET(mob->specials.act, ACT_AFRAID)) {
-      act("$N seems to look a little less afraid.", FALSE, thief, NULL, victim, TO_CHAR, ANSI_ORANGE);
+      act("$N seems to look a little less afraid.", FALSE, thief, NULL, victim,
+        TO_CHAR, ANSI_ORANGE);
       REMOVE_BIT(mob->specials.act, ACT_AFRAID);
     }
 
-    if (mob->spec == SPEC_CITYGUARD ||
-        mob->spec == SPEC_JANITOR ||
+    if (mob->spec == SPEC_CITYGUARD || mob->spec == SPEC_JANITOR ||
         mob->spec == SPEC_ARCHER) {
-          if (mob->spec == SPEC_CITYGUARD) {
-            act("$N seems to forget $S duties as a <Y>cityguard.<z>", FALSE, thief, NULL, victim, TO_CHAR);
-          }
-          if (mob->spec == SPEC_JANITOR) {
-            act("$N seems to forget $S duties as a <B>janitor.<z>", FALSE, thief, NULL, victim, TO_CHAR);
-          }
-          if (mob->spec == SPEC_ARCHER) {
-            act("$N seems to forget $S duties as an <o>archer.<z>", FALSE, thief, NULL, victim, TO_CHAR);
-          }
-      mob->spec = 0;  // Set to no special proc
+      if (mob->spec == SPEC_CITYGUARD) {
+        act("$N seems to forget $S duties as a <Y>cityguard.<z>", FALSE, thief,
+          NULL, victim, TO_CHAR);
       }
+      if (mob->spec == SPEC_JANITOR) {
+        act("$N seems to forget $S duties as a <B>janitor.<z>", FALSE, thief,
+          NULL, victim, TO_CHAR);
+      }
+      if (mob->spec == SPEC_ARCHER) {
+        act("$N seems to forget $S duties as an <o>archer.<z>", FALSE, thief,
+          NULL, victim, TO_CHAR);
+      }
+      mob->spec = 0;  // Set to no special proc
+    }
   }
 
   // Tier 4: 50% advanced discipline - Remove aggro flag
   if (mob && advLearning >= 50 && IS_SET(mob->specials.act, ACT_AGGRESSIVE)) {
     REMOVE_BIT(mob->specials.act, ACT_AGGRESSIVE);
-    act("$N's aggressive demeanor softens considerably.", FALSE, thief, NULL, victim, TO_CHAR, ANSI_YELLOW);
-    act("$N's aggressive demeanor softens considerably.", FALSE, thief, NULL, victim, TO_NOTVICT, ANSI_YELLOW);
-    act("Your demeanor softens considerably.", FALSE, thief, NULL, victim, TO_VICT, ANSI_YELLOW);
+    act("$N's aggressive demeanor softens considerably.", FALSE, thief, NULL,
+      victim, TO_CHAR, ANSI_YELLOW);
+    act("$N's aggressive demeanor softens considerably.", FALSE, thief, NULL,
+      victim, TO_NOTVICT, ANSI_YELLOW);
+    act("Your demeanor softens considerably.", FALSE, thief, NULL, victim,
+      TO_VICT, ANSI_YELLOW);
   }
 
   return true;
 }
 
 int subterfugeSuccess(TBeing* thief, TBeing* victim) {
-
   // If PC, handle PC-specific logic and exit
   if (victim->isPc()) {
     return subterfugePlayer(thief, victim);
@@ -1128,10 +1151,8 @@ int subterfugeSuccess(TBeing* thief, TBeing* victim) {
     situationalMod += 10;
   }
 
-  int attackValue = thief->specialAttack(victim, SKILL_SUBTERFUGE, situationalMod,
-                                        STAT_CHA, STAT_INT,
-                                        STAT_PER, STAT_WIS,
-                                        true);
+  int attackValue = thief->specialAttack(victim, SKILL_SUBTERFUGE,
+    situationalMod, STAT_CHA, STAT_INT, STAT_PER, STAT_WIS, true);
 
   if (attackValue <= FAILURE) {
     return subterfugeMiss(thief, victim);
@@ -1140,23 +1161,29 @@ int subterfugeSuccess(TBeing* thief, TBeing* victim) {
   // Crit actions
   if (attackValue >= GUARANTEED_SUCCESS) {
     victim->cantHit += max(1, thief->getChaReaction());
-    act("$N seems <p>TOTALLY befuddled<1> by your skills!", FALSE, thief, NULL, victim, TO_CHAR);
-    act("$n <p>TOTALLY befuddles<1> you with $S antics!", FALSE, thief, NULL, victim, TO_VICT);
-    act("$n <p>TOTALLY befuddles<1> $N with $S antics!", FALSE, thief, NULL, victim, TO_NOTVICT);
+    act("$N seems <p>TOTALLY befuddled<1> by your skills!", FALSE, thief, NULL,
+      victim, TO_CHAR);
+    act("$n <p>TOTALLY befuddles<1> you with $S antics!", FALSE, thief, NULL,
+      victim, TO_VICT);
+    act("$n <p>TOTALLY befuddles<1> $N with $S antics!", FALSE, thief, NULL,
+      victim, TO_NOTVICT);
   }
 
   return subterfugeHit(thief, victim);
 }
 
 int subterfugeFail(TBeing* thief, TBeing* victim) {
-   thief->sendTo("You fail to execute the subterfuge properly.\n\r");
-    if (!thief->isCharismatic() && !victim->isPc()) {
-      act("WUH OH! $N looks pretty pissed off.", FALSE, thief, NULL, victim, TO_CHAR);
-      act("$n tried to trick you! $e's gonna pay for that!", FALSE, thief, NULL, victim, TO_VICT);
-      act("$n tried to trick $N! $e's gonna pay for that!", FALSE, thief, NULL, victim, TO_NOTVICT);
-      thief->setCharFighting(victim);
-      victim->setVictFighting(thief);
-    }
+  thief->sendTo("You fail to execute the subterfuge properly.\n\r");
+  if (!thief->isCharismatic() && !victim->isPc()) {
+    act("WUH OH! $N looks pretty pissed off.", FALSE, thief, NULL, victim,
+      TO_CHAR);
+    act("$n tried to trick you! $e's gonna pay for that!", FALSE, thief, NULL,
+      victim, TO_VICT);
+    act("$n tried to trick $N! $e's gonna pay for that!", FALSE, thief, NULL,
+      victim, TO_NOTVICT);
+    thief->setCharFighting(victim);
+    victim->setVictFighting(thief);
+  }
   return true;
 }
 
@@ -1186,13 +1213,12 @@ int subterfuge(TBeing* thief, TBeing* victim) {
     return false;
 
   int level = thief->getSkillLevel(SKILL_SUBTERFUGE);
-  level = (max (1, (level + (thief->getChaReaction()))));
+  level = (max(1, (level + (thief->getChaReaction()))));
   int bKnown = thief->getSkillValue(SKILL_SUBTERFUGE);
 
-
-
   if (thief->isNotPowerful(victim, level, SKILL_SUBTERFUGE, SILENT_YES)) {
-    act("$N's mind is too powerful to be confused.", FALSE, thief, NULL, victim, TO_CHAR);
+    act("$N's mind is too powerful to be confused.", FALSE, thief, NULL, victim,
+      TO_CHAR);
     return false;
   }
 

--- a/code/code/disc/disc_warrior_dueling.cc
+++ b/code/code/disc/disc_warrior_dueling.cc
@@ -58,7 +58,7 @@ int TBeing::doShove(const char* argument, TBeing* vict) {
       act("$n leaps at $N, attempting to topple $M off $S $o, but fails.", TRUE,
         this, victim->riding, victim, TO_NOTVICT);
 
-      rc = crashLanding(POSITION_RESTING);
+      rc = crashLanding();
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
 
@@ -319,16 +319,13 @@ int TBeing::parryWarrior(TBeing* v, TThing* weapon, int* dam, int w_type,
 
     strcpy(type, "parry");
     sprintf(buf, "You %s $n's %s at your %s.", type,
-      attack_hit_text[w_type].singular,
-      v->describeBodySlot(part_hit).c_str());
+      attack_hit_text[w_type].singular, v->describeBodySlot(part_hit).c_str());
     act(buf, FALSE, this, 0, v, TO_VICT, ANSI_CYAN);
     sprintf(buf, "$N %ss your %s at $S %s.", type,
-      attack_hit_text[w_type].singular,
-      v->describeBodySlot(part_hit).c_str());
+      attack_hit_text[w_type].singular, v->describeBodySlot(part_hit).c_str());
     act(buf, FALSE, this, 0, v, TO_CHAR, ANSI_CYAN);
     sprintf(buf, "$N %ss $n's %s at $S %s.", type,
-      attack_hit_text[w_type].singular,
-      v->describeBodySlot(part_hit).c_str());
+      attack_hit_text[w_type].singular, v->describeBodySlot(part_hit).c_str());
     act(buf, TRUE, this, 0, v, TO_NOTVICT);
 
     return TRUE;

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1493,7 +1493,7 @@ class TBeing : public TThing {
     int preProcDam(spellNumT, int);
     int preProcDam(TBeing*, spellNumT, int);
     TBeing* findAnAttacker() const;
-    int damageEpilog(TBeing*, spellNumT);
+    int damageEpilog(TBeing*, int dam, spellNumT);
     void catchLostLink(TBeing*);
     void throwChar(TBeing* v, dirTypeT dir, bool throwerMove,
       silentTypeT silent, bool forceStand);

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1332,7 +1332,7 @@ class TBeing : public TThing {
     void doLand();
     int crashLanding(positionTypeT, bool force = FALSE, bool dam = TRUE,
       bool falling = false);
-    int stumble(TBeing* victim = nullptr);
+    int stumble(TBeing* victim);
     int doTurn(const char*, TBeing*);
     virtual void doMedit(const char*);
     void doPreen(sstring& argument);

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1332,7 +1332,7 @@ class TBeing : public TThing {
     void doLand();
     int crashLanding(positionTypeT, bool force = FALSE, bool dam = TRUE,
       bool falling = false);
-    int stumble(TBeing* victim);
+    int stumble(TBeing* opponent);
     int doTurn(const char*, TBeing*);
     virtual void doMedit(const char*);
     void doPreen(sstring& argument);

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -460,6 +460,7 @@ class TBeing : public TThing {
     virtual void setWimpy(int);
     virtual short int hitLimit() const;
     virtual int fallOffMount(TThing*, positionTypeT, bool death = FALSE);
+    int knockOffMount(int severity = 0);
     virtual bool hasQuestBit(int) const;
     virtual void setQuestBit(int);
     virtual void remQuestBit(int);
@@ -600,7 +601,6 @@ class TBeing : public TThing {
     void checkGuardiansLight();
     int checkAdvDefense();
     int doAdvDefense(TBeing*, TThing*, int*, int, wearSlotT);
-    
 
     // Postmaster
     void postmasterSendMail(const char*, TMonster*);
@@ -621,6 +621,7 @@ class TBeing : public TThing {
     void gainExpPerHit(TBeing*, double, int);
 
     int rideCheck(int);
+    int getRideMod();
     spellNumT mountSkillType() const;
     void calmMount(TBeing*);
     int advancedRidingBonus(TMonster*);
@@ -1009,7 +1010,8 @@ class TBeing : public TThing {
     int preCastCheck();
     int preDiscCheck(spellNumT);
     int doCast(const char*);
-    std::tuple<spellNumT, sstring> parseSpellNum(const sstring&, const sstring& = "") const;
+    std::tuple<spellNumT, sstring> parseSpellNum(const sstring&,
+      const sstring& = "") const;
     int parseTarget(spellNumT, char*, TThing** ret);
     int doTrigger(const char*);
     int doStore(const char*);
@@ -1330,9 +1332,8 @@ class TBeing : public TThing {
     void doScribe(const char*);
     void doFly();
     void doLand();
-    int crashLanding(positionTypeT, bool force = FALSE, bool dam = TRUE,
-      bool falling = false);
-    int stumble(TBeing* opponent);
+    int crashLanding(int severity = 0, bool falling = false);
+    int stumble();
     int doTurn(const char*, TBeing*);
     virtual void doMedit(const char*);
     void doPreen(sstring& argument);
@@ -1514,8 +1515,7 @@ class TBeing : public TThing {
     int hit(TBeing*, int pulse = -1);
     bool canCounterMove(int);
     bool canFocusedAvoidance(int);
-    int trySpringleap(TBeing*);
-      bool maybeDestroyLimb(wearSlotT part_hit, TBeing* v,
+    bool maybeDestroyLimb(wearSlotT part_hit, TBeing* v,
       const TBaseWeapon* weapon, spellNumT attackType);
     int damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
       int* dam);
@@ -1862,7 +1862,8 @@ class TBeing : public TThing {
 
     // Monk Skills
     int doQuiveringPalm(const char*, TBeing*);
-    int doSpringleap(sstring, bool, TBeing*);
+    int doSpringleap();
+    int springleap();
     int doShoulderThrow(const char*, TBeing*);
     int doGrappleMonk(const char*, int, TBeing*);
     int doFeignDeath();

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1332,6 +1332,7 @@ class TBeing : public TThing {
     void doLand();
     int crashLanding(positionTypeT, bool force = FALSE, bool dam = TRUE,
       bool falling = false);
+    int stumble(TBeing* victim = nullptr);
     int doTurn(const char*, TBeing*);
     virtual void doMedit(const char*);
     void doPreen(sstring& argument);

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -98,7 +98,7 @@ bool TBeing::isTanking() {
   //  Look through the current room and check each object.  If the object is
   //  fighting and I'm the one it is fighting, then I'm tanking.
   for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (contents = *it); ++it) {
+       it != roomp->stuff.end() && (contents = *it); ++it) {
     TBeing* tbg = dynamic_cast<TBeing*>(contents);
     if (tbg) {
       victim = tbg;
@@ -119,7 +119,7 @@ TBeing* findNextOpponent(TBeing* ch, TBeing* cur) {
   TBeing* tmp = NULL;
 
   for (StuffIter it = ch->roomp->stuff.begin(); it != ch->roomp->stuff.end();
-    ++it) {
+       ++it) {
     tmp = dynamic_cast<TBeing*>(*it);
     if (!tmp)
       continue;
@@ -212,7 +212,7 @@ void TBeing::deathCry() {
 
     if (in_room != new_room && canGo(door)) {
       for (StuffIter it = newR->stuff.begin();
-        it != newR->stuff.end() && (i = *it); ++it) {
+           it != newR->stuff.end() && (i = *it); ++it) {
         if (!inGrimhaven() && (tMons = dynamic_cast<TMonster*>(i))) {
           tMons->UA(1);
           tMons->UM(1);
@@ -253,7 +253,7 @@ void TBeing::deathCry() {
 
         if (!inGrimhaven()) {
           for (StuffIter it = newR->stuff.begin();
-            it != newR->stuff.end() && (i = *it); ++it) {
+               it != newR->stuff.end() && (i = *it); ++it) {
             TMonster* tmons = dynamic_cast<TMonster*>(i);
 
             if (tmons) {
@@ -512,9 +512,9 @@ int TBeing::rawKill(spellNumT dmg_type, TBeing* tKiller, float exp_lost) {
       format("Shopkeeper [%s] was just killed.  Find out how!") % getName());
 
     unsigned int shop_nr;
-    for (shop_nr = 0;
-      (shop_nr < shop_index.size()) && (shop_index[shop_nr].keeper != number);
-      shop_nr++)
+    for (shop_nr = 0; (shop_nr < shop_index.size()) &&
+                      (shop_index[shop_nr].keeper != number);
+         shop_nr++)
       ;
 
     if (shop_nr >= shop_index.size())
@@ -601,7 +601,7 @@ int TBeing::die(spellNumT dam_type, TBeing* tKiller) {
 
   // affectedData *aff;
   for (aff = affected; aff && aff->type != AFFECT_TEST_FIGHT_MOB;
-    aff = aff->next)
+       aff = aff->next)
     ;
   if (aff && !isPc()) {
     test_fight_death(this, dynamic_cast<TBeing*>(aff->be), aff->level);
@@ -679,7 +679,7 @@ bool TBeing::checkCut(TBeing* ch, wearSlotT part_hit, spellNumT wtype,
         act(buf, FALSE, this, item, ch, TO_CHAR);
 
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           temp = dynamic_cast<TBeing*>(t);
           if (!temp || (temp == this))
             continue;
@@ -755,7 +755,7 @@ bool TBeing::checkSmashed(TBeing* ch, wearSlotT part_hit, spellNumT wtype,
         act(buf, FALSE, this, item, ch, TO_CHAR);
 
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           temp = dynamic_cast<TBeing*>(t);
           if (!temp || (temp == this))
             continue;
@@ -836,7 +836,7 @@ bool TBeing::checkPierced(TBeing* ch, wearSlotT part_hit, spellNumT wtype,
         act(buf, TRUE, this, item, ch, TO_CHAR);
 
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           temp = dynamic_cast<TBeing*>(t);
           if (!temp || (temp == this))
             continue;
@@ -1073,8 +1073,8 @@ int TBeing::damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
   if (!percentChance(chance))
     return true;
 
-  // TODO (Cirius): Factor weapon/attacker's limb and victim's skin or eq
-  // material into equation somehow.
+    // TODO (Cirius): Factor weapon/attacker's limb and victim's skin or eq
+    // material into equation somehow.
 #if 0
   TThing* eq = v->equipment[part_hit];
   const auto* victMaterial = eq ? eq->getMaterialTypeNumbers()
@@ -1852,7 +1852,7 @@ void TBeing::stopFighting() {
     gCombatList = next_fighting;
   else {
     for (tmp = gCombatList; tmp && (tmp->next_fighting != this);
-      tmp = tmp->next_fighting)
+         tmp = tmp->next_fighting)
       ;
     if (!tmp) {
       vlogf(LOG_COMBAT,
@@ -3178,7 +3178,7 @@ int TBeing::specialAttack(TBeing* target, spellNumT skill,
     if (affectedBySpell(SKILL_INEVITABILITY)) {
       affectedData* ch_affected;
       for (ch_affected = affected; ch_affected;
-        ch_affected = ch_affected->next) {
+           ch_affected = ch_affected->next) {
         if (ch_affected->type == SKILL_INEVITABILITY) {
           affectRemove(ch_affected, SILENT_YES);
           break;
@@ -3270,7 +3270,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
           act("You are missed by $n as $e tries to bite you.", TRUE, this, 0, v,
             TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3298,7 +3298,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
       act("You are missed by $n as $e tries to shoot you.", TRUE, this, 0, v,
         TO_VICT);
     for (StuffIter it = roomp->stuff.begin();
-      it != roomp->stuff.end() && (t = *it); ++it) {
+         it != roomp->stuff.end() && (t = *it); ++it) {
       other = dynamic_cast<TBeing*>(t);
       if (!other)
         continue;
@@ -3325,7 +3325,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
           act("You are missed by $n as $e thrusts at you.", TRUE, this, 0, v,
             TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3353,7 +3353,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
           act("You are missed by $n as $e stabs wildly.", TRUE, this, 0, v,
             TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3384,7 +3384,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
         if (v->desc && !(v->desc->autobits & AUTO_NOSPAM))
           act(buf, TRUE, this, 0, v, TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3428,7 +3428,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
         if (v->desc && !(v->desc->autobits & AUTO_NOSPAM))
           act("You are missed by $n.", TRUE, this, 0, v, TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3461,7 +3461,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
           act("You are missed by $n as $e swings wildly.", TRUE, this, 0, v,
             TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3493,7 +3493,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
         if (v->desc && !(v->desc->autobits & AUTO_NOSPAM))
           act(buf, TRUE, this, 0, v, TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3537,7 +3537,7 @@ int TBeing::missVictim(TBeing* v, TThing* weapon, spellNumT wtype) {
         if (v->desc && !(v->desc->autobits & AUTO_NOSPAM))
           act("You are missed by $n.", TRUE, this, 0, v, TO_VICT);
         for (StuffIter it = roomp->stuff.begin();
-          it != roomp->stuff.end() && (t = *it); ++it) {
+             it != roomp->stuff.end() && (t = *it); ++it) {
           other = dynamic_cast<TBeing*>(t);
           if (!other)
             continue;
@@ -3653,7 +3653,7 @@ void TBeing::normalHitMessage(TBeing* v, TThing* weapon, spellNumT w_type,
   w_type -= TYPE_MIN_HIT;
 
   for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (t = *it); ++it) {
+       it != roomp->stuff.end() && (t = *it); ++it) {
     other = dynamic_cast<TBeing*>(t);
     if (!other || !other->desc || (other == this) || (other == v) ||
         !other->awake())
@@ -3823,7 +3823,7 @@ int TBeing::checkShield(TBeing* v, TThing* weapon, wearSlotT part_hit,
     act("$n parries your blow with $p.", TRUE, v, shield, this, TO_VICT,
       ANSI_CYAN);
   for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (t = *it); ++it) {
+       it != roomp->stuff.end() && (t = *it); ++it) {
     other = dynamic_cast<TBeing*>(t);
     if (!other)
       continue;
@@ -4394,7 +4394,7 @@ int TBeing::oneHit(TBeing* vict, primaryTypeT isprimary, TThing* weapon,
       // Remove inevitability if we hit.
       if (affectedBySpell(SKILL_INEVITABILITY)) {
         for (ch_affected = affected; ch_affected;
-          ch_affected = ch_affected->next) {
+             ch_affected = ch_affected->next) {
           if (ch_affected->type == SKILL_INEVITABILITY) {
             affectRemove(ch_affected, SILENT_YES);
             break;
@@ -4746,15 +4746,12 @@ bool TBeing::canFight(TBeing* target) {
   }
 
   if (riding) {
-    // make these checks trivial in nature by forcing them to fail
-    // twice before falling off
     if (dynamic_cast<TBeing*>(riding)) {
-      if (!rideCheck(-5) && !rideCheck(-5)) {
-        rc = fallOffMount(riding, POSITION_SITTING);
-        if (IS_SET_DELETE(rc, DELETE_THIS))
-          return DELETE_THIS;
-        return FALSE;
-      }
+      rc = knockOffMount();
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      if (rc)
+        return false;
     } else if (dynamic_cast<TMonster*>(this) && !desc) {
       if (fight() && !isPet(PETTYPE_PET | PETTYPE_CHARM | PETTYPE_THRALL) &&
           ::number(0, 1)) {
@@ -4764,14 +4761,16 @@ bool TBeing::canFight(TBeing* target) {
   }
   for (t = rider; t; t = t->nextRider) {
     TBeing* tb = dynamic_cast<TBeing*>(t);
-    if (tb && !tb->rideCheck(-10) && !tb->rideCheck(-10)) {
-      rc = tb->fallOffMount(this, POSITION_SITTING);
-      if (IS_SET_DELETE(rc, DELETE_THIS)) {
-        delete tb;
-        tb = NULL;
-      }
-      return FALSE;
+    if (!tb)
+      continue;
+    rc = tb->knockOffMount();
+    if (IS_SET_DELETE(rc, DELETE_THIS)) {
+      delete tb;
+      tb = nullptr;
+      return false;
     }
+    if (rc)
+      return false;
   }
   // make um fly if appropriate
   if (!target->isPc() && target->canFly() && !target->isFlying() &&
@@ -4937,7 +4936,7 @@ int TBeing::tellStatus(int dam, bool same, bool flying) {
 
     if (!inGrimhaven()) {
       for (StuffIter it = roomp->stuff.begin();
-        it != roomp->stuff.end() && (i = *it); ++it) {
+           it != roomp->stuff.end() && (i = *it); ++it) {
         TMonster* tmons = dynamic_cast<TMonster*>(i);
         if (tmons && tmons != this) {
           tmons->UA(1);
@@ -5030,7 +5029,7 @@ int TBeing::tellStatus(int dam, bool same, bool flying) {
     }
   }
   if (flying) {
-    rc = crashLanding(getPosition(), FALSE, 0);
+    rc = crashLanding();
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
   }
@@ -5268,7 +5267,7 @@ TBeing* TBeing::findAnAttacker() const {
     return NULL;
 
   for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (tmp = *it); ++it) {
+       it != roomp->stuff.end() && (tmp = *it); ++it) {
     TBeing* tbt = dynamic_cast<TBeing*>(tmp);
     if (!tbt)
       continue;
@@ -6278,7 +6277,7 @@ void doToughness(TBeing* ch) {
 
   if (ch->affectedBySpell(SKILL_TOUGHNESS)) {
     for (ch_affected = ch->affected; ch_affected;
-      ch_affected = ch_affected->next) {
+         ch_affected = ch_affected->next) {
       if (ch_affected->type == SKILL_TOUGHNESS) {
         // set the mod and remove the affect so we can add it fresh
         mod += ch_affected->modifier2;
@@ -6319,7 +6318,7 @@ void TBeing::doBloodlust() {
   long mod = 0;
   if (affectedBySpell(SKILL_BLOODLUST)) {
     for (auto* ch_affected = affected; ch_affected;
-      ch_affected = ch_affected->next) {
+         ch_affected = ch_affected->next) {
       if (ch_affected->type == SKILL_BLOODLUST) {
         // set the mod and remove the affect so we can add it fresh
         mod = ch_affected->modifier;

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -4745,13 +4745,18 @@ bool TBeing::canFight(TBeing* target) {
     return FALSE;
   }
 
+  // Pre-check on every attack so swinging from horseback doesn't spam
+  // knockOffMount's hang-on flavor. Only escalate when the rider is already
+  // struggling. Mirror the pattern used in damage.cc.
   if (riding) {
     if (dynamic_cast<TBeing*>(riding)) {
-      rc = knockOffMount();
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      if (rc)
-        return false;
+      if (!rideCheck(0)) {
+        rc = knockOffMount();
+        if (IS_SET_DELETE(rc, DELETE_THIS))
+          return DELETE_THIS;
+        if (rc)
+          return false;
+      }
     } else if (dynamic_cast<TMonster*>(this) && !desc) {
       if (fight() && !isPet(PETTYPE_PET | PETTYPE_CHARM | PETTYPE_THRALL) &&
           ::number(0, 1)) {
@@ -4762,6 +4767,8 @@ bool TBeing::canFight(TBeing* target) {
   for (t = rider; t; t = t->nextRider) {
     TBeing* tb = dynamic_cast<TBeing*>(t);
     if (!tb)
+      continue;
+    if (tb->rideCheck(0))
       continue;
     rc = tb->knockOffMount();
     if (IS_SET_DELETE(rc, DELETE_THIS)) {

--- a/code/code/misc/damage.cc
+++ b/code/code/misc/damage.cc
@@ -632,7 +632,7 @@ int TBeing::applyDamage(TBeing* v, int dam, spellNumT dmg_type) {
   rc = v->tellStatus(dam, (this == v), flying);
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
-  rc = damageEpilog(v, dmg_type);
+  rc = damageEpilog(v, dam, dmg_type);
   if (IS_SET_DELETE(rc, DELETE_VICT))
     return DELETE_VICT;
 
@@ -641,7 +641,7 @@ int TBeing::applyDamage(TBeing* v, int dam, spellNumT dmg_type) {
 }
 
 // DELETE_VICT or FALSE
-int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
+int TBeing::damageEpilog(TBeing* v, int dam, spellNumT dmg_type) {
   char buf[512], buf2[256];
   sstring taunt_buf;
   sstring discord_taunt_msg;
@@ -666,12 +666,20 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
   if (isAffected(AFF_INVISIBLE) && this != v)
     appear();
 
+  // Pre-check on every hit so routine combat doesn't spam knockOffMount's
+  // hang-on flavor. Severity scales with damage magnitude (capped) so trivial
+  // hits stay trivial and crits don't auto-throw. Only escalate to
+  // knockOffMount (which rolls again as its own save) when the rider already
+  // failed the pre-check.
+  int rideSeverity = std::min(dam, 50);
   if (v->riding && dynamic_cast<TBeing*>(v->riding)) {
-    rc = v->knockOffMount(3);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_VICT;
-    if (rc)
-      v->addToWait(combatRound(2));
+    if (!v->rideCheck(-rideSeverity)) {
+      rc = v->knockOffMount(rideSeverity);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_VICT;
+      if (rc)
+        v->addToWait(combatRound(2));
+    }
   } else if (v->riding && dynamic_cast<TMonster*>(v) && !v->desc) {
     if (::number(0, 1)) {
       dynamic_cast<TMonster*>(v)->standUp();
@@ -683,7 +691,9 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
     TBeing* tb = dynamic_cast<TBeing*>(t);
     if (!tb)
       continue;
-    rc = tb->knockOffMount(3);
+    if (tb->rideCheck(-rideSeverity))
+      continue;
+    rc = tb->knockOffMount(rideSeverity);
     if (IS_SET_DELETE(rc, DELETE_THIS)) {
       delete tb;
       tb = nullptr;

--- a/code/code/misc/damage.cc
+++ b/code/code/misc/damage.cc
@@ -667,12 +667,11 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
     appear();
 
   if (v->riding && dynamic_cast<TBeing*>(v->riding)) {
-    if (!v->rideCheck(-3)) {
-      rc = v->fallOffMount(v->riding, POSITION_SITTING);
+    rc = v->knockOffMount(3);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_VICT;
+    if (rc)
       v->addToWait(combatRound(2));
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_VICT;
-    }
   } else if (v->riding && dynamic_cast<TMonster*>(v) && !v->desc) {
     if (::number(0, 1)) {
       dynamic_cast<TMonster*>(v)->standUp();
@@ -682,14 +681,14 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
   for (t = v->rider; t; t = t2) {
     t2 = t->nextRider;
     TBeing* tb = dynamic_cast<TBeing*>(t);
-    // force a doubly failed rideCheck for riders of victim
-    if (tb && !tb->rideCheck(-3) && !tb->rideCheck(-3)) {
-      rc = tb->fallOffMount(v, POSITION_SITTING);
+    if (!tb)
+      continue;
+    rc = tb->knockOffMount(3);
+    if (IS_SET_DELETE(rc, DELETE_THIS)) {
+      delete tb;
+      tb = nullptr;
+    } else if (rc) {
       tb->addToWait(combatRound(2));
-      if (IS_SET_DELETE(rc, DELETE_THIS)) {
-        delete tb;
-        tb = NULL;
-      }
     }
   }
 

--- a/code/code/misc/mobact.cc
+++ b/code/code/misc/mobact.cc
@@ -1217,7 +1217,7 @@ int TMonster::monkMove(TBeing& vict) {
   if (getPosition() <= POSITION_SITTING) {
     if (!doesKnowSkill(SKILL_SPRINGLEAP))
       setSkillValue(SKILL_SPRINGLEAP, min(100, 10 + GetMaxLevel() * 4));
-    return doSpringleap("", false, &vict);
+    return springleap();
   } else {
 #if (0)
     if (GetMaxLevel() > 30 && !::number(0, 4)) {
@@ -1617,15 +1617,13 @@ static spellNumT get_mage_spell(TMonster& ch, TBeing& vict, bool& on_me) {
     spell = SPELL_CHAIN_LIGHTNING;
     if (!::number(0, 4) && (cutoff < discArray[spell]->start) &&
         ch.doesKnowSkill(spell) && (ch.getSkillValue(spell) > 33)) {
-      act("$n utters the words, 'Zap Zap Zap!'", TRUE, &ch, 0, 0,
-        TO_ROOM);
+      act("$n utters the words, 'Zap Zap Zap!'", TRUE, &ch, 0, 0, TO_ROOM);
       return spell;
     }
     spell = SPELL_LIGHTNING_BOLT;
     if (!::number(0, 2) && (cutoff < discArray[spell]->start) &&
         ch.doesKnowSkill(spell) && (ch.getSkillValue(spell) > 33)) {
-      act("$n utters the words, 'Time to fry!'", TRUE, &ch, 0, 0,
-        TO_ROOM);
+      act("$n utters the words, 'Time to fry!'", TRUE, &ch, 0, 0, TO_ROOM);
       return spell;
     }
     spell = SPELL_IMMOBILIZE;
@@ -1868,61 +1866,78 @@ static spellNumT get_mage_spell(TMonster& ch, TBeing& vict, bool& on_me) {
 
 // SHAMAN
 
-enum ShamanSpellCategory { SHAMAN_OFFENSIVE, SHAMAN_SITUATIONAL };
+enum ShamanSpellCategory {
+  SHAMAN_OFFENSIVE,
+  SHAMAN_SITUATIONAL
+};
 
 struct ShamanSpellEntry {
-  spellNumT spell;
-  int weight;
-  ShamanSpellCategory category;
-  const char* message;
+    spellNumT spell;
+    int weight;
+    ShamanSpellCategory category;
+    const char* message;
 };
 
 static const int SHAMAN_MIN_SKILL = 60;
 
 static const ShamanSpellEntry shamanSpellTable[] = {
   // SITUATIONAL spells — bypass tier filtering
-  {SPELL_CHASE_SPIRIT,    70, SHAMAN_SITUATIONAL, "$n utters the words, 'Spirits be gone from this pathetic one!'"},
-  {SPELL_INTIMIDATE,      40, SHAMAN_SITUATIONAL, "$n utters the invokation, 'Go Away! Leave me the Hell Alone!'"},
-  {SPELL_FLATULENCE,      20, SHAMAN_SITUATIONAL, "$n utters the invokation, 'He who smelt it, dealt it!'"},
-  {SPELL_STUPIDITY,       10, SHAMAN_SITUATIONAL, "$n utters the invokation, 'DUUHHHHHHHHHHH!!!!!!!!!'"},
-  {SPELL_DEATH_MIST,      10, SHAMAN_SITUATIONAL, "$n utters the invokation, 'Chowe Kondiz Bub!'"},
+  {SPELL_CHASE_SPIRIT, 70, SHAMAN_SITUATIONAL,
+    "$n utters the words, 'Spirits be gone from this pathetic one!'"},
+  {SPELL_INTIMIDATE, 40, SHAMAN_SITUATIONAL,
+    "$n utters the invokation, 'Go Away! Leave me the Hell Alone!'"},
+  {SPELL_FLATULENCE, 20, SHAMAN_SITUATIONAL,
+    "$n utters the invokation, 'He who smelt it, dealt it!'"},
+  {SPELL_STUPIDITY, 10, SHAMAN_SITUATIONAL,
+    "$n utters the invokation, 'DUUHHHHHHHHHHH!!!!!!!!!'"},
+  {SPELL_DEATH_MIST, 10, SHAMAN_SITUATIONAL,
+    "$n utters the invokation, 'Chowe Kondiz Bub!'"},
 
   // OFFENSIVE spells — subject to tier filtering
-  {SPELL_LIFE_LEECH,      20, SHAMAN_OFFENSIVE, "$n utters the invokation, 'I'm gonna suck you dry!!!'"},
-  {SPELL_LICH_TOUCH,      80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Lich me, SUCKAH!!!'"},
-  {SPELL_RAZE,            80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Rubbem Ow!'"},
-  {SPELL_VAMPIRIC_TOUCH,  40, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Ahh!! The BLUUD!!!!!'"},
-  {SPELL_SOUL_TWIST,      30, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Internal Pretzel!'"},
-  {SPELL_SQUISH,          10, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Firsta you takka da dough like-a dis...'"},
-  {SPELL_DISTORT,         20, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Houngan's Delight!'"},
-  {SPELL_DEATHWAVE,       80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Deadly Blackness!'"},
-  {SPELL_AQUATIC_BLAST,   60, SHAMAN_OFFENSIVE, "$n utters the invokation, 'River run DEEEEEEEEEEP!!!!'"},
-  {SPELL_BLOOD_BOIL,      60, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Bubble, bubble. BOILING BLOOD!!'"},
-  {SPELL_CARDIAC_STRESS,  80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Don't go breakin' my heart!'"},
+  {SPELL_LIFE_LEECH, 20, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'I'm gonna suck you dry!!!'"},
+  {SPELL_LICH_TOUCH, 80, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Lich me, SUCKAH!!!'"},
+  {SPELL_RAZE, 80, SHAMAN_OFFENSIVE, "$n utters the invokation, 'Rubbem Ow!'"},
+  {SPELL_VAMPIRIC_TOUCH, 40, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Ahh!! The BLUUD!!!!!'"},
+  {SPELL_SOUL_TWIST, 30, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Internal Pretzel!'"},
+  {SPELL_SQUISH, 10, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Firsta you takka da dough like-a dis...'"},
+  {SPELL_DISTORT, 20, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Houngan's Delight!'"},
+  {SPELL_DEATHWAVE, 80, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Deadly Blackness!'"},
+  {SPELL_AQUATIC_BLAST, 60, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'River run DEEEEEEEEEEP!!!!'"},
+  {SPELL_BLOOD_BOIL, 60, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Bubble, bubble. BOILING BLOOD!!'"},
+  {SPELL_CARDIAC_STRESS, 80, SHAMAN_OFFENSIVE,
+    "$n utters the invokation, 'Don't go breakin' my heart!'"},
 };
 
-static bool checkShamanSituational(TMonster& ch, TBeing& vict, spellNumT spell) {
+static bool checkShamanSituational(TMonster& ch, TBeing& vict,
+  spellNumT spell) {
   switch (spell) {
     case SPELL_CHASE_SPIRIT:
       return (vict.affectedBySpell(SPELL_HASTE) ||
-              vict.affectedBySpell(SPELL_CELERITE) ||
-              vict.affectedBySpell(SPELL_PLASMA_MIRROR) ||
-              vict.affectedBySpell(SPELL_THORNFLESH) ||
-              vict.affectedBySpell(SPELL_GILLS_OF_FLESH) ||
-              vict.affectedBySpell(SPELL_AQUALUNG)) &&
+               vict.affectedBySpell(SPELL_CELERITE) ||
+               vict.affectedBySpell(SPELL_PLASMA_MIRROR) ||
+               vict.affectedBySpell(SPELL_THORNFLESH) ||
+               vict.affectedBySpell(SPELL_GILLS_OF_FLESH) ||
+               vict.affectedBySpell(SPELL_AQUALUNG)) &&
              !(vict.affectedBySpell(SPELL_FAERIE_FIRE) ||
                vict.affectedBySpell(SPELL_BIND));
     case SPELL_INTIMIDATE:
-      return !ch.pissed() &&
-             (ch.getHit() < ch.hitLimit() / 8) &&
+      return !ch.pissed() && (ch.getHit() < ch.hitLimit() / 8) &&
              !ch.affectedBySpell(AFFECT_TEST_FIGHT_MOB);
     case SPELL_FLATULENCE:
       return ch.attackers >= 2;
     case SPELL_STUPIDITY:
       return !vict.affectedBySpell(SPELL_STUPIDITY);
     case SPELL_DEATH_MIST:
-      return ch.attackers >= 2 &&
-             !vict.affectedBySpell(SPELL_DEATH_MIST);
+      return ch.attackers >= 2 && !vict.affectedBySpell(SPELL_DEATH_MIST);
     default:
       return false;
   }
@@ -1955,7 +1970,11 @@ static spellNumT get_shaman_spell(TMonster& ch, TBeing& vict, bool& on_me) {
   }
 
   // 2. Build candidate pool
-  struct Candidate { spellNumT spell; int weight; const char* message; };
+  struct Candidate {
+      spellNumT spell;
+      int weight;
+      const char* message;
+  };
   std::vector<Candidate> candidates;
 
   for (const auto& entry : shamanSpellTable) {
@@ -1981,9 +2000,8 @@ static spellNumT get_shaman_spell(TMonster& ch, TBeing& vict, bool& on_me) {
   // 2b. Life-drain boost: when hurt, add the best known drain spell again
   //     to increase its selection weight (may duplicate an existing entry)
   if (ch.getHit() < ch.hitLimit() * 3 / 4) {
-    static const spellNumT drainSpells[] = {
-      SPELL_LICH_TOUCH, SPELL_VAMPIRIC_TOUCH, SPELL_LIFE_LEECH
-    };
+    static const spellNumT drainSpells[] = {SPELL_LICH_TOUCH,
+      SPELL_VAMPIRIC_TOUCH, SPELL_LIFE_LEECH};
     for (auto spell : drainSpells) {
       if (!ch.doesKnowSkill(spell))
         continue;
@@ -2245,7 +2263,7 @@ static spellNumT get_cleric_heal_spell(TMonster& ch, TBeing& targ) {
   }
 
   // cure blindness
-  if(ch.doesKnowSkill(SPELL_CURE_BLINDNESS) &&
+  if (ch.doesKnowSkill(SPELL_CURE_BLINDNESS) &&
       ch.getSkillValue(SPELL_CURE_BLINDNESS) > 33 &&
 #if 0
      targ.isAffected(AFF_BLIND)) {
@@ -2268,10 +2286,12 @@ static spellNumT get_cleric_heal_spell(TMonster& ch, TBeing& targ) {
   if (ch.doesKnowSkill(SPELL_CURE_DISEASE) &&
       ch.getSkillValue(SPELL_CURE_DISEASE) > 33) {
     if (targ.hasDisease(DISEASE_COLD) || targ.hasDisease(DISEASE_FLU) ||
-      targ.hasDisease(DISEASE_FROSTBITE) || targ.hasDisease(DISEASE_LEPROSY) ||
-      targ.hasDisease(DISEASE_PLAGUE) || targ.hasDisease(DISEASE_PNEUMONIA) ||
-      targ.hasDisease(DISEASE_DYSENTERY) || targ.hasDisease(DISEASE_GANGRENE) ||
-      targ.hasDisease(DISEASE_SCURVY) || targ.hasDisease(DISEASE_SYPHILIS)) {
+        targ.hasDisease(DISEASE_FROSTBITE) ||
+        targ.hasDisease(DISEASE_LEPROSY) || targ.hasDisease(DISEASE_PLAGUE) ||
+        targ.hasDisease(DISEASE_PNEUMONIA) ||
+        targ.hasDisease(DISEASE_DYSENTERY) ||
+        targ.hasDisease(DISEASE_GANGRENE) || targ.hasDisease(DISEASE_SCURVY) ||
+        targ.hasDisease(DISEASE_SYPHILIS)) {
       return SPELL_CURE_DISEASE;
     }
   }

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3514,8 +3514,8 @@ int TBeing::stumble(TBeing* victim) {
     return FALSE;
 
   if (isFlying() && roomp->isFallSector()) {
-    sendTo(format("%sYou falter in the air, but stay aloft!%s\n\r") % green() %
-           norm());
+    act("<g>You falter in the air, but stay aloft!<1>", true, this, nullptr,
+      nullptr, TO_CHAR);
     act("<g>$n falters in the air, but stays aloft!<1>", true, this, nullptr,
       nullptr, TO_ROOM);
     return FALSE;
@@ -3523,14 +3523,13 @@ int TBeing::stumble(TBeing* victim) {
 
   if (!isAgile(0)) {
     if (isFlying()) {
-      sendTo(
-        format("%sYou stumble out of the air and topple over.%s\n\r") % red() %
-        norm());
+      act("<r>You stumble out of the air and topple over.<1>", true, this,
+        nullptr, nullptr, TO_CHAR);
       act("<r>$n stumbles out of the air and topples over.<1>", true, this,
         nullptr, nullptr, TO_ROOM);
     } else {
-      sendTo(
-        format("%sYou stumble and topple over.%s\n\r") % red() % norm());
+      act("<r>You stumble and topple over.<1>", true, this, nullptr, nullptr,
+        TO_CHAR);
       act("<r>$n stumbles and topples over.<1>", true, this, nullptr, nullptr,
         TO_ROOM);
     }
@@ -3545,14 +3544,13 @@ int TBeing::stumble(TBeing* victim) {
   } else {
     setPosition(POSITION_STANDING);
     if (isFlying()) {
-      sendTo(
-        format("%sYou stumble out of the air, but land on your feet!%s\n\r") %
-        green() % norm());
+      act("<g>You stumble out of the air, but land on your feet!<1>", true,
+        this, nullptr, nullptr, TO_CHAR);
       act("<g>$n stumbles out of the air, but lands on $s feet!<1>", true, this,
         nullptr, nullptr, TO_ROOM);
     } else {
-      sendTo(
-        format("%sYou stumble, but catch yourself!%s\n\r") % green() % norm());
+      act("<g>You stumble, but catch yourself!<1>", true, this, nullptr,
+        nullptr, TO_CHAR);
       act("<g>$n stumbles, but catches $mself!<1>", true, this, nullptr,
         nullptr, TO_ROOM);
     }

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3518,25 +3518,32 @@ int TBeing::stumble(TBeing* victim) {
 
     int stumbleDam = dice(1, 4);
 
+    bool victimDeleted = false;
     TBeing* springTarget = victim ? victim : fight();
     if (springTarget) {
       int rc = trySpringleap(springTarget);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       if (IS_SET_DELETE(rc, DELETE_VICT))
-        return DELETE_VICT;
+        victimDeleted = true;
       if (rc)
         stumbleDam /= 2;
     }
 
     if (reconcileDamage(this, stumbleDam, DAMAGE_FALL) == -1)
-      return DELETE_THIS;
+      return DELETE_THIS | (victimDeleted ? DELETE_VICT : 0);
+    if (victimDeleted)
+      return DELETE_VICT;
   } else {
-    setPosition(POSITION_STANDING);
-    if (isFlying()) {
-      sendTo("You stumble, but quickly recover your footing!\n\r");
-      act("$n stumbles, but quickly recovers!", true, this, nullptr, nullptr, TO_ROOM);
+    if (isFlying() && roomp->isFallSector()) {
+      sendTo("You falter in the air, but quickly recover!\n\r");
+      act("$n falters in the air, but quickly recovers!", true, this, nullptr, nullptr, TO_ROOM);
+    } else if (isFlying()) {
+      setPosition(POSITION_STANDING);
+      sendTo("You stumble out of the air, but land on your feet!\n\r");
+      act("$n stumbles out of the air, but lands on $s feet!", true, this, nullptr, nullptr, TO_ROOM);
     } else {
+      setPosition(POSITION_STANDING);
       sendTo("You stumble, but catch yourself!\n\r");
       act("$n stumbles, but catches $mself!", true, this, nullptr, nullptr, TO_ROOM);
     }

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -808,7 +808,7 @@ int TBeing::rawMove(dirTypeT dir) {
         sendTo(
           "Oops, you must have crashed into one of those purple elephants you "
           "keep seeing.\n\r");
-        rc = crashLanding(POSITION_SITTING);
+        rc = crashLanding();
         if (IS_SET_DELETE(rc, DELETE_THIS))
           return DELETE_THIS;
         return FALSE;
@@ -1194,7 +1194,7 @@ int TBeing::moveGroup(dirTypeT dir) {
         } else {
           followData* found = NULL;
           for (found = followers; found && found->follower != tft;
-            found = found->next)
+               found = found->next)
             ;
           if (!found) {
             vlogf(LOG_BUG,
@@ -1478,7 +1478,7 @@ int TBeing::displayMove(dirTypeT dir, int was_in, int total) {
   --(*this);
   *rp1 += *this;
   for (StuffIter it = rp1->stuff.begin(); it != rp1->stuff.end() && (t = *it);
-    ++it) {
+       ++it) {
     TBeing* ch = dynamic_cast<TBeing*>(t);
     if (!ch)
       continue;
@@ -1566,7 +1566,7 @@ int TBeing::displayMove(dirTypeT dir, int was_in, int total) {
     sprintf(tmp + strlen(tmp), " [%d]", total);
 
   for (StuffIter it = rp2->stuff.begin(); it != rp2->stuff.end() && (t = *it);
-    ++it) {
+       ++it) {
     TBeing* tbt = dynamic_cast<TBeing*>(t);
     if (!tbt)
       continue;
@@ -1672,14 +1672,14 @@ int TBeing::genericMovedIntoRoom(TRoom* rp, int was_in,
   int groupcount = 0;  // used to make mobs not go superaggro on groups - dash
 
   for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (t3 = *it); ++it) {
+       it != roomp->stuff.end() && (t3 = *it); ++it) {
     TBeing* tbt = dynamic_cast<TBeing*>(t3);
     if (tbt && inGroup(*tbt))
       groupcount++;
   }
   if (was_in != -1) {
     for (StuffIter it = real_roomp(was_in)->stuff.begin();
-      it != real_roomp(was_in)->stuff.end() && (t3 = *it); ++it) {
+         it != real_roomp(was_in)->stuff.end() && (t3 = *it); ++it) {
       TBeing* tbt = dynamic_cast<TBeing*>(t3);
       if (tbt && inGroup(*tbt))
         groupcount++;
@@ -2271,7 +2271,7 @@ bool has_key(TBeing* ch, int key) {
 
   // check inv
   for (StuffIter it = ch->stuff.begin(); it != ch->stuff.end() && (t = *it);
-    ++it) {
+       ++it) {
     o = dynamic_cast<TObj*>(t);
     if (!o)
       continue;
@@ -2282,7 +2282,7 @@ bool has_key(TBeing* ch, int key) {
     if (!ring)
       continue;
     for (StuffIter it = ring->stuff.begin();
-      it != ring->stuff.end() && (t2 = *it); ++it) {
+         it != ring->stuff.end() && (t2 = *it); ++it) {
       o = dynamic_cast<TObj*>(t2);
       if (!o)
         continue;
@@ -2545,7 +2545,7 @@ int TBeing::portalLeaveCheck(char* argum, cmdTypeT cmd) {
 
   one_argument(argum, arg, cElements(arg));
   for (StuffIter it = roomp->stuff.begin();
-    it != roomp->stuff.end() && (t = *it); ++it) {
+       it != roomp->stuff.end() && (t = *it); ++it) {
     o = dynamic_cast<TPortal*>(t);
     if (o && (((cmd == CMD_LEAVE) && (!*arg || isname(arg, o->name))) ||
                ((cmd == CMD_EXITS) && *arg && isname(arg, o->name)))) {
@@ -3445,71 +3445,50 @@ void TBeing::doLand() {
   setPosition(POSITION_STANDING);
 }
 
-int TBeing::crashLanding(positionTypeT pos, bool force, bool dam,
-  bool falling) {
-  if (force) {
-    // option to force this
-    setPosition(pos);
-    sendTo(COLOR_ROOMS,
-      format("You smash into the %s hard!\n\r") % roomp->describeGround());
-    act("$n tumbles end over end as $e crash lands!", TRUE, this, 0, 0,
-      TO_ROOM);
-  } else if (!isFlying()) {
-    setPosition(pos);
-    if ((getPosition() >= POSITION_RESTING) &&
-        ((pos == POSITION_FLYING) || roomp->isFlyingSector())) {
-      sendTo("You start flying around.\n\r");
-      act("$n starts to fly up in the air.", TRUE, this, 0, 0, TO_ROOM);
-      setPosition(POSITION_FLYING);
-      return FALSE;
-    } else if (roomp->isFallSector()) {
-      if (falling || IS_SET_DELETE(checkFalling(), DELETE_THIS))
-        return DELETE_THIS;
-      return TRUE;
-    }
-    return FALSE;
-  } else if (roomp->isFlyingSector()) {
-    if (pos == POSITION_FLYING) {
-      return FALSE;
-    } else if (getPosition() >= POSITION_RESTING) {
-      sendTo("You start flying around.\n\r");
-      act("$n starts to fly up in the air.", TRUE, this, 0, 0, TO_ROOM);
-      setPosition(POSITION_FLYING);
-      return FALSE;
-    } else {
-      setPosition(pos);
-      return FALSE;
-    }
-  } else if (roomp->isFallSector()) {
-    setPosition(pos);
+// Knock the character to the ground. Higher severity makes the agility roll
+// harder, biasing toward POSITION_RESTING over POSITION_SITTING. Severity is
+// currently a placeholder int; future work will tie it to skill damage so each
+// caller passes a meaningful magnitude. Invokes springleap() for monks (return
+// ignored) so they may bounce back to standing in a single chain. Only
+// downgrades position — characters already at or below the rolled outcome keep
+// their current state.
+int TBeing::crashLanding(int severity, bool falling) {
+  positionTypeT newPos =
+    isAgile(-severity) ? POSITION_SITTING : POSITION_RESTING;
+  bool changed = (getPosition() > newPos);
+  if (changed)
+    setPosition(newPos);
+
+  // In fall sectors checkFalling handles the narrative — either the character
+  // plummets (with its own messaging) or is held in place by an upstream
+  // condition. Either way, the sit/sprawl flavor would be misleading, so skip
+  // the position-change messaging here.
+  if (roomp->isFallSector()) {
     if (falling || IS_SET_DELETE(checkFalling(), DELETE_THIS))
       return DELETE_THIS;
-    return TRUE;
-  } else if (doesKnowSkill(SKILL_CATFALL) && bSuccess(SKILL_CATFALL)) {
-    setPosition(POSITION_STANDING);
-    act("$n drops gracefully onto the $g.", FALSE, this, 0, 0, TO_ROOM);
-    sendTo(COLOR_ROOMS,
-      format("You drop gracefully to the %s.\n\r") % roomp->describeGround());
-    dam = false;
-  } else {
-    // Flying person
-    setPosition(pos);
-    sendTo(COLOR_ROOMS,
-      format("You smash into the %s hard!\n\r") % roomp->describeGround());
-    act("$n tumbles end over end as $e crash lands!", TRUE, this, 0, 0,
+  } else if (changed && getPosition() == POSITION_SITTING) {
+    act("<y>You drop to a sit on the $g.<1>", true, this, nullptr, nullptr,
+      TO_CHAR);
+    act("<y>$n drops to a sit on the $g.<1>", true, this, nullptr, nullptr,
+      TO_ROOM);
+  } else if (changed && getPosition() == POSITION_RESTING) {
+    act("<r>You sprawl across the $g.<1>", true, this, nullptr, nullptr,
+      TO_CHAR);
+    act("<r>$n sprawls across the $g.<1>", true, this, nullptr, nullptr,
       TO_ROOM);
   }
 
-  if (dam) {
-    // some things skip damage.  (e.g. already dead when crashed)
-    if (reconcileDamage(this, ::number(2, 8), DAMAGE_FALL) == -1)
-      return DELETE_THIS;
-  }
+  if (doesKnowSkill(SKILL_SPRINGLEAP))
+    springleap();
 
   return TRUE;
 }
 
-int TBeing::stumble(TBeing* opponent) {
+// Attacker self-stumble after a failed attempt. Two layered agility rolls give
+// agile characters a meaningfully better worst case: first roll here decides
+// whether the attacker stays standing; on failure crashLanding rolls again to
+// decide sitting vs. resting. The compounded distribution is intentional.
+int TBeing::stumble() {
   if (!hasLegs())
     return FALSE;
 
@@ -3534,13 +3513,9 @@ int TBeing::stumble(TBeing* opponent) {
         TO_ROOM);
     }
 
-    int rc = crashLanding(POSITION_SITTING);
+    int rc = crashLanding();
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
-
-    rc = trySpringleap(opponent);
-    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
-      return rc;
   } else {
     if (isFlying()) {
       act("<g>You stumble out of the air, but land on your feet!<1>", true,

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3524,15 +3524,15 @@ int TBeing::stumble(TBeing* victim) {
   if (!isAgile(0)) {
     if (isFlying()) {
       sendTo(
-        format("%sYou stumble out of the air and land on your butt!%s\n\r") %
-        red() % norm());
-      act("<r>$n stumbles out of the air and lands on $s butt!<1>", true, this,
+        format("%sYou stumble out of the air and topple over.%s\n\r") % red() %
+        norm());
+      act("<r>$n stumbles out of the air and topples over.<1>", true, this,
         nullptr, nullptr, TO_ROOM);
     } else {
       sendTo(
-        format("%sYou stumble and fall on your butt!%s\n\r") % red() % norm());
-      act("<r>$n stumbles and falls on $s butt!<1>", true, this, nullptr,
-        nullptr, TO_ROOM);
+        format("%sYou stumble and topple over.%s\n\r") % red() % norm());
+      act("<r>$n stumbles and topples over.<1>", true, this, nullptr, nullptr,
+        TO_ROOM);
     }
 
     int rc = crashLanding(POSITION_SITTING);

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3464,7 +3464,9 @@ int TBeing::crashLanding(int severity, bool falling) {
   // condition. Either way, the sit/sprawl flavor would be misleading, so skip
   // the position-change messaging here.
   if (roomp->isFallSector()) {
-    if (falling || IS_SET_DELETE(checkFalling(), DELETE_THIS))
+    // falling=true is a recursion guard for flightCheck, not a death signal —
+    // skip the recursive checkFalling but don't fabricate a DELETE_THIS.
+    if (!falling && IS_SET_DELETE(checkFalling(), DELETE_THIS))
       return DELETE_THIS;
   } else if (changed && getPosition() == POSITION_SITTING) {
     act("<y>You drop to a sit on the $g.<1>", true, this, nullptr, nullptr,

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3509,7 +3509,7 @@ int TBeing::crashLanding(positionTypeT pos, bool force, bool dam,
   return TRUE;
 }
 
-int TBeing::stumble(TBeing* victim) {
+int TBeing::stumble(TBeing* opponent) {
   if (!hasLegs())
     return FALSE;
 
@@ -3538,7 +3538,7 @@ int TBeing::stumble(TBeing* victim) {
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
 
-    rc = trySpringleap(victim);
+    rc = trySpringleap(opponent);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3510,35 +3510,51 @@ int TBeing::crashLanding(positionTypeT pos, bool force, bool dam,
 }
 
 int TBeing::stumble(TBeing* victim) {
+  if (!hasLegs())
+    return FALSE;
+
+  if (isFlying() && roomp->isFallSector()) {
+    sendTo(format("%sYou falter in the air, but stay aloft!%s\n\r") % green() %
+           norm());
+    act("<g>$n falters in the air, but stays aloft!<1>", true, this, nullptr,
+      nullptr, TO_ROOM);
+    return FALSE;
+  }
+
   if (!isAgile(0)) {
-    if (isFlying() && roomp->isFallSector()) {
-      sendTo("You falter in the air, but stay aloft!\n\r");
-      act("$n falters in the air, but stays aloft!", true, this, nullptr, nullptr, TO_ROOM);
-    } else if (isFlying()) {
-      setPosition(POSITION_SITTING);
-      sendTo("You stumble out of the air and land on your butt!\n\r");
-      act("$n stumbles out of the air and lands on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+    if (isFlying()) {
+      sendTo(
+        format("%sYou stumble out of the air and land on your butt!%s\n\r") %
+        red() % norm());
+      act("<r>$n stumbles out of the air and lands on $s butt!<1>", true, this,
+        nullptr, nullptr, TO_ROOM);
     } else {
-      setPosition(POSITION_SITTING);
-      sendTo("You stumble and fall on your butt!\n\r");
-      act("$n stumbles and falls on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+      sendTo(
+        format("%sYou stumble and fall on your butt!%s\n\r") % red() % norm());
+      act("<r>$n stumbles and falls on $s butt!<1>", true, this, nullptr,
+        nullptr, TO_ROOM);
     }
 
-    int rc = trySpringleap(victim);
+    int rc = crashLanding(POSITION_SITTING);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+
+    rc = trySpringleap(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
-    if (isFlying() && roomp->isFallSector()) {
-      sendTo("You falter in the air, but quickly recover!\n\r");
-      act("$n falters in the air, but quickly recovers!", true, this, nullptr, nullptr, TO_ROOM);
-    } else if (isFlying()) {
-      setPosition(POSITION_STANDING);
-      sendTo("You stumble out of the air, but land on your feet!\n\r");
-      act("$n stumbles out of the air, but lands on $s feet!", true, this, nullptr, nullptr, TO_ROOM);
+    setPosition(POSITION_STANDING);
+    if (isFlying()) {
+      sendTo(
+        format("%sYou stumble out of the air, but land on your feet!%s\n\r") %
+        green() % norm());
+      act("<g>$n stumbles out of the air, but lands on $s feet!<1>", true, this,
+        nullptr, nullptr, TO_ROOM);
     } else {
-      setPosition(POSITION_STANDING);
-      sendTo("You stumble, but catch yourself!\n\r");
-      act("$n stumbles, but catches $mself!", true, this, nullptr, nullptr, TO_ROOM);
+      sendTo(
+        format("%sYou stumble, but catch yourself!%s\n\r") % green() % norm());
+      act("<g>$n stumbles, but catches $mself!<1>", true, this, nullptr,
+        nullptr, TO_ROOM);
     }
   }
   return FALSE;

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3511,29 +3511,23 @@ int TBeing::crashLanding(positionTypeT pos, bool force, bool dam,
 
 int TBeing::stumble(TBeing* victim) {
   if (!isAgile(0)) {
-    setPosition(POSITION_SITTING);
-    sendTo("You stumble and fall on your butt!\n\r");
-    act("$n stumbles and falls on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+    if (isFlying() && roomp->isFallSector()) {
+      sendTo("You falter in the air, but stay aloft!\n\r");
+      act("$n falters in the air, but stays aloft!", true, this, nullptr, nullptr, TO_ROOM);
+    } else if (isFlying()) {
+      setPosition(POSITION_SITTING);
+      sendTo("You stumble out of the air and land on your butt!\n\r");
+      act("$n stumbles out of the air and lands on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+    } else {
+      setPosition(POSITION_SITTING);
+      sendTo("You stumble and fall on your butt!\n\r");
+      act("$n stumbles and falls on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+    }
     addToWait(combatRound(1));
 
-    int stumbleDam = dice(1, 4);
-
-    bool victimDeleted = false;
-    TBeing* springTarget = victim ? victim : fight();
-    if (springTarget) {
-      int rc = trySpringleap(springTarget);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      if (IS_SET_DELETE(rc, DELETE_VICT))
-        victimDeleted = true;
-      if (rc)
-        stumbleDam /= 2;
-    }
-
-    if (reconcileDamage(this, stumbleDam, DAMAGE_FALL) == -1)
-      return DELETE_THIS | (victimDeleted ? DELETE_VICT : 0);
-    if (victimDeleted)
-      return DELETE_VICT;
+    int rc = trySpringleap(victim);
+    if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
+      return rc;
   } else {
     if (isFlying() && roomp->isFallSector()) {
       sendTo("You falter in the air, but quickly recover!\n\r");

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -2727,7 +2727,7 @@ void TBeing::doSit(const sstring& argument) {
   }
 #if 0
   int rc = triggerSpecial(this, CMD_OBJ_SATON, arg);
-  if (IS_SET_DELETE(rc, DELETE_THIS)) 
+  if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_THIS;
 
   if (rc)
@@ -3507,6 +3507,42 @@ int TBeing::crashLanding(positionTypeT pos, bool force, bool dam,
   }
 
   return TRUE;
+}
+
+int TBeing::stumble(TBeing* victim) {
+  if (!isAgile(0)) {
+    setPosition(POSITION_SITTING);
+    sendTo("You stumble and fall on your butt!\n\r");
+    act("$n stumbles and falls on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
+    addToWait(combatRound(1));
+
+    int stumbleDam = dice(1, 4);
+
+    TBeing* springTarget = victim ? victim : fight();
+    if (springTarget) {
+      int rc = trySpringleap(springTarget);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      if (IS_SET_DELETE(rc, DELETE_VICT))
+        return DELETE_VICT;
+      if (rc)
+        stumbleDam /= 2;
+    }
+
+    if (reconcileDamage(this, stumbleDam, DAMAGE_FALL) == -1)
+      return DELETE_THIS;
+  } else {
+    setPosition(POSITION_STANDING);
+    if (isFlying()) {
+      sendTo("You stumble, but quickly recover your footing!\n\r");
+      act("$n stumbles, but quickly recovers!", true, this, nullptr, nullptr, TO_ROOM);
+    } else {
+      sendTo("You stumble, but catch yourself!\n\r");
+      act("$n stumbles, but catches $mself!", true, this, nullptr, nullptr, TO_ROOM);
+    }
+    addToWait(combatRound(1) / 2);
+  }
+  return FALSE;
 }
 
 int TBeing::doMortalGoto(const sstring& argument) {

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3542,7 +3542,6 @@ int TBeing::stumble(TBeing* victim) {
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
       return rc;
   } else {
-    setPosition(POSITION_STANDING);
     if (isFlying()) {
       act("<g>You stumble out of the air, but land on your feet!<1>", true,
         this, nullptr, nullptr, TO_CHAR);
@@ -3554,6 +3553,7 @@ int TBeing::stumble(TBeing* victim) {
       act("<g>$n stumbles, but catches $mself!<1>", true, this, nullptr,
         nullptr, TO_ROOM);
     }
+    setPosition(POSITION_STANDING);
   }
   return FALSE;
 }

--- a/code/code/misc/movement.cc
+++ b/code/code/misc/movement.cc
@@ -3523,7 +3523,6 @@ int TBeing::stumble(TBeing* victim) {
       sendTo("You stumble and fall on your butt!\n\r");
       act("$n stumbles and falls on $s butt!", true, this, nullptr, nullptr, TO_ROOM);
     }
-    addToWait(combatRound(1));
 
     int rc = trySpringleap(victim);
     if (IS_SET_DELETE(rc, DELETE_THIS) || IS_SET_DELETE(rc, DELETE_VICT))
@@ -3541,7 +3540,6 @@ int TBeing::stumble(TBeing* victim) {
       sendTo("You stumble, but catch yourself!\n\r");
       act("$n stumbles, but catches $mself!", true, this, nullptr, nullptr, TO_ROOM);
     }
-    addToWait(combatRound(1) / 2);
   }
   return FALSE;
 }

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -313,7 +313,7 @@ int TBeing::doCommand(cmdTypeT cmd, const sstring& argument, TThing* vict,
           doUnsaddle(newarg);
           break;
         case CMD_SPRINGLEAP:
-          doSpringleap(newarg, true, dynamic_cast<TBeing*>(vict));
+          doSpringleap();
           break;
         case CMD_HARNESS:
         case CMD_SADDLE:

--- a/code/code/misc/physics.cc
+++ b/code/code/misc/physics.cc
@@ -37,6 +37,11 @@ bool TBeing::canClimb() {
   int skill, num;
   TBeing* tbt;
 
+  // Sprawled or worse — can't hold a grip on a vertical surface. Sitting still
+  // counts as holding on (you can sit on a branch); RESTING and below cannot.
+  if (getPosition() < POSITION_SITTING)
+    return false;
+
   if (!isPc() && canFly() && !isFlying()) {
     doFly();
   } else {
@@ -839,9 +844,8 @@ bool TBeing::canFly() const {
 // force to fly, then crash land.
 int TBeing::flightCheck() {
   if (isFlying() && !canFly() && !roomp->isFlyingSector()) {
-    // last argument is true: force landing, don't recheck.
-    // avoids infinite recursion.
-    int rc = crashLanding(POSITION_SITTING, false, true, true);
+    // falling=true: don't recurse into checkFalling.
+    int rc = crashLanding(0, true);
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
   }

--- a/code/code/misc/riding.cc
+++ b/code/code/misc/riding.cc
@@ -732,30 +732,106 @@ int TBeing::doMount(const char* arg, cmdTypeT cmd, TBeing* h,
   return TRUE;
 }
 
+// Sum the situational modifiers that apply to any riding skill check.
+// Positive values favor the rider. Includes equipment, class, combat state,
+// stat reactions, intoxication/hunger/thirst, limb injuries, and exhaustion.
+int TBeing::getRideMod() {
+  int mod = 0;
+
+  TBeing* mount = dynamic_cast<TBeing*>(riding);
+  if (!mount)
+    return mod;
+
+  // Roll once and reuse — bSuccess advances skill learning, so multiple calls
+  // would inflate the rider's advanced-riding XP per check.
+  bool advRiding = bSuccess(SKILL_ADVANCED_RIDING);
+
+  // Saddle: master in saddle gets the benefit; advanced riding amplifies it.
+  if (mount->hasSaddle() && mount->horseMaster() == this) {
+    mod += 8;
+    if (advRiding)
+      mod += 5;
+  }
+
+  // Secondary rider (not the master) is at a disadvantage.
+  if (mount->horseMaster() != this)
+    mod -= 5;
+
+  // Deikhan class bonus, plus a variable advanced-riding kicker.
+  if (hasClass(CLASS_DEIKHAN)) {
+    mod += 5;
+    mod +=
+      ::number(0, advancedRidingBonus(dynamic_cast<TMonster*>(mount))) / 15;
+  }
+
+  // Combat state divides attention; deikhans handle it better.
+  if (isTanking()) {
+    mod -= 4;
+    if (hasClass(CLASS_DEIKHAN))
+      mod += 5;  // net +1 for tanking deikhans
+  }
+  if (isAffected(AFF_ENGAGER))
+    mod -= 3;
+  if (fight()) {
+    mod -= 3;
+    if (hasClass(CLASS_DEIKHAN))
+      mod += 4;  // net +1 for fighting deikhans
+  }
+  if (mount->fight())
+    mod -= 5;  // mount in combat is a moving target
+
+  // Mount-type-specific skill bonus.
+  spellNumT mountSkill = mount->mountSkillType();
+  if (doesKnowSkill(mountSkill) && bSuccess(mountSkill))
+    mod += getSkillValue(mountSkill) / 5;
+
+  // Stat reactions — agile/dextrous riders handle motion better. Advanced
+  // riding doubles positive reactions.
+  auto applyStat = [&](int stat) {
+    mod += stat;
+    if (stat > 0 && advRiding)
+      mod += stat;
+  };
+  applyStat(getAgiReaction());
+  applyStat(getDexReaction());
+  applyStat(plotStat(STAT_CURRENT, STAT_BRA, -4, 6, 0));
+
+  // Intoxication.
+  if (getCond(DRUNK) > 5) {
+    mod -= 5;
+    if (!bSuccess(SKILL_ALCOHOLISM))
+      mod -= 10;
+  }
+
+  // Hunger and thirst (low cond values mean depleted; -1 means immortal).
+  if (getCond(FULL) >= 0 && getCond(FULL) < 5)
+    mod -= 5;
+  if (getCond(THIRST) >= 0 && getCond(THIRST) < 5)
+    mod -= 3;
+
+  // Limb injuries — legs grip the mount, arms work the reins.
+  if (eitherLegHurt())
+    mod -= 10;
+  if (bothLegsHurt())
+    mod -= 10;  // additional, total -20
+  if (eitherArmHurt())
+    mod -= 5;
+  if (bothArmsHurt())
+    mod -= 5;  // additional, total -10
+
+  // Exhaustion.
+  if (getMove() <= 0)
+    mod -= 20;
+
+  return mod;
+}
+
 // a positive mod is beneficial to the rider
 int TBeing::rideCheck(int mod) {
-  int learn = 0;
-
   if (isImmortal())
     return TRUE;
 
-  TBeing* tbt = dynamic_cast<TBeing*>(riding);
-  if (tbt && tbt->hasSaddle() && tbt->horseMaster() == this)
-    // only guy in saddle gets benefit
-    mod += 8;
-
-  if (tbt && hasClass(CLASS_DEIKHAN)) {
-    mod += 5;  // default bonus for deikhans
-
-    // 0-6
-    mod += ::number(0, advancedRidingBonus(dynamic_cast<TMonster*>(tbt))) / 15;
-  }
-
-  if (tbt && tbt->horseMaster() != this)
-    mod -= 5;  // secondary rider
-
-  learn = getSkillValue(SKILL_RIDE);
-  learn += (3 * mod);
+  int learn = getSkillValue(SKILL_RIDE) + getRideMod() + mod;
 
   // rideChecks are sometimes made for people sitting on objects
   // use of bSuccess here allows them to learn "ride" while on chairs.
@@ -791,21 +867,15 @@ int TBeing::fallOffMount(TThing* h, positionTypeT pos, bool death) {
 
     // fall off a flying mount..
     if (h->isFlying()) {
-      if (h->roomp->isFlyingSector()) {
-        rc = crashLanding(POSITION_FLYING);
+      if (h->roomp->isFlyingSector() || canFly()) {
+        setPosition(POSITION_FLYING);
       } else if (h->roomp->isFallSector()) {
         rc = checkFalling();
       } else {
-        if (canFly()) {
-          rc = crashLanding(POSITION_FLYING);
-        } else {
-          rc = crashLanding(POSITION_RESTING);
-        }
+        rc = crashLanding();
       }
     } else if (h->roomp->isFallSector()) {
       rc = checkFalling();
-
-    } else {
     }
     if (IS_SET_DELETE(rc, DELETE_THIS))
       return DELETE_THIS;
@@ -840,6 +910,60 @@ int TBeing::fallOffMount(TThing* h, positionTypeT pos, bool death) {
     setDistracted(-1, FALSE);
 
   return FALSE;
+}
+
+// Hostile dislodge from a mount — the rider was thrown by an outside force
+// (combat skill, spell, etc.) rather than losing their own balance. Severity
+// threads through crashLanding's agility roll the same way it does for any
+// other "body hits ground" caller.
+int TBeing::knockOffMount(int severity) {
+  TThing* h = riding;
+  if (!h)
+    return false;
+
+  // Riding skill check — higher severity makes hanging on harder. Pass = the
+  // rider keeps their seat; fail = they're thrown.
+  if (rideCheck(-severity)) {
+    if (dynamic_cast<TBeing*>(h)) {
+      act("You hang on tight to $N.", false, this, nullptr, h, TO_CHAR);
+      act("$n hangs on tight to $N.", false, this, nullptr, h, TO_NOTVICT);
+      act("$n hangs on tight to your back.", false, this, nullptr, h, TO_VICT);
+    } else {
+      act("You keep your seat on $p.", false, this, h, nullptr, TO_CHAR);
+      act("$n keeps $s seat on $p.", false, this, h, nullptr, TO_ROOM);
+    }
+    return false;
+  }
+
+  if (auto* tb = dynamic_cast<TBeing*>(h)) {
+    act("$n is thrown clear of $N!", false, this, nullptr, h, TO_NOTVICT,
+      ANSI_RED);
+    act("$n is thrown clear of your back!", false, this, nullptr, h, TO_VICT,
+      ANSI_RED);
+    act("You are thrown clear of $N!", false, this, nullptr, h, TO_CHAR,
+      ANSI_RED);
+
+    if (!tb->isPc())
+      dynamic_cast<TMonster*>(tb)->aiHorse(this);
+  } else {
+    act("$n is knocked off $p!", false, this, h, nullptr, TO_ROOM, ANSI_RED);
+    act("You are knocked off $p!", false, this, h, nullptr, TO_CHAR, ANSI_RED);
+  }
+
+  // Thrown clear of a flying mount — if the rider can stay aloft (own wings,
+  // magical flight, or a flying-sector that holds them up), they catch
+  // themselves instead of crashing.
+  if (h->isFlying() && (canFly() || roomp->isFlyingSector())) {
+    act("You catch yourself in the air.", false, this, nullptr, nullptr,
+      TO_CHAR);
+    act("$n catches $mself in the air.", false, this, nullptr, nullptr,
+      TO_ROOM);
+    dismount(POSITION_FLYING);
+    return true;
+  }
+
+  dismount(POSITION_STANDING);
+  return crashLanding(severity);
 }
 
 // ego is a number representing how "ballsy" the mount is

--- a/code/code/spec/spec_rooms.cc
+++ b/code/code/spec/spec_rooms.cc
@@ -1410,13 +1410,16 @@ namespace {
       int minDam{20};
       int maxDam{50};
 
-      // onTrigger is optional, as you might want to only display a single trigger message for multiple effects
+      // onTrigger is optional, as you might want to only display a single
+      // trigger message for multiple effects
       const char* onTrigger{nullptr};
 
-      // onDamage is required, as it describes the effect of this specific damage type
+      // onDamage is required, as it describes the effect of this specific
+      // damage type
       const char* onDamage;
 
-      // onSave is optional, as a save being possible depends on the behavior of the proc itself
+      // onSave is optional, as a save being possible depends on the behavior of
+      // the proc itself
       const char* onSave{nullptr};
 
       // All damage types should have an onImmune message to avoid confusion for
@@ -1985,7 +1988,7 @@ knocking the unwary off-guard.<1>\n\r");
     act("$n lands flat on $s back!",
   FALSE, player, 0, 0, TO_ROOM);
 
-    rc = player->crashLanding(POSITION_SITTING);
+    rc = player->crashLanding();
     if (IS_SET_DELETE(rc, DELETE_THIS)){
       delete player;
       player = NULL;

--- a/code/code/sys/handler.cc
+++ b/code/code/sys/handler.cc
@@ -195,7 +195,7 @@ void TBeing::affectChange(uint64_t original, silentTypeT silent) {
       sendTo("You lose your ability to fly.\n\r");
       if (roomp && isFlying()) {
         // roomp is needed since this is sometimes called by dead critters
-        rc = crashLanding(POSITION_SITTING);
+        rc = crashLanding();
         if (IS_SET_DELETE(rc, DELETE_THIS))
           // I don't think this can happen, so won't bother to do work to pass
           // the return if it does

--- a/lib/help/_skills/bash
+++ b/lib/help/_skills/bash
@@ -14,4 +14,6 @@ at bashing is also dependent on relative weights and dexterities.
 Bashing is a physical attack, and as such, requires the basher be able to
 successfully hit the victim.  The closer you are to your target the easier it
 is to bash so that person most directly fighting will have the best chance of
-success.  Failure to bash successfully may cause the basher to fall.
+success.  Failure to bash successfully may cause the basher to stumble.
+
+See Also: STUMBLE

--- a/lib/help/_skills/bodyslam
+++ b/lib/help/_skills/bodyslam
@@ -9,4 +9,6 @@ specialization.
 
 Bodyslamming is a physical attack, and as such, requires the bodyslammer be
 able to successfully hit the victim.  Failure to do so will cause the attempt
-to fail.
+to fail, and the bodyslammer to stumble.
+
+See Also: STUMBLE

--- a/lib/help/_skills/grapple
+++ b/lib/help/_skills/grapple
@@ -7,4 +7,7 @@ grappler rather than the being they were fighting originally. It is
 notoriously difficult to grapple a monk. 
 
 Grappling is a physical attack, and as such, requires the grappler be able to
-successfully hit the victim.  Failure to do so will cause the attempt to fail.
+successfully hit the victim.  Failure to do so will cause the attempt to fail,
+and the grappler to stumble.
+
+See Also: STUMBLE

--- a/lib/help/_skills/headbutt
+++ b/lib/help/_skills/headbutt
@@ -12,4 +12,6 @@ the attacker at too much of a disadvantage in terms of being off-balance.
 
 Headbutting is a physical attack, and as such, requires the headbutter be
 able to successfully hit the victim.  Failure to do so will cause the attempt
-to fail.
+to fail, and the headbutter to stumble.
+
+See Also: STUMBLE

--- a/lib/help/_skills/ride
+++ b/lib/help/_skills/ride
@@ -31,7 +31,11 @@ It is not possible to mount a creature that is higher level than you,
 nor one involved in a fight.  Karma plays a certain role in determining
 ride success.
 
-
+Riders taking hits in combat can be thrown from their mounts.  Heavier
+hits are harder to shrug off, and better riders are harder to dislodge.
+Deikhans in particular make excellent mounted combatants -- a deikhan
+who specializes in riding a particular kind of mount becomes nearly
+impossible to dislodge at high skill levels.
 
 See Also: DISMOUNT
 Related Topics: MOVEMENT

--- a/lib/help/_skills/spin
+++ b/lib/help/_skills/spin
@@ -10,4 +10,6 @@ brawling specialization is known.
 
 Spinning is a physical attack, and as such, requires the warrior to be able to
 successfully hit the victim.  Failure to do so will cause the attempted spin to
-fail.
+fail, and the warrior to stumble.
+
+See Also: STUMBLE

--- a/lib/help/_skills/springleap
+++ b/lib/help/_skills/springleap
@@ -1,11 +1,14 @@
-Syntax: springleap <victim>
+Syntax: springleap
 
-Spring leap is an interesting counter move taught to monks as a response to
-being knocked off their feet.  The move will allow the monk to leap back to
-their feet, and at the same time kick the enemy.  It can be done either
-automatically as a response to some attacks or manually by the monk under the
-right conditions.
+Springleap is a recovery technique taught to monks: a quick spring off the
+ground that brings the monk back to their feet from a sitting or resting
+position.  Anyone who knows springleap will attempt one automatically
+whenever they are knocked down, with no need to issue the command.  The
+springleap can also be invoked manually any time the monk is sitting or
+lying on the ground.
 
-Spring leap is a physical attack, and as such, requires the Jumandoist be able
-to successfully hit the victim.  Failure to do so will cause the attempt to
-fail.
+A successful springleap leaves the monk standing; a failed attempt leaves
+them flopped back where they started.  The chance of success is governed
+by the monk's skill in springleap.
+
+See Also: CATFALL, CATLEAP, COUNTER MOVE, GROUNDFIGHTING

--- a/lib/help/_skills/trip
+++ b/lib/help/_skills/trip
@@ -5,6 +5,6 @@ Triping is a physical attack, and requires the warrior to be able to
 successfully hit the victim.  The closer you are to your target the easier it
 is to trip them so that person most directly fighting will have the best chance
 of success.  Balance is key for the trip skill and improper use may cause the
-warrior to fall over.
+warrior to stumble.
 
-See Also: BASH
+See Also: BASH, STUMBLE

--- a/lib/help/stumble
+++ b/lib/help/stumble
@@ -1,0 +1,17 @@
+A stumble is what happens when an attacker botches a knockdown attempt
+and risks being knocked down themselves.  Bash, trip, grapple, bodyslam,
+headbutt, and spin can all leave a warrior stumbling on a miss; several
+monk takedowns do the same.
+
+The outcome depends on the attacker's agility.  Agile attackers catch
+themselves and stay standing, losing only a little time to recover their
+footing.  Less agile attackers topple over -- a second roll then decides
+whether they end up sitting or fully sprawled on the ground.
+
+Anyone with the springleap skill will attempt to bounce straight back to
+their feet the moment they hit the ground.
+
+A flier stumbling in a fall sector falters but stays aloft; elsewhere, a
+stumbling flier topples out of the sky.
+
+See Also: SPRINGLEAP, GROUNDFIGHTING, AGILITY

--- a/lib/txt/news.d/2026-05-05-stumble-recovery-and-mounted-combat
+++ b/lib/txt/news.d/2026-05-05-stumble-recovery-and-mounted-combat
@@ -1,0 +1,25 @@
+Combat takedowns and mounted combat have been reworked.
+
+1) Springleap is now a recovery skill rather than an attack.
+    - It no longer takes a target or kicks anyone.  Instead, the monk
+      springs from sitting or resting back to a standing position.
+    - Anyone with springleap will attempt one automatically the moment
+      they hit the ground, with no need to issue the command.
+    - It can still be invoked manually while sitting or resting.
+    - See 'help springleap' for details.
+
+2) Missing a knockdown attempt no longer guarantees you eat dirt.
+    - Bash, trip, grapple, bodyslam, headbutt, and spin can all leave
+      the attacker stumbling on a miss.  An agile attacker now catches
+      themselves and stays standing; a less agile one topples over,
+      with a second roll deciding sitting vs. fully sprawled.
+    - Monks with springleap will bounce straight back to their feet.
+    - See 'help stumble' for details.
+
+3) Combat hits can now throw a rider off their mount.
+    - Heavier hits are harder to shrug off, and better riders are
+      harder to dislodge.
+    - Deikhans, especially those who specialize in a particular kind
+      of mount, become nearly impossible to dislodge at high skill
+      levels.
+    - See 'help ride' for details.


### PR DESCRIPTION
## Summary

Builds on the original `TBeing::stumble()` work to refactor the entire "character hits the ground" chain (stumble → crashLanding → springleap), introduce a new hostile-dislodge path (`knockOffMount`) for mounted victims, and centralize riding modifiers (`getRideMod`) so every ride check pulls from the same comprehensive state model.

## What changed

### `crashLanding` — universal landing primitive
- Signature: `crashLanding(positionTypeT, bool force, bool dam, bool falling)` → `crashLanding(int severity = 0, bool falling = false)`.
- Internal `isAgile(-severity)` roll picks SITTING (pass) vs RESTING (fail). Position is **downgrade-only** — never promotes.
- Catfall, the force branch, and direct fall damage are gone. `checkFalling` still handles fall-sector lethality; the sit/sprawl flavor is gated on actual position change *and* suppressed in fall sectors (where checkFalling provides its own narrative).
- Tail-calls `springleap()` for monks so they may bounce back to standing as part of the chain.

### `springleap` — monk-only stand-up
- Drops target, drops the entire combat path (specialAttack, getActualDamage, kick flavor, reconcileDamage, lag).
- `bSuccess(SKILL_SPRINGLEAP)` gates whether the caster actually stands up; failure leaves them on the ground.
- Position guard: `RESTING <= getPosition() <= SITTING`. Cannot promote unconscious characters.

### `stumble`, `trySpringleap`, `doSpringleap`
- `stumble()` drops `opponent` parameter and the post-call `trySpringleap` (now internal to `crashLanding`).
- `trySpringleap` deleted entirely.
- `doSpringleap` becomes no-arg; `monkMove` calls `springleap()` directly. Player command keeps its "You're not in position for that!" message.

### `canClimb` — sprawled drops
- Gated at `< POSITION_SITTING`. Sitting characters can still hold a branch; sprawled characters can't. A bashed mounted-tree victim now actually falls via `checkFalling`.

### `knockOffMount(int severity = 0)` — new hostile dislodge
- Internal `rideCheck(-severity)` save: pass = "hangs on tight" flavor, early return; fail = "thrown clear" flavor + `dismount` + `crashLanding` chain.
- Stays-aloft branch: if mount was flying and rider can fly themselves (or room is flying-sector), dismount to POSITION_FLYING instead of crashing.

### `getRideMod()` — new helper
- Sums situational modifiers for any riding skill check: saddle bonus + advanced-riding amplifier, secondary-rider penalty, deikhan class bonus, combat state (tanking / engager / fighting / mount-fighting with deikhan offsets), mount-type-specific skill, stat reactions (agi / dex / bra, doubled when positive by advanced riding), drunk / hunger / thirst, leg / arm injuries, exhaustion.
- `bSuccess(SKILL_ADVANCED_RIDING)` cached once per call so it doesn't grind 4× per check.

### `rideCheck` — formula change
- New: `learn = getSkillValue(SKILL_RIDE) + getRideMod() + mod`.
- The old 3× amplification on caller mod is removed; `getRideMod` now provides the comprehensive baseline.
- Doubled rideCheck patterns ("force two failures") consolidated to single checks.

### Skill migrations
- **bash, bodyslam, spin, grapple** — success path now uses `wasMounted ? knockOffMount() : crashLanding()`. Each preserves skill-specific takedown flavor in both branches. Grapple is special-cased: if the rider hangs on, grapple aborts cleanly with "slips" flavor and a 2-round lag.
- **combat.cc canFight** (mounted attacker entering combat, secondary riders when their mount enters combat) — replaced `rideCheck → fallOffMount(POSITION_SITTING)` with `knockOffMount()`.
- **damage.cc reconcileDamage** (rider takes damage, secondary riders when their mount takes damage) — replaced with `knockOffMount(3)`. `addToWait` only fires if the rider was actually thrown.

## Gameplay changes

| Aspect | Before | After |
|---|---|---|
| **Skill miss recovery** | Always fall to sitting | Agile: stay standing. Non-agile: fall (sitting or resting via internal roll). |
| **Flying + fall sector miss** | Mixed | Unified "stay aloft" |
| **Hit the ground** | Took 2-8 fall damage | No automatic damage (severity-based future tuning) |
| **Mounted character hit by combat skill** | Always knocked off (or just printed flavor) | Riding skill check: skilled riders / deikhans / saddled hold their seat; impaired riders fall |
| **Rider fall in vert sector while sprawled** | Stayed on the branch | Falls via checkFalling |
| **Knocked off a flying mount with own wings** | Not handled | Catches yourself, stays aloft |
| **Monk recovery** | Auto-springleap only after specific skills | Auto-springleap after any "hit the ground" event (stumble, crashLanding, knockOffMount fall) |

### Tuning notes

- Severity values are placeholders (mostly `0` everywhere, `3` for damage events). Future work will tie severity to skill damage so each caller passes a meaningful magnitude.
- `getRideMod` produces a much wider dynamic range than the old simple modifiers — skilled riders are noticeably harder to dislodge, impaired riders much easier. Intentional model shift.

## DELETE flag safety

All migrated sites propagate `DELETE_THIS` correctly. `knockOffMount` returns whatever `crashLanding` returns, so DELETE_THIS flows through to callers. Iteration loops in `combat.cc canFight` and `damage.cc reconcileDamage` are safe — single-iteration on throw, or `t2 = t->nextRider` cached before the call.

Two pre-existing latent UAFs surfaced (handler.cc affectChange + disc_thief_stealth.cc subterfugeMiss both discard `crashLanding`'s return). Neither was introduced or worsened by this branch — they predate it. Documented for follow-up PRs.

## Test plan

- [x] Trip / bash / bodyslam / spin / grapple / headbutt — verify variable SITTING/RESTING outcome
- [x] Sleeping / stunned / incapacitated victim — verify no position promotion
- [x] Monk gets bashed — verify auto-springleap fires after crashLanding
- [x] Non-monk gets bashed — stays on ground (no springleap)
- [x] `springleap` while standing — "not in position" message; while sitting (monk) — springs up or fails
- [x] Bash/bodyslam/spin a mounted victim — skill flavor + knockOffMount chain (rideCheck save → hang-on or throw)
- [x] Grapple a mounted victim that hangs on — "grapple slips" flavor, no pin
- [x] Vertical-sector strong man bashed — falls via checkFalling (canClimb=false at RESTING)
- [x] Knocked off flying mount with own wings — catches in air, stays at POSITION_FLYING
- [x] Dispel fly affect — crashLanding fires, sprawls (handler.cc:198 path)
- [x] Build clean, formatted, tests pass