### PR TITLE
Fix UB: validate weapon type on load

### DIFF
--- a/code/code/obj/obj_general_weapon.cc
+++ b/code/code/obj/obj_general_weapon.cc
@@ -42,13 +42,13 @@ TGenWeapon::~TGenWeapon() {}
 void TGenWeapon::assignFourValues(int x1, int x2, int x3, int x4) {
   TBaseWeapon::assignFourValues(x1, x2, x3, x4);
 
-  setWeaponType((weaponT)GET_BITS(x3, 7, 8), 0);
+  setWeaponType(GET_BITS(x3, 7, 8), 0);
   setWeaponFreq(GET_BITS(x3, 15, 8), 0);
 
-  setWeaponType((weaponT)GET_BITS(x3, 23, 8), 1);
+  setWeaponType(GET_BITS(x3, 23, 8), 1);
   setWeaponFreq(GET_BITS(x3, 31, 8), 1);
 
-  setWeaponType((weaponT)GET_BITS(x4, 7, 8), 2);
+  setWeaponType(GET_BITS(x4, 7, 8), 2);
   setWeaponFreq(GET_BITS(x4, 15, 8), 2);
 }
 
@@ -87,7 +87,14 @@ int TGenWeapon::getWeaponFreq(int which) const {
   return wtype_frequency[which];
 }
 
-void TGenWeapon::setWeaponType(weaponT n, int which) { weapon_type[which] = n; }
+void TGenWeapon::setWeaponType(int n, int which) {
+  if (n < WEAPON_TYPE_NONE || n >= WEAPON_TYPE_MAX) {
+    vlogf(LOG_BUG,
+      format("Invalid weapon type %d on %s, resetting to NONE") % n % getName());
+    n = WEAPON_TYPE_NONE;
+  }
+  weapon_type[which] = (weaponT)n;
+}
 
 void TGenWeapon::setWeaponFreq(int n, int which) { wtype_frequency[which] = n; }
 

--- a/code/code/obj/obj_general_weapon.h
+++ b/code/code/obj/obj_general_weapon.h
@@ -27,7 +27,7 @@ class TGenWeapon : public TBaseWeapon {
     virtual bool sellMeCheck(TBeing*, TMonster*, int, int) const;
 
     virtual weaponT getWeaponType(int which = -1) const;
-    virtual void setWeaponType(weaponT n, int which = 0);
+    virtual void setWeaponType(int n, int which = 0);
     int getWeaponFreq(int which) const;
     void setWeaponFreq(int n, int which = 0);
 


### PR DESCRIPTION
## Summary

Fixes #681 — undefined behavior from invalid `weaponT` enum values (e.g. 102, 126) loaded from the database or player rent files.

- Changed `setWeaponType` parameter from `weaponT` to `int` so validation happens before the enum cast, eliminating the UB at the call site
- Added bounds check that logs `LOG_BUG` and resets to `WEAPON_TYPE_NONE` for out-of-range values
- Removed the unsafe `(weaponT)` casts in `assignFourValues` since `setWeaponType` now handles the conversion

## Test plan

- [x] Build with UBSan enabled and verify no `weaponT` load-of-invalid-value errors
- [x] Run `show obj holy` — the command from the original bug report — and confirm no UBSan warnings
- [x] Check the bug log after boot for `Invalid weapon type` messages to identify which objects have bad data in the DB
- [x] Verify a player with weapons can rent out and rent back in without issues
- [x] Verify normal weapon combat still works (slash/pierce/blunt all resolve correctly)
- [x] Verify spec proc weapons (e.g. lightsabers, shapeshifting weapons) still set their types correctly — these call `setWeaponType` with valid enum constants
- [x] Confirm the objects flagged in the bug log and fix their `val2`/`val3` data in the DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened weapon type validation with improved bounds checking. Invalid weapon type configurations are now detected and prevented from being applied to the system. Violations are logged for troubleshooting, and out-of-range values are automatically reset to safe defaults for enhanced stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->