### PR TITLE
Fix UB engravecost and friends

### DIFF
--- a/code/code/misc/extern.h
+++ b/code/code/misc/extern.h
@@ -16,8 +16,14 @@
 
 #include <sys/select.h>  // for fd_set
 #include <cmath>         // for pow
+#include <climits>       // for INT_MAX, INT_MIN
+#include <algorithm>     // for std::clamp
 
 struct PolyType;
+
+inline int saturate_to_int(double v) {
+  return (int)std::clamp(v, (double)INT_MIN, (double)INT_MAX);
+}
 class charFile;
 
 using std::max;

--- a/code/code/misc/shop.cc
+++ b/code/code/misc/shop.cc
@@ -357,7 +357,7 @@ int TObj::sellPrice(int, int shop_nr, float chr, const TBeing* ch) {
   // make sure we don't have a negative cost
   cost = max(1.0, cost);
 
-  return (int)cost;
+  return saturate_to_int(cost);
 }
 
 // this is price shop will sell it at
@@ -377,7 +377,7 @@ int TObj::shopPrice(int num, int shop_nr, float chr, const TBeing* ch) const {
 
   // cast this back to an int so that we can multiple without inflating the
   // price
-  int singleCost = (int)cost;
+  int singleCost = saturate_to_int(cost);
 
   // finally do the multiplication for number of items
   // we do this last so that the actual price is the same as the single-object

--- a/code/code/obj/obj_base_clothing.cc
+++ b/code/code/obj/obj_base_clothing.cc
@@ -347,8 +347,8 @@ int TBaseClothing::armorPriceStruct(armorLevT type, double* lev) const {
   double str_price = (str_lev * max(str_lev, 20.0) * 75);
 
   // now adjust above number so that it splits it over all the pieces...
-  int ac_comp = (int)(ac_price * ac_perc);
-  int str_comp = (int)(str_price * str_perc);
+  int ac_comp = saturate_to_int(ac_price * ac_perc);
+  int str_comp = saturate_to_int(str_price * str_perc);
 
   int price = 0;
   *lev = 0.0;
@@ -508,8 +508,9 @@ int TBaseClothing::suggestedPrice() const {
         affected[i].location == APPLY_HITNDAM) {
       // add directly to price since we don't want to be scaled
       // this formula is in balance notes
-      int amt = (int)(lev * max(lev, 20.0) * 450 / 4);
-      amt -= (int)((lev - num) * max(lev - num, 20.0) * 450 / 4);
+      double amt_d = lev * max(lev, 20.0) * 450.0 / 4.0
+                   - (lev - num) * max(lev - num, 20.0) * 450.0 / 4.0;
+      int amt = saturate_to_int(amt_d);
       price += amt;
     }
     if (canWear(ITEM_WEAR_FINGERS)) {

--- a/code/code/obj/obj_base_weapon.cc
+++ b/code/code/obj/obj_base_weapon.cc
@@ -222,9 +222,7 @@ void TBaseWeapon::dullMe(TBeing* ch, TTool* tool) {
 }
 
 int TBaseWeapon::sharpenPrice() const {
-  int cost = obj_flags.cost;
-  cost *= 5;
-  cost /= 100;
+  int cost = saturate_to_int((double)obj_flags.cost * 5 / 100);
 
   cost = max(cost, 1);
   if (!getMaxSharp())
@@ -1246,9 +1244,9 @@ int TBaseWeapon::suggestedPrice() const {
   }
   if (tohit) {
     // this formula is from balance notes
-    int amt = (int)(weapon_lev * max(weapon_lev, 20.0) * 450 / 4);
-    amt -=
-      (int)((weapon_lev - tohit) * max(weapon_lev - tohit, 20.0) * 450 / 4);
+    double amt_d = weapon_lev * max(weapon_lev, 20.0) * 450.0 / 4.0
+                 - (weapon_lev - tohit) * max(weapon_lev - tohit, 20.0) * 450.0 / 4.0;
+    int amt = saturate_to_int(amt_d);
     price += amt;
   }
   switch (todam) {

--- a/code/code/obj/obj_potion.cc
+++ b/code/code/obj/obj_potion.cc
@@ -93,7 +93,7 @@ int TPotion::sellPrice(int, int shop_nr, float chr, const TBeing* ch) {
   // make sure we don't have a negative cost
   cost = max(1.0, cost);
 
-  return (int)cost;
+  return saturate_to_int(cost);
 }
 
 int TPotion::shopPrice(int num, int shop_nr, float chr,
@@ -114,7 +114,7 @@ int TPotion::shopPrice(int num, int shop_nr, float chr,
   // make sure we don't have a negative cost
   cost = max(1.0, cost);
 
-  return (int)cost;
+  return saturate_to_int(cost);
 }
 
 // return the liquid associated with the shaman spell

--- a/code/code/spec/spec_mobs.cc
+++ b/code/code/spec/spec_mobs.cc
@@ -3203,7 +3203,7 @@ static int attunePrice(const TSymbol* obj, TBeing* ch, unsigned int shop_nr) {
 
   cost *= shop_index[shop_nr].getProfitBuy(obj, ch);
 
-  return (int)cost;
+  return saturate_to_int(cost);
 }
 
 void attune_struct::clearAttuneData() {

--- a/code/code/spec/spec_mobs_customizers.cc
+++ b/code/code/spec/spec_mobs_customizers.cc
@@ -40,7 +40,7 @@ static int engraveCost(TObj* obj, TBeing* ch, unsigned int shop_nr) {
   if (shop_nr)
     cost *= shop_index[shop_nr].getProfitBuy(obj, ch);
 
-  return (int)cost;
+  return saturate_to_int(cost);
 }
 
 int engraver(TBeing* ch, cmdTypeT cmd, const char* arg, TMonster* me, TObj* o) {

--- a/code/code/spec/spec_objs.cc
+++ b/code/code/spec/spec_objs.cc
@@ -104,11 +104,12 @@
 int TObj::checkSpec(TBeing* t, cmdTypeT cmd, const char* arg, TThing* t2) {
   int rc;
 
-  // we use static_cast here because we don't ALWAYS pass the proper kind of
-  // parameter through the pointer fields.
+  // We use reinterpret_cast as we don't always pass a true TObj* as the extra
+  // pointer. Some commands pass other types (e.g. TBeing*) through t2.
+  // The receiving spec procs that need the real type cast it back via TThing*.
   if (spec) {
     rc = (objSpecials[GET_OBJ_SPE_INDEX(spec)].proc)(t, cmd, arg, this,
-      static_cast<TObj*>(t2));
+      reinterpret_cast<TObj*>(t2));
     return rc;
   }
   return FALSE;


### PR DESCRIPTION
I tried to just fix one thing but in order to test with the UB sanitizer on I had to fix some adjacent issues.

I think this should fix these issues:

  - #678 — engraveCost() in spec_mobs_customizers.cc — fixed (the original issue)
  - #675 — TBaseWeapon::suggestedPrice() in obj_base_weapon.cc — fixed (the std::clamp on the hitroll formula)
  - #674 — TBaseClothing::armorPriceStruct() in obj_base_clothing.cc — fixed (clamping ac_comp/str_comp)

