### PR TITLE
Centralize trap damage logic with data-driven TrapTypeInfo table

### DIFF
--- a/code/code/disc/disc_thief_looting.cc
+++ b/code/code/disc/disc_thief_looting.cc
@@ -8,7 +8,10 @@
 #include "combat.h"
 #include "disc_thief_looting.h"
 #include "obj_trap.h"
+#include "obj_trap_component.h"
+#include "trap.h"
 #include "obj_portal.h"
+#include "low.h"
 
 int TBeing::doSearch(const char* argument) {
   int rc;
@@ -141,10 +144,8 @@ int TBeing::disarmTrap(const char* arg, TObj* tp) {
 
   if ((trap = tp) || (trap = get_obj_vis_accessible(this, type))) {
     rc = disarmTrapObj(this, trap);
-    if (IS_SET_DELETE(rc, DELETE_ITEM)) {
-      delete trap;
-      trap = NULL;
-    }
+    if (IS_SET_DELETE(rc, DELETE_ITEM))
+      trap = nullptr;
     if (rc)
       addSkillLag(SKILL_DISARM_TRAP, rc);
 
@@ -170,6 +171,94 @@ int TBeing::disarmTrap(const char* arg, TObj* tp) {
   return FALSE;
 }
 
+// Helper function to reclaim trap components during disarming
+bool reclaimTrapComps(TBeing* thief, sstring trap_type, TTrap* trap) {
+  std::vector<int> components;
+  size_t comp_recovered = 0;
+  bool casing_recovered = false;
+
+  // Determine trap target type for correct component selection
+  trap_targ_t targ = TRAP_TARG_DOOR; // default for door traps (trap == nullptr)
+  if (trap) {
+    if (trap->isTrapEffectType(TRAP_EFF_THROW))
+      targ = TRAP_TARG_GRENADE;
+    else if (trap->isTrapEffectType(TRAP_EFF_MOVE))
+      targ = TRAP_TARG_MINE;
+    else
+      targ = TRAP_TARG_CONT;
+  }
+
+  int item1, item2, item3;
+  if (!getTrapComponents(trap_type.c_str(), targ, item1, item2, item3))
+    return false;
+
+  components = {item1, item2, item3};
+
+  // Calculate chance of recovering each component
+  int recovery_chance = 50 + (thief->getSkillValue(SKILL_DISARM_TRAP) / 2);
+
+  for (auto item_vnum : components) {
+    // Roll for each component
+    if (::number(1, 100) <= recovery_chance) {
+      TObj* comp = read_object(item_vnum, VIRTUAL);
+      if (comp) {
+        // If it's a trap component, set it up with charges
+        TTrapComponent* trapComp = dynamic_cast<TTrapComponent*>(comp);
+        if (trapComp) {
+          trapComp->setTrapComponentCharges(1); // Salvaged components have 1 charge
+        }
+
+        // Notify player of recovered component first
+        thief->sendTo(format("You carefully recover %s from the trap.\n\r") %
+                      comp->shortDescr);
+
+        // Then add to inventory (which may trigger merge messages)
+        *thief += *comp;
+        comp_recovered++;
+      }
+    }
+  }
+
+  // Also try to recover the casing for grenades and mines
+  if (targ == TRAP_TARG_GRENADE || targ == TRAP_TARG_MINE) {
+    int casing_vnum = (targ == TRAP_TARG_GRENADE)
+      ? Obj::ST_CASE_GRENADE
+      : Obj::ST_CASE_MINE;
+
+    if (casing_vnum != -1 && ::number(1, 100) <= recovery_chance) {
+      TObj* casing = read_object(casing_vnum, VIRTUAL);
+      if (casing) {
+        // If it's a trap component, set it up with charges
+        TTrapComponent* trapComp = dynamic_cast<TTrapComponent*>(casing);
+        if (trapComp) {
+          trapComp->setTrapComponentCharges(1); // Salvaged components have 1 charge
+        }
+
+        // Notify player of recovered casing first
+        thief->sendTo(format("You carefully recover %s from the trap.\n\r") %
+                      casing->shortDescr);
+
+        // Then add to inventory (which may trigger merge messages)
+        *thief += *casing;
+        casing_recovered = true;
+      }
+    }
+  }
+
+  if (comp_recovered == 0 && !casing_recovered) {
+    thief->sendTo(
+      "You were unable to salvage any components from the trap.\n\r");
+    return false;
+  } else if (comp_recovered < components.size()) {
+    thief->sendTo("You managed to salvage some components from the trap.\n\r");
+  } else {
+    thief->sendTo(
+      "You successfully recovered all components from the trap!\n\r");
+  }
+
+  return true;
+}
+
 int TObj::disarmMe(TBeing* thief) {
   thief->sendTo("I don't think that's a trap.\n\r");
   return FALSE;
@@ -190,8 +279,31 @@ int TTrap::disarmMe(TBeing* thief) {
   if (thief->bSuccess(bKnown, SKILL_DISARM_TRAP)) {
     thief->sendTo(format("Click.  You disarm the %s trap.\n\r") % trap_type);
     act("$n disarms $p.", FALSE, thief, this, 0, TO_ROOM);
-    setTrapCharges(0);
-    return TRUE;
+
+    // Try to salvage components if the thief has the appropriate trap-setting skills
+    bool canSalvage = false;
+    if (isTrapEffectType(TRAP_EFF_THROW) && thief->doesKnowSkill(SKILL_SET_TRAP_GREN)) {
+      canSalvage = true;
+    } else if (isTrapEffectType(TRAP_EFF_MOVE) && !isTrapEffectType(TRAP_EFF_THROW) &&
+               thief->doesKnowSkill(SKILL_SET_TRAP_MINE)) {
+      canSalvage = true;
+    } else if (!isTrapEffectType(TRAP_EFF_THROW) && !isTrapEffectType(TRAP_EFF_MOVE) &&
+               thief->doesKnowSkill(SKILL_SET_TRAP_CONT)) {
+      canSalvage = true;
+    }
+
+    if (canSalvage) {
+      reclaimTrapComps(thief, trap_type, this);
+    } else {
+      thief->sendTo(
+        "You lack the knowledge to salvage components from this type of "
+        "trap.\n\r");
+    }
+
+    // Trap is spent — remove from world and notify caller
+    --(*this);
+    delete this;
+    return DELETE_ITEM;
   } else {
     thief->sendTo("Click. (whoops)\n\r");
     act("$n tries to disarm $p.", FALSE, thief, this, 0, TO_ROOM);
@@ -209,7 +321,7 @@ int disarmTrapObj(TBeing* thief, TObj* trap) {
   if (IS_SET_DELETE(rc, DELETE_VICT)) {
     return DELETE_THIS;
   }
-  return FALSE;
+  return rc;
 }
 
 int disarmTrapDoor(TBeing* thief, dirTypeT door) {
@@ -237,6 +349,16 @@ int disarmTrapDoor(TBeing* thief, dirTypeT door) {
                   trap_type % doorbuf);
     sprintf(buf, "$n disarms the %s trap in the %s.", trap_type, doorbuf);
     act(buf, FALSE, thief, 0, 0, TO_ROOM);
+
+    // Try to salvage components from door traps if the thief has the appropriate skill
+    if (thief->doesKnowSkill(SKILL_SET_TRAP_DOOR)) {
+      reclaimTrapComps(thief, trap_type, nullptr); // nullptr indicates door trap
+    } else {
+      thief->sendTo(
+        "You lack the knowledge to salvage components from this type of "
+        "trap.\n\r");
+    }
+
     REMOVE_BIT(exitp->condition, EXIT_TRAPPED);
     if ((rp = real_roomp(exitp->to_room)) &&
         (back = rp->dir_option[rev_dir(door)])) {

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1055,8 +1055,7 @@ class TBeing : public TThing {
     bool willBump(int) const;
     bool willBumpHead(TRoom*) const;
     bool willBumpHeadDoor(roomDirData*, int*) const;
-    void sendTrapMessage(const char*, trap_targ_t, int);
-    bool hasTrapComps(const char*, trap_targ_t, int, int* price = NULL);
+    bool hasTrapComps(const char*, trap_targ_t, int, int* price = nullptr);
     int goofUpTrap(doorTrapT, trap_targ_t);
     int springTrap(TTrap*);
     int triggerTrap(TTrap*);
@@ -1068,14 +1067,6 @@ class TBeing : public TThing {
     int checkForInsideTrap(TThing*);
     int checkForGetTrap(TThing*);
     int checkForAnyTrap(TThing*);
-    int trapDoorSlashDamage(int, dirTypeT);
-    int trapDoorFireDamage(int, dirTypeT);
-    int trapDoorPierceDamage(int, dirTypeT);
-    int trapDoorTntDamage(int, dirTypeT);
-    int trapDoorAcidDamage(int, dirTypeT);
-    int trapDoorHammerDamage(int, dirTypeT);
-    int trapDoorEnergyDamage(int, dirTypeT);
-    int trapDoorFrostDamage(int, dirTypeT);
     virtual int grenadeHit(TTrap*);
     virtual bool addHated(TBeing*);
     virtual void setHunting(TBeing*) {}

--- a/code/code/misc/constants.cc
+++ b/code/code/misc/constants.cc
@@ -385,6 +385,9 @@ void assign_item_info() {
   ItemInfo[ITEM_COMPONENT] = new itemInfo("Component", "a spell component",
     "Number of uses left", 10, 0, "Maximum number of uses", 10, 0,
     "Spell # component is for", 1000, 0, "Special - decay/useage", 15, 0);
+  ItemInfo[ITEM_TRAP_COMPONENT] = new itemInfo("Trap Component", "a trap component",
+    "Number of uses left", 100, 0, "Unused", 0, 0,
+    "Unused", 0, 0, "Component type flags", 15, 0);
   ItemInfo[ITEM_BOOK] =
     new itemInfo("Book", "a book", "", 0, 0, "", 0, 0, "", 0, 0, "", 0, 0);
   ItemInfo[ITEM_PORTAL] =

--- a/code/code/misc/obj.cc
+++ b/code/code/misc/obj.cc
@@ -249,6 +249,8 @@ itemTypeT mapFileToItemType(int num) {
       return ITEM_MONEYPOUCH;
     case 76:
       return ITEM_FRUIT;
+    case 77:
+      return ITEM_TRAP_COMPONENT;
   }
   vlogf(LOG_BUG, format("Unknown type %d in map file") % num);
   return ITEM_UNDEFINED;
@@ -410,6 +412,8 @@ int mapItemTypeToFile(itemTypeT itt) {
       return 75;
     case ITEM_FRUIT:
       return 76;
+    case ITEM_TRAP_COMPONENT:
+      return 77;
     case MAX_OBJ_TYPES:
       break;
   }

--- a/code/code/misc/obj.h
+++ b/code/code/misc/obj.h
@@ -128,6 +128,7 @@ enum itemTypeT {
   ITEM_WAGON,
   ITEM_MONEYPOUCH,
   ITEM_FRUIT,
+  ITEM_TRAP_COMPONENT,
   MAX_OBJ_TYPES
 };
 const itemTypeT MIN_OBJ_TYPE = itemTypeT(0);

--- a/code/code/misc/thing.cc
+++ b/code/code/misc/thing.cc
@@ -136,7 +136,8 @@ int TThing::getCarriedVolume() const {
   }
 
   for (StuffIter it = stuff.begin(); it != stuff.end() && (t = *it); ++it) {
-    if (t->getKind() == TThing::TThingKind::TComponent)
+    if (t->getKind() == TThing::TThingKind::TComponent ||
+        t->getKind() == TThing::TThingKind::TTrapComponent)
       total += (int)(t->getTotalVolume() * 0.10);
     else
       total += t->getTotalVolume();

--- a/code/code/misc/thing.h
+++ b/code/code/misc/thing.h
@@ -63,6 +63,7 @@ class TThing {
       TRoom,
       TObj,  // there are many object types. Add overloads as needed.
       TComponent,
+      TTrapComponent,
       TBaseContainer,
     };
     virtual TThingKind getKind() const;

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -1160,17 +1160,12 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
 
 // returns DELETE_THIS or FALSE
 int TBeing::triggerDoorTrap(dirTypeT door) {
-  roomDirData *exitp, *back = NULL;
-  TRoom* rp;
-  int dam;
+  roomDirData *exitp, *back = nullptr;
+  TRoom* rp = nullptr;
   int rc;
 
   exitp = exitDir(door);
-  dam = dice(exitp->trap_dam, 8);
-
-  // door traps can be triggered by means other than opening
-  // eg trying to set another trap
-  //  rawOpenDoor(door);
+  int dam = dice(exitp->trap_dam, TRAP_DICE_SIZE);
 
   REMOVE_BIT(exitp->condition, EXIT_TRAPPED);
   if ((rp = real_roomp(exitp->to_room)) &&
@@ -1178,145 +1173,81 @@ int TBeing::triggerDoorTrap(dirTypeT door) {
     REMOVE_BIT(back->condition, EXIT_TRAPPED);
   }
 
-  act("You hear a strange noise...", TRUE, this, 0, 0, TO_ROOM);
-  act("You hear a strange noise...", TRUE, this, 0, 0, TO_CHAR);
+  act(STRANGE_NOISE_MSG, true, this, 0, 0, TO_ROOM);
+  act(STRANGE_NOISE_MSG, true, this, 0, 0, TO_CHAR);
 
-  switch (exitp->trap_info) {
+  const auto trapType = static_cast<doorTrapT>(exitp->trap_info);
+  const auto& info = trapTypeInfo[trapType];
+
+  // Source message — where the trap is
+  sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+  act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), false, this, 0, 0, TO_ROOM);
+
+  // Status-only types: dispatch to dedicated functions
+  switch (trapType) {
     case DOOR_TRAP_POISON:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
       trapPoison(dam);
-      break;
-    case DOOR_TRAP_SPIKE:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_PIERCE, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
+      return false;
     case DOOR_TRAP_SLEEP:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
       rc = trapSleep(dam);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
-      break;
-    case DOOR_TRAP_TNT:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      exitp->destroyDoor(door, in_room);
-
-      // Room-wide TNT effects
-      for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-        TThing* t = *(it++);
-        TBeing* tbt = dynamic_cast<TBeing*>(t);
-        if (tbt && this != tbt) {
-          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
-          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, dam * ROOM_MOD, NULL);
-          if (IS_SET_DELETE(rc, DELETE_THIS)) {
-            delete tbt;
-            tbt = NULL;
-          }
-        }
-      }
-
-      act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_TNT, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
-    case DOOR_TRAP_FIRE:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_FIRE, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      rc = flameEngulfed();
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
-    case DOOR_TRAP_ACID:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_ACID, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      rc = acidEngulfed();
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
+      return false;
     case DOOR_TRAP_DISEASE:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
       trapDisease(dam);
-      break;
+      return false;
     case DOOR_TRAP_TELEPORT:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
       rc = trapTeleport(dam);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return rc;
-    case DOOR_TRAP_HAMMER:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_BLUNT, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
-    case DOOR_TRAP_BLADE:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_SLASH, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
-    case DOOR_TRAP_ENERGY:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_ENERGY, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
-    case DOOR_TRAP_FROST:
-      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
-      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
-      act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
-      act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
-      rc = objDamage(DAMAGE_TRAP_FROST, dam, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      rc = frostEngulfed();
-      if (IS_SET_DELETE(rc, DELETE_THIS))
-        return DELETE_THIS;
-      break;
     default:
       break;
   }
-  return FALSE;
+
+  // Damage types: use table-driven path
+
+  // TNT special: destroy the door
+  if (trapType == DOOR_TRAP_TNT)
+    exitp->destroyDoor(door, in_room);
+
+  // Room-wide damage for area trap types
+  if (isDoorAreaTrap(trapType)) {
+    // Frost and energy skip immortals in the same room; TNT and acid do not
+    std::function<bool(TBeing*)> filter = nullptr;
+    if (trapType == DOOR_TRAP_FROST || trapType == DOOR_TRAP_ENERGY)
+      filter = [](TBeing* b) { return b->isImmortal(); };
+
+    applyRoomWideDamage(this, roomp, info, dam, ROOM_MOD, nullptr, filter);
+
+    // Other-side-of-door damage
+    if (rp)
+      applyOtherSideDamage(this, rp, info, dam);
+  }
+
+  // Effect messages and direct damage to triggerer
+  act(info.charMsg, false, this, 0, 0, TO_CHAR);
+  act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+  rc = objDamage(info.damageType, dam, nullptr);
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    return DELETE_THIS;
+
+  // Engulfed effect (fire, frost, acid)
+  if (info.engulfedFn) {
+    rc = (this->*(info.engulfedFn))();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+  }
+
+  return false;
 }
 
 // returns DELETE_VICT

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -691,7 +691,6 @@ int TBeing::doSetTraps(const char* arg) {
 int TBeing::triggerPortalTrap(TPortal* o) {
   int rc;
   int amnt;
-  TThing* t;
 
   act("You hear a strange noise...", TRUE, this, 0, 0, TO_ROOM);
   act("You hear a strange noise...", TRUE, this, 0, 0, TO_CHAR);
@@ -783,21 +782,9 @@ int TBeing::triggerPortalTrap(TPortal* o) {
       act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
       amnt = o->getPortalTrapDam();
 
-      // fry people in room
-
-      for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-        t = *(it++);
-        TBeing* tbt = dynamic_cast<TBeing*>(t);
-        if (tbt && this != tbt && !tbt->isImmortal()) {
-          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
-          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, o);
-          if (IS_SET_DELETE(rc, DELETE_THIS)) {
-            delete tbt;
-            tbt = NULL;
-          }
-        }
-      }
+      applyRoomWideDamage(this, roomp, trapTypeInfo[DOOR_TRAP_TNT],
+                          amnt, ROOM_MOD, o,
+                          [](TBeing* b) { return b->isImmortal(); });
 
       act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
       act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
@@ -906,19 +893,8 @@ int TBeing::triggerContTrap(TOpenContainer* obj) {
         t = NULL;
       }
       // fry people in room
-      for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-        t = *(it++);
-        TBeing* tbt = dynamic_cast<TBeing*>(t);
-        if (tbt && this != tbt) {
-          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
-          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, obj);
-          if (IS_SET_DELETE(rc, DELETE_THIS)) {
-            delete tbt;
-            tbt = NULL;
-          }
-        }
-      }
+      applyRoomWideDamage(this, roomp, trapTypeInfo[DOOR_TRAP_TNT],
+                          amnt, ROOM_MOD, obj);
       act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
       act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = objDamage(DAMAGE_TRAP_TNT, amnt, obj);
@@ -1018,7 +994,6 @@ int TBeing::triggerContTrap(TOpenContainer* obj) {
 // triggers when arrow hits
 int TBeing::triggerArrowTrap(TArrow* obj) {
   int rc = 0;
-  TThing* t;
   int amnt;
 
   act(STRANGE_NOISE_MSG, TRUE, this, 0, 0, TO_ROOM);
@@ -1090,20 +1065,9 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
     case DOOR_TRAP_TNT:
       amnt = obj->getTrapDamAmount();
 
-      // fry people in room
-      for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-        t = *(it++);
-        TBeing* tbt = dynamic_cast<TBeing*>(t);
-        if (tbt && this != tbt && !tbt->isImmortal()) {
-          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
-          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, obj);
-          if (IS_SET_DELETE(rc, DELETE_THIS)) {
-            delete tbt;
-            tbt = NULL;
-          }
-        }
-      }
+      applyRoomWideDamage(this, roomp, trapTypeInfo[DOOR_TRAP_TNT],
+                          amnt, ROOM_MOD, obj,
+                          [](TBeing* b) { return b->isImmortal(); });
 
       act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
       act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -1602,286 +1602,6 @@ int TBeing::triggerTrap(TTrap* o) {
   return TRUE;
 }
 
-// returns DELETE_THIs or FALSE
-int TBeing::trapDoorTntDamage(int amnt, dirTypeT door) {
-  TThing* t;
-  int rc;
-
-  sendToRoom("You hear a loud boom.\n\r", in_room);
-  sendToRoom("The door is ripped apart by some sort of explosive.\n\r",
-    in_room);
-
-  for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-    t = *(it++);
-    TBeing* tbt = dynamic_cast<TBeing*>(t);
-    if (tbt && this != tbt) {
-      rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS)) {
-        delete tbt;
-        tbt = NULL;
-      }
-    }
-  }
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom("You hear a loud boom.\n\r", exitDir(door)->to_room);
-    sendToRoom("The door is ripped apart by some sort of explosive.\n\r",
-      exitDir(door)->to_room);
-
-    for (StuffIter it = rp->stuff.begin(); it != rp->stuff.end();) {
-      t = *(it++);
-      TBeing* tbt = dynamic_cast<TBeing*>(t);
-      if (tbt && this != tbt) {
-        rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * OTHER_SIDE_MOD, NULL);
-        if (IS_SET_DELETE(rc, DELETE_THIS)) {
-          delete tbt;
-          tbt = NULL;
-        }
-      }
-    }
-  }
-
-  // apply top opened
-  return objDamage(DAMAGE_TRAP_TNT, amnt, NULL);
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorPierceDamage(int amnt, dirTypeT door) {
-  char buf[256];
-
-  sprintf(buf,
-    "You hear a loud metallic sound as a sharpened spike leaps out of the "
-    "%s!\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom(buf, exitDir(door)->to_room);
-  }
-
-  act("$n is skewered by the spike.", TRUE, this, 0, 0, TO_ROOM);
-  act("You are skewered by the spike.", TRUE, this, 0, 0, TO_CHAR);
-  return objDamage(DAMAGE_TRAP_PIERCE, amnt, NULL);
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorHammerDamage(int amnt, dirTypeT door) {
-  char buf[256];
-
-  sprintf(buf,
-    "You hear a grinding noise as giant weights fall from above the %s!\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom(buf, exitDir(door)->to_room);
-  }
-
-  act("$n is hit by a falling weight.", TRUE, this, 0, 0, TO_ROOM);
-  act("You are crushed by a falling weight.", TRUE, this, 0, 0, TO_CHAR);
-  return objDamage(DAMAGE_TRAP_BLUNT, amnt, NULL);
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorSlashDamage(int amnt, dirTypeT door) {
-  char buf[256];
-
-  sprintf(buf,
-    "You hear a grinding noise as swinging blades slice out of %s!\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom(buf, exitDir(door)->to_room);
-  }
-
-  act("$n is cut by the blades.", TRUE, this, 0, 0, TO_ROOM);
-  act("You are cut by the blades.", TRUE, this, 0, 0, TO_CHAR);
-  return objDamage(DAMAGE_TRAP_SLASH, amnt, NULL);
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorFrostDamage(int amnt, dirTypeT door) {
-  TThing* t;
-  int rc;
-  char buf[256];
-
-  sprintf(buf,
-    "You hear a high pitched whine as a frosty blast rushes out of the %s!\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-    t = *(it++);
-    TBeing* tbt = dynamic_cast<TBeing*>(t);
-    if (tbt && this != tbt && !tbt->isImmortal()) {
-      act("$n is chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_ROOM);
-      act("You are chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_CHAR);
-      rc = tbt->objDamage(DAMAGE_TRAP_FROST, amnt * ROOM_MOD, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS)) {
-        delete tbt;
-        tbt = NULL;
-      }
-    }
-  }
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom(buf, exitDir(door)->to_room);
-
-    for (StuffIter it = rp->stuff.begin(); it != rp->stuff.end();) {
-      t = *(it++);
-      TBeing* tbt = dynamic_cast<TBeing*>(t);
-      if (tbt && this != tbt) {
-        act("$n is chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_ROOM);
-        act("You are chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_CHAR);
-        rc = tbt->objDamage(DAMAGE_TRAP_FROST, amnt * OTHER_SIDE_MOD, NULL);
-        if (IS_SET_DELETE(rc, DELETE_THIS)) {
-          delete tbt;
-          tbt = NULL;
-        }
-      }
-    }
-  }
-
-  act("$n is frozen by the arctic blast.", TRUE, this, 0, 0, TO_ROOM);
-  act("You are frozen by the arctic blast.", TRUE, this, 0, 0, TO_CHAR);
-
-  rc = frostEngulfed();
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-
-  return objDamage(DAMAGE_TRAP_FROST, amnt, NULL);
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorEnergyDamage(int amnt, dirTypeT door) {
-  TThing* t;
-  int rc;
-  char buf[256];
-
-  sprintf(buf,
-    "You hear a powerful humming as bolts of plasma stream out of the %s!\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-    t = *(it++);
-    TBeing* tbt = dynamic_cast<TBeing*>(t);
-    if (tbt && this != tbt && !tbt->isImmortal()) {
-      act("$n is hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_ROOM);
-      act("You are hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_CHAR);
-      rc = tbt->objDamage(DAMAGE_TRAP_ENERGY, amnt * ROOM_MOD, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS)) {
-        delete tbt;
-        tbt = NULL;
-      }
-    }
-  }
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom(buf, exitDir(door)->to_room);
-
-    for (StuffIter it = rp->stuff.begin(); it != rp->stuff.end();) {
-      t = *(it++);
-      TBeing* tbt = dynamic_cast<TBeing*>(t);
-      if (tbt && this != tbt) {
-        act("$n is hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_ROOM);
-        act("You are hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_CHAR);
-        rc = tbt->objDamage(DAMAGE_TRAP_ENERGY, amnt * OTHER_SIDE_MOD, NULL);
-        if (IS_SET_DELETE(rc, DELETE_THIS)) {
-          delete tbt;
-          tbt = NULL;
-        }
-      }
-    }
-  }
-
-  act("$n is blasted by numerous plasma bolts!", TRUE, this, 0, 0, TO_ROOM);
-  act("You are blasted by numerous plasma bolts!", TRUE, this, 0, 0, TO_CHAR);
-
-  return objDamage(DAMAGE_TRAP_ENERGY, amnt, NULL);
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorFireDamage(int amnt, dirTypeT door) {
-  int rc;
-  char buf[256];
-
-  sprintf(buf,
-    "You feel an intense amount of heat as flames shoot from a %s!\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  act("$n is enveloped by flames.", TRUE, this, 0, 0, TO_ROOM);
-  act("You are enveloped by fire.", TRUE, this, 0, 0, TO_CHAR);
-
-  rc = flameEngulfed();
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-
-  rc = objDamage(DAMAGE_TRAP_FIRE, amnt, NULL);
-  return rc;
-}
-
-// returns DELETE_THIS or FALSE
-int TBeing::trapDoorAcidDamage(int amnt, dirTypeT door) {
-  TThing* t;
-  int rc;
-  char buf[256];
-
-  sprintf(buf, "A strange liquid squirts everywhere as the %s is opened.\n\r",
-    fname(exitDir(door)->keyword).c_str());
-  sendToRoom(buf, in_room);
-
-  for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-    t = *(it++);
-    TBeing* tbt = dynamic_cast<TBeing*>(t);
-    if (tbt && this != tbt) {
-      rc = tbt->objDamage(DAMAGE_TRAP_ACID, amnt * ROOM_MOD, NULL);
-      if (IS_SET_DELETE(rc, DELETE_THIS)) {
-        delete tbt;
-        tbt = NULL;
-      }
-    }
-  }
-
-  // blow other side too
-  TRoom* rp;
-  if ((rp = real_roomp(exitDir(door)->to_room))) {
-    sendToRoom(buf, exitDir(door)->to_room);
-
-    for (StuffIter it = rp->stuff.begin(); it != rp->stuff.end();) {
-      t = *(it++);
-      TBeing* tbt = dynamic_cast<TBeing*>(t);
-      if (tbt && this != tbt) {
-        rc = tbt->objDamage(DAMAGE_TRAP_ACID, amnt * OTHER_SIDE_MOD, NULL);
-        if (IS_SET_DELETE(rc, DELETE_THIS)) {
-          delete tbt;
-          tbt = NULL;
-        }
-      }
-    }
-  }
-
-  rc = acidEngulfed();
-  if (IS_SET_DELETE(rc, DELETE_THIS))
-    return DELETE_THIS;
-
-  return objDamage(DAMAGE_TRAP_ACID, amnt, NULL);
-}
-
 // returns DELETE_THIS
 int TBeing::trapTeleport(int amt) {
   int rc;
@@ -2828,8 +2548,7 @@ int TObj::grenadeHit(TTrap* o) {
 }
 
 namespace {
-  // Door trap damage modifiers
-  constexpr int getDoorTrapDamageModifier(doorTrapT trap_type) {
+  constexpr int getTrapDamageModifier(doorTrapT trap_type) {
     switch (trap_type) {
       case DOOR_TRAP_TNT: return 3;
       case DOOR_TRAP_POISON: return -1;
@@ -2891,7 +2610,7 @@ int TBeing::getDoorTrapDam(doorTrapT trap_type) {
   int damage = 10 + getSkillLevel(SKILL_SET_TRAP_DOOR) / 2;
   damage *= getDoorTrapLearn(trap_type);
   damage /= 100;
-  damage += getDoorTrapDamageModifier(trap_type);
+  damage += getTrapDamageModifier(trap_type);
   return min(max(damage, 1), 50);
 }
 
@@ -2900,7 +2619,7 @@ int TBeing::getContainerTrapDam(doorTrapT trap_type) {
   int damage = 20 + getSkillLevel(SKILL_SET_TRAP_CONT) / 3;
   damage *= getContainerTrapLearn(trap_type);
   damage /= 100;
-  damage += getDoorTrapDamageModifier(trap_type);  // Same modifiers as door traps
+  damage += getTrapDamageModifier(trap_type);
   return min(max(damage, 1), 50);
 }
 
@@ -2909,7 +2628,7 @@ int TBeing::getMineTrapDam(doorTrapT trap_type) {
   int damage = 20 + getSkillLevel(SKILL_SET_TRAP_MINE) / 2;
   damage *= getMineTrapLearn(trap_type);
   damage /= 100;
-  damage += getDoorTrapDamageModifier(trap_type);  // Same modifiers as door traps
+  damage += getTrapDamageModifier(trap_type);
   return min(max(damage, 1), 50);
 }
 
@@ -2923,52 +2642,7 @@ int TBeing::getGrenadeTrapDam(doorTrapT trap_type) {
   damage *= getGrenadeTrapLearn(trap_type);
   damage /= 100;
 
-  switch (trap_type) {
-    case DOOR_TRAP_TNT:
-      damage += 3;
-      break;
-    case DOOR_TRAP_POISON:
-      damage -= 1;
-      break;
-    case DOOR_TRAP_SLEEP:
-      damage += 1;
-      break;
-    case DOOR_TRAP_ACID:
-      damage += 1;
-      break;
-    case DOOR_TRAP_DISEASE:
-      damage += 3;
-      break;
-    case DOOR_TRAP_FROST:
-      damage += 3;
-      break;
-    case DOOR_TRAP_SPIKE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_BOLT:
-      damage += 1;
-      break;
-    case DOOR_TRAP_BLADE:
-      damage -= 3;
-      break;
-    case DOOR_TRAP_DISK:
-      damage += 3;
-      break;
-    case DOOR_TRAP_HAMMER:
-      damage -= 10;
-      break;
-    case DOOR_TRAP_PEBBLE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_ENERGY:
-      damage += 5;
-      break;
-    case DOOR_TRAP_TELEPORT:
-      damage += 5;
-      break;
-    default:
-      break;
-  }
+  damage += getTrapDamageModifier(trap_type);
   damage = min(max(damage, 1), 50);
   return damage;
 }
@@ -2980,49 +2654,7 @@ int TBeing::getArrowTrapDam(doorTrapT trap_type) {
   damage *= getArrowTrapLearn(trap_type);
   damage /= 100;
 
-  switch (trap_type) {
-    case DOOR_TRAP_TNT:
-      damage += 3;
-      break;
-    case DOOR_TRAP_SLEEP:
-      damage += 1;
-      break;
-    case DOOR_TRAP_ACID:
-      damage += 1;
-      break;
-    case DOOR_TRAP_DISEASE:
-      damage += 3;
-      break;
-    case DOOR_TRAP_FROST:
-      damage += 3;
-      break;
-    case DOOR_TRAP_SPIKE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_BOLT:
-      damage += 1;
-      break;
-    case DOOR_TRAP_BLADE:
-      damage -= 3;
-      break;
-    case DOOR_TRAP_DISK:
-      damage += 3;
-      break;
-    case DOOR_TRAP_HAMMER:
-      damage -= 10;
-      break;
-    case DOOR_TRAP_PEBBLE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_ENERGY:
-      damage += 5;
-      break;
-    case DOOR_TRAP_TELEPORT:
-      damage += 5;
-      break;
-    default:
-      break;
-  }
+  damage += getTrapDamageModifier(trap_type);
   damage = min(max(damage, 1), 50);
   return damage;
 }

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -16,6 +16,7 @@
 #include "disc_thief_looting.h"
 #include "disease.h"
 #include "obj_trap.h"
+#include "obj_trap_component.h"
 #include "obj_portal.h"
 #include "obj_open_container.h"
 #include "obj_arrow.h"
@@ -24,86 +25,319 @@
 extern const char* const GRENADE_EX_DESC = "__grenade_puller";
 extern const char* const TRAP_EX_DESC = "__trap_setter";
 
-doorTrapT mapFileToDoorTrap(int dt) {
-  switch (dt) {
-    case 0:
-      return DOOR_TRAP_NONE;
-    case 1:
-      return DOOR_TRAP_POISON;
-    case 2:
-      return DOOR_TRAP_SPIKE;
-    case 3:
-      return DOOR_TRAP_SLEEP;
-    case 4:
-      return DOOR_TRAP_TNT;
-    case 5:
-      return DOOR_TRAP_BLADE;
-    case 6:
-      return DOOR_TRAP_FIRE;
-    case 7:
-      return DOOR_TRAP_ACID;
-    case 8:
-      return DOOR_TRAP_DISEASE;
-    case 9:
-      return DOOR_TRAP_HAMMER;
-    case 10:
-      return DOOR_TRAP_FROST;
-    case 11:
-      return DOOR_TRAP_TELEPORT;
-    case 12:
-      return DOOR_TRAP_ENERGY;
-    case 13:
-      return DOOR_TRAP_BOLT;
-    case 14:
-      return DOOR_TRAP_DISK;
-    case 15:
-      return DOOR_TRAP_PEBBLE;
-  }
+// Constants for trap mechanics
+namespace {
+  constexpr int TRAP_DICE_SIZE = 8;
+  constexpr int TRAP_GOOF_DAMAGE_DIVISOR = 3;
 
-  vlogf(LOG_BUG, format("Bad value (%d) in mapFileToDoorTrap") % dt);
-  return MAX_TRAP_TYPES;
+  // Fixed durations for trap status effects (in mud-hours)
+  constexpr int SLEEP_DURATION_HOURS = 2;
+  constexpr int DISEASE_DURATION_HOURS = 4;
+  constexpr int POISON_DURATION_HOURS = 12;
+  constexpr int POISON_STR_MODIFIER = -20;
+
+  // Disease duration multipliers (applied based on luck/toughness checks)
+  constexpr int SEVERE_DISEASE_MULTIPLIER = 4;
+  constexpr int MODERATE_DISEASE_MULTIPLIER = 2;
+
+  // Room effect modifiers - different for status vs damage effects
+  constexpr double STATUS_ROOM_MOD = 2.0/3.0;  // 66.7% strength for status effects (poison, sleep, disease, teleport)
+  constexpr double DAMAGE_ROOM_MOD = 0.5;       // 50% strength for damage effects (fire, frost, energy, acid, TNT, etc.)
+
+  // Context-based damage multipliers - same modifier for all damage types in each context
+  constexpr double GOOF_MOD = 0.5;        // When traps backfire on the setter
+  constexpr double ROOM_MOD = DAMAGE_ROOM_MOD;  // Legacy alias for damage room effects
+  constexpr double OTHER_SIDE_MOD = 1.0/3.0;     // When effects reach through doors/walls
+
+  // Common trap messages
+  constexpr const char* STRANGE_NOISE_MSG = "You hear a strange noise...";
+  constexpr const char* NOTHING_HAPPENS_CHAR_MSG = "...But nothing happens.";
+  constexpr const char* NOTHING_HAPPENS_ROOM_MSG = "...But nothing happens.";
+
+  // Standardized trap source messages - WHERE the trap comes from
+  constexpr const char* DOOR_TRAP_CHAR_MSG = "A mechanism in the %s triggers!\n\r";
+  constexpr const char* DOOR_TRAP_ROOM_MSG = "A mechanism in the %s triggers!";
+  constexpr const char* PORTAL_TRAP_CHAR_MSG = "A mechanism in the %s triggers!\n\r";
+  constexpr const char* PORTAL_TRAP_ROOM_MSG = "A mechanism in the %s triggers!";
+  constexpr const char* CONTAINER_TRAP_CHAR_MSG = "The %s springs a trap!\n\r";
+  constexpr const char* CONTAINER_TRAP_ROOM_MSG = "The %s springs a trap!";
+  constexpr const char* MINE_TRAP_CHAR_MSG = "The %s detonates!\n\r";
+  constexpr const char* MINE_TRAP_ROOM_MSG = "The %s detonates!";
+  constexpr const char* ARROW_TRAP_CHAR_MSG = "The %s releases its trapped payload!\n\r";
+  constexpr const char* ARROW_TRAP_ROOM_MSG = "The %s releases its trapped payload!";
+
+  // Standardized trap effect messages - used across ALL contexts
+  constexpr const char* POISON_EFFECT_CHAR_MSG = "You are sprayed with contact poison!";
+  constexpr const char* POISON_EFFECT_ROOM_MSG = "$n is sprayed with contact poison!";
+  constexpr const char* SLEEP_EFFECT_CHAR_MSG = "You are surrounded by a noxious mist!";
+  constexpr const char* SLEEP_EFFECT_ROOM_MSG = "$n is surrounded by a noxious mist!";
+  constexpr const char* FIRE_EFFECT_CHAR_MSG = "You are burned by the flames!";
+  constexpr const char* FIRE_EFFECT_ROOM_MSG = "$n is burned by the flames.";
+  constexpr const char* FROST_EFFECT_CHAR_MSG = "You are chilled by the arctic blast!";
+  constexpr const char* FROST_EFFECT_ROOM_MSG = "$n is chilled by the arctic blast.";
+  constexpr const char* ACID_EFFECT_CHAR_MSG = "You are surrounded by the acid cloud!";
+  constexpr const char* ACID_EFFECT_ROOM_MSG = "$n is surrounded by the acid cloud.";
+  constexpr const char* ENERGY_EFFECT_CHAR_MSG = "You are hit by the energy bolts!";
+  constexpr const char* ENERGY_EFFECT_ROOM_MSG = "$n is hit by the energy bolts.";
+  constexpr const char* SPIKE_EFFECT_CHAR_MSG = "You are impaled by the spikes!";
+  constexpr const char* SPIKE_EFFECT_ROOM_MSG = "$n is impaled by the spikes.";
+  constexpr const char* BLADE_EFFECT_CHAR_MSG = "You are sliced by the razor blades!";
+  constexpr const char* BLADE_EFFECT_ROOM_MSG = "$n is sliced by the razor blades.";
+  constexpr const char* BLUNT_EFFECT_CHAR_MSG = "You are pummeled by the heavy weights!";
+  constexpr const char* BLUNT_EFFECT_ROOM_MSG = "$n is pummeled by the heavy weights.";
+  constexpr const char* TELEPORT_EFFECT_CHAR_MSG = "You find yourself sucked into the vortex!";
+  constexpr const char* TELEPORT_EFFECT_ROOM_MSG = "$n flails wildly, but falls into the vortex.";
+  constexpr const char* DISEASE_EFFECT_CHAR_MSG = "You are surrounded by a cloud of spores!";
+  constexpr const char* DISEASE_EFFECT_ROOM_MSG = "$n is surrounded by a cloud of spores.";
+  constexpr const char* TNT_EFFECT_CHAR_MSG = "You are hit by the explosive shrapnel!";
+  constexpr const char* TNT_EFFECT_ROOM_MSG = "$n is hit by the explosive shrapnel.";
+  // Consolidated trap goof messages
+  constexpr const char* GOOF_CHAR_MSG = "Your hand slips and you fall victim to your own device!";
+  constexpr const char* GOOF_ROOM_MSG = "$n's hand slips and $e falls victim to $s own device!";
+
+  // Standardized trap creation messages
+  constexpr const char* TRAP_START_CHAR_MSG = "You start working on your trap.";
+  constexpr const char* TRAP_START_MINE_ROOM_MSG = "$n starts constructing a land-mine.";
+  constexpr const char* TRAP_START_ARROW_ROOM_MSG = "$n starts trapping an arrow.";
+  constexpr const char* TRAP_START_GRENADE_ROOM_MSG = "$n starts constructing a grenade.";
+
+  // Standardized component assembly messages
+  constexpr const char* ATTACH_CHAR_MSG = "You attach the %s to the %s.\n\r";
+  constexpr const char* ATTACH_ROOM_MSG = "$n attaches the %s to the %s.";
+  constexpr const char* PLACE_CHAR_MSG = "You place the %s into the %s.\n\r";
+  constexpr const char* PLACE_ROOM_MSG = "$n places the %s into the %s.";
+  constexpr const char* CONNECT_CHAR_MSG = "You connect the %s to the %s.\n\r";
+  constexpr const char* CONNECT_ROOM_MSG = "$n connects the %s to the %s.";
+  constexpr const char* ARM_CHAR_MSG = "You arm the %s mechanism.\n\r";
+  constexpr const char* ARM_ROOM_MSG = "$n arms the %s mechanism.";
+  constexpr const char* CONCEAL_CHAR_MSG = "You conceal the %s inside the %s.\n\r";
+  constexpr const char* CONCEAL_ROOM_MSG = "$n conceals the %s inside the %s.";
+
+  // Component name mapping for clean messages
+  const char* getComponentName(int vnum) {
+    switch (vnum) {
+      case Obj::ST_FLINT: return "flint";
+      case Obj::ST_SULPHUR: return "sulphur";
+      case Obj::ST_BAG: return "bellows";
+      case Obj::ST_BELLOWS: return "bellows";
+      case Obj::ST_HYDROGEN: return "compressed gas";
+      case Obj::ST_NEEDLE: return "needle";
+      case Obj::ST_SPRING: return "spring";
+      case Obj::ST_POISON: return "poison";
+      case Obj::ST_CANISTER: return "canister";
+      case Obj::ST_CON_POISON: return "concentrated poison";
+      case Obj::ST_TRIPWIRE: return "tripwire";
+      case Obj::ST_PENTAGRAM: return "pentagram";
+      case Obj::ST_ATHANOR: return "athanor";
+      case Obj::ST_CRYSTALINE: return "crystal";
+      case Obj::ST_BOLTS: return "bolts";
+      case Obj::ST_TUBING: return "tubing";
+      case Obj::ST_PEBBLES: return "pebbles";
+      case Obj::ST_RAZOR_DISK: return "razor discs";
+      case Obj::ST_FUNGUS: return "spores";
+      case Obj::ST_ACID_VIAL: return "acid vial";
+      case Obj::ST_FROST: return "frost compound";
+      case Obj::ST_CONCRETE: return "concrete weight";
+      case Obj::ST_RAZOR_BLADE: return "razor blade";
+      case Obj::ST_NOZZLE: return "nozzle";
+      case Obj::ST_HOSE: return "hose";
+      case Obj::ST_GAS: return "gas";
+      case Obj::ST_CGAS: return "compressed gas";
+      case Obj::ST_SPIKE: return "spike";
+      case Obj::ST_WEDGE: return "wedge";
+      case Obj::ST_BLINK: return "blink powder";
+      default: return "component";
+    }
+  }
+}
+
+// Returns the 3 component vnums for a given trap type string and target context.
+// Must match hasTrapComps() logic exactly — both are authoritative for component lists.
+// Returns false if the trap type is unrecognized.
+bool getTrapComponents(const char* trap_type, trap_targ_t targ,
+                       int& item1, int& item2, int& item3) {
+  item1 = item2 = item3 = 0;
+  bool isPortable = (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE);
+  bool isArrow = (targ == TRAP_TARG_ARROW);
+
+  if (is_abbrev(trap_type, "fire")) {
+    if (isArrow) {
+      item1 = Obj::ST_FLINT; item2 = Obj::ST_SULPHUR; item3 = Obj::ST_TRIPWIRE;
+    } else {
+      item1 = Obj::ST_FLINT; item2 = Obj::ST_SULPHUR; item3 = Obj::ST_BAG;
+    }
+  } else if (is_abbrev(trap_type, "explosive")) {
+    if (isArrow) {
+      item1 = Obj::ST_FLINT; item2 = Obj::ST_SULPHUR; item3 = Obj::ST_TRIPWIRE;
+    } else {
+      item1 = Obj::ST_FLINT; item2 = Obj::ST_SULPHUR; item3 = Obj::ST_HYDROGEN;
+    }
+  } else if (is_abbrev(trap_type, "poison")) {
+    if (isArrow) {
+      item1 = Obj::ST_NEEDLE; item2 = Obj::ST_POISON; item3 = Obj::ST_TRIPWIRE;
+    } else if (isPortable) {
+      item1 = Obj::ST_CANISTER; item2 = Obj::ST_SPRING; item3 = Obj::ST_CON_POISON;
+    } else {
+      item1 = Obj::ST_NEEDLE; item2 = Obj::ST_SPRING; item3 = Obj::ST_POISON;
+    }
+  } else if (is_abbrev(trap_type, "sleep")) {
+    if (isArrow) {
+      item1 = Obj::ST_FUNGUS; item2 = Obj::ST_BELLOWS; item3 = Obj::ST_TRIPWIRE;
+    } else {
+      item1 = Obj::ST_NOZZLE; item2 = Obj::ST_GAS; item3 = Obj::ST_HOSE;
+    }
+  } else if (is_abbrev(trap_type, "acid")) {
+    if (isArrow) {
+      item1 = Obj::ST_ACID_VIAL; item2 = Obj::ST_NOZZLE; item3 = Obj::ST_TRIPWIRE;
+    } else if (isPortable) {
+      item1 = Obj::ST_CANISTER; item2 = Obj::ST_SPRING; item3 = Obj::ST_ACID_VIAL;
+    } else {
+      item1 = Obj::ST_NOZZLE; item2 = Obj::ST_ACID_VIAL; item3 = Obj::ST_BELLOWS;
+    }
+  } else if (is_abbrev(trap_type, "spore")) {
+    if (isArrow) {
+      item1 = Obj::ST_FUNGUS; item2 = Obj::ST_NOZZLE; item3 = Obj::ST_TRIPWIRE;
+    } else if (isPortable) {
+      item1 = Obj::ST_CANISTER; item2 = Obj::ST_SPRING; item3 = Obj::ST_FUNGUS;
+    } else {
+      item1 = Obj::ST_FUNGUS; item2 = Obj::ST_NOZZLE; item3 = Obj::ST_BELLOWS;
+    }
+  } else if (is_abbrev(trap_type, "spike")) {
+    item1 = Obj::ST_SPIKE; item2 = Obj::ST_SPRING; item3 = Obj::ST_TRIPWIRE;
+  } else if (is_abbrev(trap_type, "bolt")) {
+    item1 = Obj::ST_TUBING; item2 = Obj::ST_CGAS; item3 = Obj::ST_BOLTS;
+  } else if (is_abbrev(trap_type, "blade")) {
+    item1 = Obj::ST_RAZOR_BLADE; item2 = Obj::ST_SPRING; item3 = Obj::ST_TRIPWIRE;
+  } else if (is_abbrev(trap_type, "disc") || is_abbrev(trap_type, "disk")) {
+    item1 = Obj::ST_RAZOR_DISK; item2 = Obj::ST_SPRING; item3 = Obj::ST_CANISTER;
+  } else if (is_abbrev(trap_type, "hammer")) {
+    item1 = Obj::ST_CONCRETE; item2 = Obj::ST_WEDGE; item3 = Obj::ST_TRIPWIRE;
+  } else if (is_abbrev(trap_type, "pebble")) {
+    item1 = Obj::ST_TUBING; item2 = Obj::ST_CGAS; item3 = Obj::ST_PEBBLES;
+  } else if (is_abbrev(trap_type, "frost")) {
+    if (isArrow) {
+      item1 = Obj::ST_FROST; item2 = Obj::ST_BELLOWS; item3 = Obj::ST_TRIPWIRE;
+    } else {
+      item1 = Obj::ST_NOZZLE; item2 = Obj::ST_HOSE; item3 = Obj::ST_FROST;
+    }
+  } else if (is_abbrev(trap_type, "teleport")) {
+    if (isArrow) {
+      item1 = Obj::ST_PENTAGRAM; item2 = Obj::ST_BLINK; item3 = Obj::ST_TRIPWIRE;
+    } else if (isPortable) {
+      item1 = Obj::ST_PENTAGRAM; item2 = Obj::ST_CRYSTALINE; item3 = Obj::ST_BLINK;
+    } else {
+      item1 = Obj::ST_PENTAGRAM; item2 = Obj::ST_TRIPWIRE; item3 = Obj::ST_BLINK;
+    }
+  } else if (is_abbrev(trap_type, "power") || is_abbrev(trap_type, "energy")) {
+    if (isArrow) {
+      item1 = Obj::ST_PENTAGRAM; item2 = Obj::ST_ATHANOR; item3 = Obj::ST_TRIPWIRE;
+    } else if (isPortable) {
+      item1 = Obj::ST_PENTAGRAM; item2 = Obj::ST_CRYSTALINE; item3 = Obj::ST_ATHANOR;
+    } else {
+      item1 = Obj::ST_PENTAGRAM; item2 = Obj::ST_TRIPWIRE; item3 = Obj::ST_ATHANOR;
+    }
+  } else {
+    return false;
+  }
+  return true;
+}
+
+namespace {
+  // Mapping tables for trap type conversion
+  constexpr doorTrapT FILE_TO_TRAP_MAP[] = {
+    DOOR_TRAP_NONE,     // 0
+    DOOR_TRAP_POISON,   // 1
+    DOOR_TRAP_SPIKE,    // 2
+    DOOR_TRAP_SLEEP,    // 3
+    DOOR_TRAP_TNT,      // 4
+    DOOR_TRAP_BLADE,    // 5
+    DOOR_TRAP_FIRE,     // 6
+    DOOR_TRAP_ACID,     // 7
+    DOOR_TRAP_DISEASE,  // 8
+    DOOR_TRAP_HAMMER,   // 9
+    DOOR_TRAP_FROST,    // 10
+    DOOR_TRAP_TELEPORT, // 11
+    DOOR_TRAP_ENERGY,   // 12
+    DOOR_TRAP_BOLT,     // 13
+    DOOR_TRAP_DISK,     // 14
+    DOOR_TRAP_PEBBLE    // 15
+  };
+
+  constexpr int TRAP_TO_FILE_MAP[] = {
+    0,  // DOOR_TRAP_NONE
+    1,  // DOOR_TRAP_POISON
+    2,  // DOOR_TRAP_SPIKE
+    3,  // DOOR_TRAP_SLEEP
+    4,  // DOOR_TRAP_TNT
+    5,  // DOOR_TRAP_BLADE
+    6,  // DOOR_TRAP_FIRE
+    7,  // DOOR_TRAP_ACID
+    8,  // DOOR_TRAP_DISEASE
+    9,  // DOOR_TRAP_HAMMER
+    10, // DOOR_TRAP_FROST
+    11, // DOOR_TRAP_TELEPORT
+    12, // DOOR_TRAP_ENERGY
+    13, // DOOR_TRAP_BOLT
+    14, // DOOR_TRAP_DISK
+    15  // DOOR_TRAP_PEBBLE
+  };
+
+  constexpr size_t MAX_FILE_TRAP_VALUE = sizeof(FILE_TO_TRAP_MAP) / sizeof(FILE_TO_TRAP_MAP[0]) - 1;
+}
+
+doorTrapT mapFileToDoorTrap(int dt) {
+  if (dt < 0 || dt > static_cast<int>(MAX_FILE_TRAP_VALUE)) {
+    vlogf(LOG_BUG, format("Bad value (%d) in mapFileToDoorTrap") % dt);
+    return MAX_TRAP_TYPES;
+  }
+  return FILE_TO_TRAP_MAP[dt];
 }
 
 int mapDoorTrapToFile(doorTrapT dt) {
-  switch (dt) {
-    case DOOR_TRAP_NONE:
-      return 0;
-    case DOOR_TRAP_POISON:
-      return 1;
-    case DOOR_TRAP_SPIKE:
-      return 2;
-    case DOOR_TRAP_SLEEP:
-      return 3;
-    case DOOR_TRAP_TNT:
-      return 4;
-    case DOOR_TRAP_BLADE:
-      return 5;
-    case DOOR_TRAP_FIRE:
-      return 6;
-    case DOOR_TRAP_ACID:
-      return 7;
-    case DOOR_TRAP_DISEASE:
-      return 8;
-    case DOOR_TRAP_HAMMER:
-      return 9;
-    case DOOR_TRAP_FROST:
-      return 10;
-    case DOOR_TRAP_TELEPORT:
-      return 11;
-    case DOOR_TRAP_ENERGY:
-      return 12;
-    case DOOR_TRAP_BOLT:
-      return 13;
-    case DOOR_TRAP_DISK:
-      return 14;
-    case DOOR_TRAP_PEBBLE:
-      return 15;
-    case MAX_TRAP_TYPES:
-      break;
+  if (dt < 0 || dt >= MAX_TRAP_TYPES) {
+    vlogf(LOG_BUG, format("Bad value (%d) in mapDoorTrapToFile") % dt);
+    return -1;
+  }
+  return TRAP_TO_FILE_MAP[dt];
+}
+
+// Standardized trap assembly message function
+void sendTrapMessage(TBeing* ch, const char* trap_type, trap_targ_t targ, int step) {
+  int item1 = 0, item2 = 0, item3 = 0;
+
+  if (!getTrapComponents(trap_type, targ, item1, item2, item3)) {
+    // Unrecognized trap type — use generic fallback
+    item1 = Obj::ST_SPRING; item2 = Obj::ST_TRIPWIRE; item3 = Obj::ST_CANISTER;
   }
 
-  vlogf(LOG_BUG, format("Bad value (%d) in mapDoorTrapToFile") % dt);
-  return -1;
+  // Send standardized messages based on step
+  switch (step) {
+    case 1:
+      ch->sendTo(format(ATTACH_CHAR_MSG) % getComponentName(item1) % getComponentName(item2));
+      act(format(ATTACH_ROOM_MSG) % getComponentName(item1) % getComponentName(item2), TRUE, ch, nullptr, nullptr, TO_ROOM);
+      break;
+    case 2:
+      ch->sendTo(format(CONNECT_CHAR_MSG) % getComponentName(item2) % getComponentName(item3));
+      act(format(CONNECT_ROOM_MSG) % getComponentName(item2) % getComponentName(item3), TRUE, ch, nullptr, nullptr, TO_ROOM);
+      break;
+    case 3:
+      ch->sendTo(format(ARM_CHAR_MSG) % "trigger");
+      act(format(ARM_ROOM_MSG) % "trigger", TRUE, ch, nullptr, nullptr, TO_ROOM);
+      break;
+    case 4:
+      if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
+        ch->sendTo(format(CONCEAL_CHAR_MSG) % "mechanism" % "casing");
+        act(format(CONCEAL_ROOM_MSG) % "mechanism" % "casing", TRUE, ch, nullptr, nullptr, TO_ROOM);
+      } else {
+        ch->sendTo(format(PLACE_CHAR_MSG) % "assembly" % "position");
+        act(format(PLACE_ROOM_MSG) % "assembly" % "position", TRUE, ch, nullptr, nullptr, TO_ROOM);
+      }
+      break;
+    default:
+      ch->sendTo("You continue working on the trap.\n\r");
+      act("$n continues working on the trap.", TRUE, ch, nullptr, nullptr, TO_ROOM);
+      break;
+  }
 }
 
 const sstring trap_types[] = {"None", "Poison", "Spike", "Sleep", "Explosive",
@@ -113,18 +347,47 @@ const sstring trap_types[] = {"None", "Poison", "Spike", "Sleep", "Explosive",
 const char* user_trap_types[] = {"exit", "container", "mine", "grenade",
   "arrow", "\n"};
 
+namespace {
+  // Helper function to parse trap type from string
+  doorTrapT parseTrapType(const char* trap_type, trap_targ_t target) {
+    if (is_abbrev(trap_type, "fire")) return DOOR_TRAP_FIRE;
+    if (is_abbrev(trap_type, "explosive")) return DOOR_TRAP_TNT;
+    if (is_abbrev(trap_type, "poison")) return DOOR_TRAP_POISON;
+    if (is_abbrev(trap_type, "sleep")) return DOOR_TRAP_SLEEP;
+    if (is_abbrev(trap_type, "acid")) return DOOR_TRAP_ACID;
+    if (is_abbrev(trap_type, "spore")) return DOOR_TRAP_DISEASE;
+    if (is_abbrev(trap_type, "frost")) return DOOR_TRAP_FROST;
+    if (is_abbrev(trap_type, "teleport")) return DOOR_TRAP_TELEPORT;
+    if (is_abbrev(trap_type, "power")) return DOOR_TRAP_ENERGY;
+
+    // Target-specific trap types
+    if (target == TRAP_TARG_DOOR || target == TRAP_TARG_CONT || target == TRAP_TARG_ARROW) {
+      if (is_abbrev(trap_type, "spike")) return DOOR_TRAP_SPIKE;
+      if (is_abbrev(trap_type, "blade")) return DOOR_TRAP_BLADE;
+      if (is_abbrev(trap_type, "pebble")) return DOOR_TRAP_PEBBLE;
+    }
+
+    if (target == TRAP_TARG_DOOR) {
+      if (is_abbrev(trap_type, "hammer")) return DOOR_TRAP_HAMMER;
+    }
+
+    if (target == TRAP_TARG_MINE || target == TRAP_TARG_GRENADE) {
+      if (is_abbrev(trap_type, "bolt")) return DOOR_TRAP_BOLT;
+      if (is_abbrev(trap_type, "disk")) return DOOR_TRAP_DISK;
+      if (is_abbrev(trap_type, "pebble")) return DOOR_TRAP_PEBBLE;
+    }
+
+    return MAX_TRAP_TYPES; // Invalid trap type
+  }
+}
+
 int TBeing::springTrap(TTrap* obj) {
-  int adj, fireperc, roll;
+  const int level_adjustment = obj->getTrapLevel() - GetMaxLevel();
+  const int dex_adjustment = getDexReaction() * 5;
+  const int fire_percentage = 95 + level_adjustment - dex_adjustment;
+  const int roll = ::number(1, 100);
 
-  adj = obj->getTrapLevel() - GetMaxLevel();
-  adj -= getDexReaction() * 5;
-  fireperc = 95 + adj;
-  roll = ::number(1, 100);
-
-  if (roll < fireperc)
-    return TRUE;  // trap is sprung
-
-  return FALSE;
+  return (roll < fire_percentage);
 }
 
 int TBeing::doSetTraps(const char* arg) {
@@ -137,9 +400,6 @@ int TBeing::doSetTraps(const char* arg) {
   int rc;
   TObj* obj;
 
-  // prevent people from making traps in peace rooms:
-  // policeman may attack if they see you trapping
-  // goofup may cause damage
   if (checkPeaceful("You are not permitted to construct traps here.\n\r"))
     return FALSE;
 
@@ -179,35 +439,14 @@ int TBeing::doSetTraps(const char* arg) {
           return DELETE_THIS;
         return FALSE;
       }
-      if (is_abbrev(trap_type, "fire")) {
-        type = DOOR_TRAP_FIRE;
-      } else if (is_abbrev(trap_type, "explosive")) {
-        type = DOOR_TRAP_TNT;
-      } else if (is_abbrev(trap_type, "poison")) {
-        type = DOOR_TRAP_POISON;
-      } else if (is_abbrev(trap_type, "sleep")) {
-        type = DOOR_TRAP_SLEEP;
-      } else if (is_abbrev(trap_type, "acid")) {
-        type = DOOR_TRAP_ACID;
-      } else if (is_abbrev(trap_type, "spore")) {
-        type = DOOR_TRAP_DISEASE;
-      } else if (is_abbrev(trap_type, "spike")) {
-        type = DOOR_TRAP_SPIKE;
-      } else if (is_abbrev(trap_type, "blade")) {
-        type = DOOR_TRAP_BLADE;
-      } else if (is_abbrev(trap_type, "hammer")) {
-        type = DOOR_TRAP_HAMMER;
-      } else if (is_abbrev(trap_type, "frost")) {
-        type = DOOR_TRAP_FROST;
-      } else if (is_abbrev(trap_type, "teleport")) {
-        type = DOOR_TRAP_TELEPORT;
-      } else if (is_abbrev(trap_type, "power")) {
-        type = DOOR_TRAP_ENERGY;
-      } else {
+
+      type = parseTrapType(trap_type, TRAP_TARG_DOOR);
+      if (type == MAX_TRAP_TYPES) {
         sendTo("No such exit trap-type.\n\r");
         sendTo("Syntax: trap exit <direction> <trap-type>\n\r");
         return FALSE;
       }
+
       if (!hasTrapComps(trap_type, TRAP_TARG_DOOR, 0)) {
         sendTo("You need more items to make that trap.\n\r");
         return FALSE;
@@ -254,35 +493,13 @@ int TBeing::doSetTraps(const char* arg) {
 
       sscanf(sstring, "%s", trap_type);
 
-      if (is_abbrev(trap_type, "fire")) {
-        type = DOOR_TRAP_FIRE;
-      } else if (is_abbrev(trap_type, "explosive")) {
-        type = DOOR_TRAP_TNT;
-      } else if (is_abbrev(trap_type, "poison")) {
-        type = DOOR_TRAP_POISON;
-      } else if (is_abbrev(trap_type, "sleep")) {
-        type = DOOR_TRAP_SLEEP;
-      } else if (is_abbrev(trap_type, "acid")) {
-        type = DOOR_TRAP_ACID;
-      } else if (is_abbrev(trap_type, "spore")) {
-        type = DOOR_TRAP_DISEASE;
-      } else if (is_abbrev(trap_type, "bolt")) {
-        type = DOOR_TRAP_BOLT;
-      } else if (is_abbrev(trap_type, "disk")) {
-        type = DOOR_TRAP_DISK;
-      } else if (is_abbrev(trap_type, "pebble")) {
-        type = DOOR_TRAP_PEBBLE;
-      } else if (is_abbrev(trap_type, "frost")) {
-        type = DOOR_TRAP_FROST;
-      } else if (is_abbrev(trap_type, "teleport")) {
-        type = DOOR_TRAP_TELEPORT;
-      } else if (is_abbrev(trap_type, "power")) {
-        type = DOOR_TRAP_ENERGY;
-      } else {
+      type = parseTrapType(trap_type, TRAP_TARG_MINE);
+      if (type == MAX_TRAP_TYPES) {
         sendTo("No such mine trap-type.\n\r");
         sendTo("Syntax: trap mine <trap-type>\n\r");
         return FALSE;
       }
+
       if (getMineTrapLearn(type) <= 0) {
         sendTo("You need more training before setting a mine trap.\n\r");
         return FALSE;
@@ -293,8 +510,8 @@ int TBeing::doSetTraps(const char* arg) {
         return FALSE;
       }
 
-      sendTo("You start working on your trap.\n\r");
-      act("$n starts constructing a land-mine.", TRUE, this, 0, 0, TO_ROOM);
+      sendTo(TRAP_START_CHAR_MSG);
+      act(TRAP_START_MINE_ROOM_MSG, TRUE, this, 0, 0, TO_ROOM);
       start_task(this, NULL, NULL, TASK_TRAP_MINE, trap_type, 3, inRoom(), type,
         0, 5);
       return FALSE;
@@ -310,29 +527,8 @@ int TBeing::doSetTraps(const char* arg) {
         return FALSE;
       }
 
-      if (is_abbrev(trap_type, "fire")) {
-        type = DOOR_TRAP_FIRE;
-      } else if (is_abbrev(trap_type, "explosive")) {
-        type = DOOR_TRAP_TNT;
-      } else if (is_abbrev(trap_type, "sleep")) {
-        type = DOOR_TRAP_SLEEP;
-      } else if (is_abbrev(trap_type, "acid")) {
-        type = DOOR_TRAP_ACID;
-      } else if (is_abbrev(trap_type, "spore")) {
-        type = DOOR_TRAP_DISEASE;
-      } else if (is_abbrev(trap_type, "spike")) {
-        type = DOOR_TRAP_SPIKE;
-      } else if (is_abbrev(trap_type, "blade")) {
-        type = DOOR_TRAP_BLADE;
-      } else if (is_abbrev(trap_type, "pebble")) {
-        type = DOOR_TRAP_PEBBLE;
-      } else if (is_abbrev(trap_type, "frost")) {
-        type = DOOR_TRAP_FROST;
-      } else if (is_abbrev(trap_type, "teleport")) {
-        type = DOOR_TRAP_TELEPORT;
-      } else if (is_abbrev(trap_type, "power")) {
-        type = DOOR_TRAP_ENERGY;
-      } else {
+      type = parseTrapType(trap_type, TRAP_TARG_ARROW);
+      if (type == MAX_TRAP_TYPES) {
         sendTo("No such arrow trap type.\n\r");
         sendTo("Syntax: trap arrow <trap-type>\n\r");
         return FALSE;
@@ -343,14 +539,13 @@ int TBeing::doSetTraps(const char* arg) {
         return FALSE;
       }
 
-      // TODO:: modify hasTrapComps for arrows
-      if (!hasTrapComps(trap_type, TRAP_TARG_CONT, 0)) {
+      if (!hasTrapComps(trap_type, TRAP_TARG_ARROW, 0)) {
         sendTo("You need more items to make that trap.\n\r");
         return FALSE;
       }
 
-      sendTo("You start working on your arrow.\n\r");
-      act("$n starts trapping an arrow.", TRUE, this, 0, 0, TO_ROOM);
+      sendTo(TRAP_START_CHAR_MSG);
+      act(TRAP_START_ARROW_ROOM_MSG, TRUE, this, 0, 0, TO_ROOM);
       start_task(this, obj, NULL, TASK_TRAP_ARROW, trap_type, 3, inRoom(), type,
         0, 5);
       break;
@@ -362,31 +557,8 @@ int TBeing::doSetTraps(const char* arg) {
 
       sscanf(sstring, "%s", trap_type);
 
-      if (is_abbrev(trap_type, "fire")) {
-        type = DOOR_TRAP_FIRE;
-      } else if (is_abbrev(trap_type, "explosive")) {
-        type = DOOR_TRAP_TNT;
-      } else if (is_abbrev(trap_type, "poison")) {
-        type = DOOR_TRAP_POISON;
-      } else if (is_abbrev(trap_type, "sleep")) {
-        type = DOOR_TRAP_SLEEP;
-      } else if (is_abbrev(trap_type, "acid")) {
-        type = DOOR_TRAP_ACID;
-      } else if (is_abbrev(trap_type, "spore")) {
-        type = DOOR_TRAP_DISEASE;
-      } else if (is_abbrev(trap_type, "bolt")) {
-        type = DOOR_TRAP_BOLT;
-      } else if (is_abbrev(trap_type, "disk")) {
-        type = DOOR_TRAP_DISK;
-      } else if (is_abbrev(trap_type, "pebble")) {
-        type = DOOR_TRAP_PEBBLE;
-      } else if (is_abbrev(trap_type, "frost")) {
-        type = DOOR_TRAP_FROST;
-      } else if (is_abbrev(trap_type, "teleport")) {
-        type = DOOR_TRAP_TELEPORT;
-      } else if (is_abbrev(trap_type, "power")) {
-        type = DOOR_TRAP_ENERGY;
-      } else {
+      type = parseTrapType(trap_type, TRAP_TARG_GRENADE);
+      if (type == MAX_TRAP_TYPES) {
         sendTo("No such grenade trap-type.\n\r");
         sendTo("Syntax: trap grenade <trap-type>\n\r");
         return FALSE;
@@ -401,8 +573,8 @@ int TBeing::doSetTraps(const char* arg) {
         return FALSE;
       }
 
-      sendTo("You start working on your grenade.\n\r");
-      act("$n starts constructing a grenade.", TRUE, this, 0, 0, TO_ROOM);
+      sendTo(TRAP_START_CHAR_MSG);
+      act(TRAP_START_GRENADE_ROOM_MSG, TRUE, this, 0, 0, TO_ROOM);
       start_task(this, NULL, NULL, TASK_TRAP_GRENADE, trap_type, 3, inRoom(),
         type, 0, 5);
       return FALSE;
@@ -427,26 +599,26 @@ int TBeing::triggerPortalTrap(TPortal* o) {
 
   switch (o->getPortalTrapType()) {
     case DOOR_TRAP_POISON:
-      act("A tiny needle in $p jams into your hand.", FALSE, this, o, 0,
-        TO_CHAR);
-      act("A tiny needle in $p jams into $n's hand.", FALSE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       trapPoison(o->getPortalTrapDam());
       break;
     case DOOR_TRAP_SLEEP:
-      act("A puff of smoke seeps from $p, enveloping you.", FALSE, this, o, 0,
-        TO_CHAR);
-      act("A puff of smoke seeps from $p, enveloping $n.", FALSE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = trapSleep(o->getPortalTrapDam());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       break;
     case DOOR_TRAP_FIRE:
-      act("A column of flame shoots from a concealed jet in $p at you.", TRUE,
-        this, o, 0, TO_CHAR);
-      act("A column of flame shoots from a concealed jet in $p at $n.", TRUE,
-        this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FIRE, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -458,59 +630,58 @@ int TBeing::triggerPortalTrap(TPortal* o) {
 
       return TRUE;
     case DOOR_TRAP_TELEPORT:
-      act("A chaotic, swirling vortex surrounds you.", TRUE, this, o, 0,
-        TO_CHAR);
-      act("A chaotic, swirling vortex surrounds $n.", TRUE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = trapTeleport(o->getPortalTrapDam());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return rc;
     case DOOR_TRAP_SPIKE:
-      act("Sharpened spikes leap from a place of concealment in $p at you.",
-        TRUE, this, o, 0, TO_CHAR);
-      act("Sharpened spikes leap from a place of concealment in $p at $n.",
-        TRUE, this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_PIERCE, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_DISEASE:
-      act("You are engulfed in a cloud of spores.", FALSE, this, 0, 0, TO_ROOM);
-      act("$n is engulfed in a cloud of spores.", FALSE, this, 0, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_DISEASE, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_HAMMER:
-      act("Giant weights concealed in $p crash down on you.", TRUE, this, o, 0,
-        TO_CHAR);
-      act("Giant weights concealed in $p crash down on $n.", TRUE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_BLUNT, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_BLADE:
-      act(
-        "Razor sharp blades slice from a place of concealment in $p into you.",
-        TRUE, this, o, 0, TO_CHAR);
-      act("Razor sharp blades slice from a place of concealment in $p into $n.",
-        TRUE, this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_SLASH, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_TNT:
-      act("A massive explosion destroys $p, and spews shrapnel into the room!",
-        TRUE, this, o, 0, TO_CHAR);
-      act("A massive explosion destroys $p, and spews shrapnel into the room!",
-        TRUE, this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
       amnt = o->getPortalTrapDam();
 
       // fry people in room
@@ -519,9 +690,9 @@ int TBeing::triggerPortalTrap(TPortal* o) {
         t = *(it++);
         TBeing* tbt = dynamic_cast<TBeing*>(t);
         if (tbt && this != tbt && !tbt->isImmortal()) {
-          act("You are hit by shrapnel!", TRUE, tbt, 0, 0, TO_CHAR);
-          act("$n is hit by shrapnel.", TRUE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt / 2, o);
+          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
+          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
+          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, o);
           if (IS_SET_DELETE(rc, DELETE_THIS)) {
             delete tbt;
             tbt = NULL;
@@ -529,6 +700,8 @@ int TBeing::triggerPortalTrap(TPortal* o) {
         }
       }
 
+      act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = objDamage(DAMAGE_TRAP_TNT, amnt, o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS | DELETE_ITEM;
@@ -539,10 +712,10 @@ int TBeing::triggerPortalTrap(TPortal* o) {
 
       return DELETE_ITEM;
     case DOOR_TRAP_FROST:
-      act("A frosty blast jets from a place of concealment in $p into you.",
-        TRUE, this, o, 0, TO_CHAR);
-      act("A frosty blast jets from a place of concealment in $p into $n.",
-        TRUE, this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FROST, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -554,13 +727,10 @@ int TBeing::triggerPortalTrap(TPortal* o) {
 
       return TRUE;
     case DOOR_TRAP_ENERGY:
-      act(
-        "Bolts of raw plasma stream from a place of concealment in $p into "
-        "you.",
-        TRUE, this, o, 0, TO_CHAR);
-      act(
-        "Jets of raw plasma stream from a place of concealment in $p into $n.",
-        TRUE, this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ENERGY, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -568,14 +738,10 @@ int TBeing::triggerPortalTrap(TPortal* o) {
 
       return TRUE;
     case DOOR_TRAP_ACID:
-      act(
-        "A steaming liquid splashes from a place of concealment in $p covering "
-        "you.",
-        TRUE, this, o, 0, TO_CHAR);
-      act(
-        "A steaming liquid splashes from a place of concealment in $p covering "
-        "$n.",
-        TRUE, this, o, 0, TO_ROOM);
+      sendTo(format(PORTAL_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(PORTAL_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ACID, o->getPortalTrapDam(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -600,23 +766,24 @@ int TBeing::triggerContTrap(TOpenContainer* obj) {
   TThing* t;
   int amnt;
 
-  act("You hear a strange noise...", TRUE, this, 0, 0, TO_ROOM);
-  act("You hear a strange noise...", TRUE, this, 0, 0, TO_CHAR);
+  act(STRANGE_NOISE_MSG, TRUE, this, 0, 0, TO_ROOM);
+  act(STRANGE_NOISE_MSG, TRUE, this, 0, 0, TO_CHAR);
   obj->remContainerFlag(CONT_TRAPPED);
   obj->remContainerFlag(CONT_CLOSED);
   obj->addContainerFlag(CONT_EMPTYTRAP);
 
-  if (!::number(0, 100)) {
-    act("...But nothing happens.", TRUE, this, 0, 0, TO_CHAR);
-    act("...But nothing happens.", TRUE, this, 0, 0, TO_ROOM);
-
+  if (percentChance(1)) {
+    act(NOTHING_HAPPENS_CHAR_MSG, TRUE, this, 0, 0, TO_CHAR);
+    act(NOTHING_HAPPENS_ROOM_MSG, TRUE, this, 0, 0, TO_ROOM);
     return FALSE;
   }
 
   switch (obj->getContainerTrapType()) {
     case DOOR_TRAP_FIRE:
-      act("$p bursts into flame.", TRUE, this, obj, 0, TO_ROOM);
-      act("$p bursts into flame.", TRUE, this, obj, 0, TO_CHAR);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       // bag explodes, contents go boom
       for (StuffIter it = obj->stuff.begin(); it != obj->stuff.end();) {
@@ -629,10 +796,8 @@ int TBeing::triggerContTrap(TOpenContainer* obj) {
       ADD_DELETE(rc, DELETE_ITEM);
       return rc;
     case DOOR_TRAP_TNT:
-      act("$p explodes violently, spewing shrapnel into the room!", TRUE, this,
-        obj, 0, TO_ROOM);
-      act("$p explodes violently, spewing shrapnel into the room!", TRUE, this,
-        obj, 0, TO_CHAR);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
       amnt = obj->getContainerTrapDam();
 
       // bag explodes, contents go boom
@@ -646,102 +811,100 @@ int TBeing::triggerContTrap(TOpenContainer* obj) {
         t = *(it++);
         TBeing* tbt = dynamic_cast<TBeing*>(t);
         if (tbt && this != tbt) {
-          act("You are hit by shrapnel!", TRUE, tbt, 0, 0, TO_CHAR);
-          act("$n is hit by shrapnel.", TRUE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt / 2, obj);
+          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
+          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
+          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, obj);
           if (IS_SET_DELETE(rc, DELETE_THIS)) {
             delete tbt;
             tbt = NULL;
           }
         }
       }
+      act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = objDamage(DAMAGE_TRAP_TNT, amnt, obj);
 
       ADD_DELETE(rc, DELETE_ITEM);
       return rc;
     case DOOR_TRAP_POISON:
-      act("A tiny needle in $p jams into your hand.", FALSE, this, obj, 0,
-        TO_CHAR);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       trapPoison(obj->getContainerTrapDam());
       break;
     case DOOR_TRAP_SLEEP:
-      act("A puff of smoke seeps from $p, enveloping you.", FALSE, this, obj, 0,
-        TO_CHAR);
-      act("A puff of smoke seeps from $p, enveloping $n.", FALSE, this, obj, 0,
-        TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = trapSleep(obj->getContainerTrapDam());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       break;
     case DOOR_TRAP_SPIKE:
-      act("Sharpened spikes leap from a place of concealment in $p at you.",
-        TRUE, this, obj, 0, TO_CHAR);
-      act("Sharpened spikes leap from a place of concealment in $p at $n.",
-        TRUE, this, obj, 0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_PIERCE, obj->getContainerTrapDam(), obj);
       return rc;
     case DOOR_TRAP_DISEASE:
-      act("A cloud of spores pours from $p, engulfing you.", FALSE, this, obj,
-        0, TO_ROOM);
-      act("A cloud of spores pours from $p, engulfing $n.", FALSE, this, obj, 0,
-        TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       trapDisease(obj->getContainerTrapDam());
       break;
     case DOOR_TRAP_TELEPORT:
-      act("As you touch $p, a chaotic, swirling vortex surrounds you.", TRUE,
-        this, obj, 0, TO_CHAR);
-      act("As $n touches $p, a chaotic, swirling vortex surrounds $m.", TRUE,
-        this, obj, 0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = trapTeleport(obj->getContainerTrapDam());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return rc;
     case DOOR_TRAP_PEBBLE:
-      act("Dozens of tiny pebbles shoot from $p, pelting you!", TRUE, this, obj,
-        0, TO_CHAR);
-      act("Dozens of tiny pebbles shoot from $p, pelting $n.", TRUE, this, obj,
-        0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_BLUNT, obj->getContainerTrapDam(), obj);
       return rc;
     case DOOR_TRAP_BLADE:
-      act(
-        "Razor sharp blades slide forth from a place of concealment in $p into "
-        "you.",
-        TRUE, this, obj, 0, TO_CHAR);
-      act(
-        "Razor sharp blades slide forth from a place of concealment in $p into "
-        "$n.",
-        TRUE, this, obj, 0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_SLASH, obj->getContainerTrapDam(), obj);
       return rc;
     case DOOR_TRAP_FROST:
-      act("A frosty blast jets from a place of concealment in $p into you.",
-        TRUE, this, obj, 0, TO_CHAR);
-      act("A frosty blast jets from a place of concealment in $p into $n.",
-        TRUE, this, obj, 0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FROST, obj->getContainerTrapDam(), obj);
       return rc;
     case DOOR_TRAP_ENERGY:
-      act("Bolts of plasma stream from a place of concealment in $p into you.",
-        TRUE, this, obj, 0, TO_CHAR);
-      act(
-        "Bolts of plasma stream forth from a place of concealment in $p into "
-        "$n.",
-        TRUE, this, obj, 0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ENERGY, obj->getContainerTrapDam(), obj);
       return rc;
     case DOOR_TRAP_ACID:
-      act("A strange liquid pours from a place of concealment in $p onto you.",
-        TRUE, this, obj, 0, TO_CHAR);
-      act("A strange liquid pours from a place of concealment in $p onto $n.",
-        TRUE, this, obj, 0, TO_ROOM);
+      sendTo(format(CONTAINER_TRAP_CHAR_MSG) % fname(obj->getName()));
+      act(format(CONTAINER_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ACID, obj->getContainerTrapDam(), obj);
       return rc;
@@ -759,31 +922,30 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
   TThing* t;
   int amnt;
 
-  act("You hear a strange noise...", TRUE, this, 0, 0, TO_ROOM);
-  act("You hear a strange noise...", TRUE, this, 0, 0, TO_CHAR);
+  act(STRANGE_NOISE_MSG, TRUE, this, 0, 0, TO_ROOM);
+  act(STRANGE_NOISE_MSG, TRUE, this, 0, 0, TO_CHAR);
 
-  if (!::number(0, 100)) {
-    act("...But nothing happens.", TRUE, this, 0, 0, TO_CHAR);
-    act("...But nothing happens.", TRUE, this, 0, 0, TO_ROOM);
-
+  if (percentChance(1)) {
+    act(NOTHING_HAPPENS_CHAR_MSG, TRUE, this, 0, 0, TO_CHAR);
+    act(NOTHING_HAPPENS_ROOM_MSG, TRUE, this, 0, 0, TO_ROOM);
     return FALSE;
   }
 
+  // Single arrow source message for ALL arrow trap cases
+  sendTo(format(ARROW_TRAP_CHAR_MSG) % fname(obj->getName()));
+  act(format(ARROW_TRAP_ROOM_MSG) % fname(obj->getName()), FALSE, this, 0, 0, TO_ROOM);
+
   switch (obj->getTrapDamType()) {
     case DOOR_TRAP_SLEEP:
-      act("A puff of smoke seeps from $p, enveloping you.", FALSE, this, obj, 0,
-        TO_CHAR);
-      act("A puff of smoke seeps from $p, enveloping $n.", FALSE, this, obj, 0,
-        TO_ROOM);
+      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = trapSleep(obj->getTrapDamAmount());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       break;
     case DOOR_TRAP_FIRE:
-      act("A column of flame shoots from $p at you.", TRUE, this, obj, 0,
-        TO_CHAR);
-      act("A column of flame shoots from $p at $n.", TRUE, this, obj, 0,
-        TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FIRE, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -795,46 +957,38 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
 
       return TRUE;
     case DOOR_TRAP_TELEPORT:
-      act("A chaotic, swirling vortex surrounds you.", TRUE, this, obj, 0,
-        TO_CHAR);
-      act("A chaotic, swirling vortex surrounds $n.", TRUE, this, obj, 0,
-        TO_ROOM);
+      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = trapTeleport(obj->getTrapDamAmount());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return rc;
     case DOOR_TRAP_SPIKE:
-      act("Sharpened spikes leap from $p at you.", TRUE, this, obj, 0, TO_CHAR);
-      act("Sharpened spikes leap from $p at $n.", TRUE, this, obj, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_PIERCE, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_DISEASE:
-      act("You are engulfed in a cloud of spores.", FALSE, this, 0, 0, TO_ROOM);
-      act("$n is engulfed in a cloud of spores.", FALSE, this, 0, 0, TO_ROOM);
+      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_DISEASE, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_BLADE:
-      act("Razor sharp blades slice from $p into you.", TRUE, this, obj, 0,
-        TO_CHAR);
-      act("Razor sharp blades slice from $p into $n.", TRUE, this, obj, 0,
-        TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_SLASH, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_TNT:
-      act("A massive explosion destroys $p, and spews shrapnel into the room!",
-        TRUE, this, obj, 0, TO_CHAR);
-      act("A massive explosion destroys $p, and spews shrapnel into the room!",
-        TRUE, this, obj, 0, TO_ROOM);
       amnt = obj->getTrapDamAmount();
 
       // fry people in room
@@ -842,9 +996,9 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
         t = *(it++);
         TBeing* tbt = dynamic_cast<TBeing*>(t);
         if (tbt && this != tbt && !tbt->isImmortal()) {
-          act("You are hit by shrapnel!", TRUE, tbt, 0, 0, TO_CHAR);
-          act("$n is hit by shrapnel.", TRUE, tbt, 0, 0, TO_ROOM);
-          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt / 2, obj);
+          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
+          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
+          rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, obj);
           if (IS_SET_DELETE(rc, DELETE_THIS)) {
             delete tbt;
             tbt = NULL;
@@ -852,6 +1006,8 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
         }
       }
 
+      act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = objDamage(DAMAGE_TRAP_TNT, amnt, obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS | DELETE_ITEM;
@@ -862,8 +1018,8 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
 
       return DELETE_ITEM;
     case DOOR_TRAP_FROST:
-      act("A frosty blast jets from $p into you.", TRUE, this, obj, 0, TO_CHAR);
-      act("A frosty blast jets from $p into $n.", TRUE, this, obj, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FROST, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -875,10 +1031,8 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
 
       return TRUE;
     case DOOR_TRAP_ENERGY:
-      act("Bolts of raw plasma stream from $p into you.", TRUE, this, obj, 0,
-        TO_CHAR);
-      act("Jets of raw plasma stream from $p into $n.", TRUE, this, obj, 0,
-        TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ENERGY, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -886,10 +1040,8 @@ int TBeing::triggerArrowTrap(TArrow* obj) {
 
       return TRUE;
     case DOOR_TRAP_ACID:
-      act("A steaming liquid splashes from $p covering you.", TRUE, this, obj,
-        0, TO_CHAR);
-      act("A steaming liquid splashes from $p covering $n.", TRUE, this, obj, 0,
-        TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ACID, obj->getTrapDamAmount(), obj);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -932,51 +1084,136 @@ int TBeing::triggerDoorTrap(dirTypeT door) {
 
   switch (exitp->trap_info) {
     case DOOR_TRAP_POISON:
-      sendTo(
-        format(
-          "A small needle lunges out of the %s and punctures your hand.\n\r") %
-        fname(exitp->keyword));
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       trapPoison(dam);
       break;
     case DOOR_TRAP_SPIKE:
-      return trapDoorPierceDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_PIERCE, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_SLEEP:
-      sendTo("You are engulfed in a cloud of gas.\n\r");
-      act("$n is engulfed in a cloud of gas.", FALSE, this, 0, 0, TO_ROOM);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       rc = trapSleep(dam);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       break;
     case DOOR_TRAP_TNT:
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
       exitp->destroyDoor(door, in_room);
-      return trapDoorTntDamage(dam, door);
+
+      // Room-wide TNT effects
+      for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
+        TThing* t = *(it++);
+        TBeing* tbt = dynamic_cast<TBeing*>(t);
+        if (tbt && this != tbt) {
+          act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, 0, 0, TO_CHAR);
+          act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, 0, 0, TO_ROOM);
+          rc = tbt->objDamage(DAMAGE_TRAP_TNT, dam * ROOM_MOD, NULL);
+          if (IS_SET_DELETE(rc, DELETE_THIS)) {
+            delete tbt;
+            tbt = NULL;
+          }
+        }
+      }
+
+      act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_TNT, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_FIRE:
-      return trapDoorFireDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_FIRE, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      rc = flameEngulfed();
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_ACID:
-      return trapDoorAcidDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_ACID, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      rc = acidEngulfed();
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_DISEASE:
-      sendTo("You are engulfed in a cloud of spores.\n\r");
-      act("$n is engulfed in a cloud of spores.", FALSE, this, 0, 0, TO_ROOM);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
       trapDisease(dam);
       break;
     case DOOR_TRAP_TELEPORT:
-      act("A chaotic, swirling vortex surrounds you.", TRUE, this, 0, 0,
-        TO_CHAR);
-      act("A chaotic, swirling vortex surrounds $n.", TRUE, this, 0, 0,
-        TO_ROOM);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
       rc = trapTeleport(dam);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return rc;
     case DOOR_TRAP_HAMMER:
-      return trapDoorHammerDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_BLUNT, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_BLADE:
-      return trapDoorSlashDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_SLASH, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_ENERGY:
-      return trapDoorEnergyDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_ENERGY, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     case DOOR_TRAP_FROST:
-      return trapDoorFrostDamage(dam, door);
+      sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+      act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), FALSE, this, 0, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+      rc = objDamage(DAMAGE_TRAP_FROST, dam, NULL);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      rc = frostEngulfed();
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      break;
     default:
       break;
   }
@@ -1117,43 +1354,37 @@ int TBeing::triggerTrap(TTrap* o) {
 
   switch (o->getTrapDamType()) {
     case DOOR_TRAP_POISON:
-      act("A small canister pops out of $p and detonates.", FALSE, this, o, 0,
-        TO_CHAR);
-      act("A small canister pops out of $p and detonates.", FALSE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are sprayed with contact poison!", FALSE, tbt, o, 0,
-              TO_CHAR);
-            act("$n is sprayed with contact poison!", FALSE, tbt, o, 0,
-              TO_ROOM);
-            tbt->trapPoison(2 * o->getTrapDamAmount() / 3);
+            act(POISON_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(POISON_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
+            tbt->trapPoison(o->getTrapDamAmount() * STATUS_ROOM_MOD);
           }
         }
       }
 
-      act("You are sprayed with contact poison!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is sprayed with contact poison!", FALSE, this, o, 0, TO_ROOM);
+      act(POISON_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(POISON_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
       trapPoison(o->getTrapDamAmount());
       return TRUE;
     case DOOR_TRAP_SLEEP:
-      act("A vaporous fog steams from $p.", FALSE, this, o, 0, TO_CHAR);
-      act("A vaporous fog steams from $p.", FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are surrounded by a noxious mist!", FALSE, tbt, o, 0,
-              TO_CHAR);
-            act("$n is surrounded by a noxious mist!", FALSE, tbt, o, 0,
-              TO_ROOM);
-            rc = tbt->trapSleep(2 * o->getTrapDamAmount() / 3);
+            act(SLEEP_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(SLEEP_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
+            rc = tbt->trapSleep(o->getTrapDamAmount() * STATUS_ROOM_MOD);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1162,27 +1393,24 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are surrounded by a noxious mist!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is surrounded by a noxious mist!", FALSE, this, o, 0, TO_ROOM);
+      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
       rc = trapSleep(o->getTrapDamAmount());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_FIRE:
-      act("A tiny spark comes out of $p, just before it erupts in flame.",
-        FALSE, this, o, 0, TO_CHAR);
-      act("A tiny spark comes out of $p, just before it erupts in flame.",
-        FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are burned by the flames!", FALSE, tbt, o, 0, TO_CHAR);
-            act("$n is burned by the flames.", FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_FIRE, 1 * o->getTrapDamAmount() / 2,
-              o);
+            act(FIRE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(FIRE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
+            rc = tbt->objDamage(DAMAGE_TRAP_FIRE, o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1191,8 +1419,8 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are burned by the flames!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is burned by the flames.", FALSE, this, o, 0, TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FIRE, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1204,21 +1432,17 @@ int TBeing::triggerTrap(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_TELEPORT:
-      act("A whirling vortex suddenly surrounds $p.", FALSE, this, o, 0,
-        TO_CHAR);
-      act("A whirling vortex suddenly surrounds $p.", FALSE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You find yourself sucked into the vortex!", FALSE, tbt, o, 0,
-              TO_CHAR);
-            act("$n flails wildly, but falls into the vortex.", FALSE, tbt, o,
-              0, TO_ROOM);
-            rc = tbt->trapTeleport(2 * o->getTrapDamAmount() / 3);
+            act(TELEPORT_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(TELEPORT_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
+            rc = tbt->trapTeleport(o->getTrapDamAmount() * STATUS_ROOM_MOD);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1227,56 +1451,46 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You find yourself sucked into the vortex!", FALSE, this, o, 0,
-        TO_CHAR);
-      act("$n flails wildly, but falls into the vortex.", FALSE, this, o, 0,
-        TO_ROOM);
+      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = trapTeleport(o->getTrapDamAmount());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_DISEASE:
-      act("A cloud of spores puffs from $p.", FALSE, this, o, 0, TO_CHAR);
-      act("A cloud of spores puffs from $p.", FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are surrounded by the thick cloud!", FALSE, tbt, o, 0,
-              TO_CHAR);
-            act("$n is surrounded by the thick cloud!", FALSE, tbt, o, 0,
-              TO_ROOM);
-            tbt->trapDisease(2 * o->getTrapDamAmount() / 3);
+            act(DISEASE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(DISEASE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
+            tbt->trapDisease(o->getTrapDamAmount() * STATUS_ROOM_MOD);
           }
         }
       }
 
-      act("You are surrounded by the thick cloud!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is surrounded by the thick cloud!", FALSE, this, o, 0, TO_ROOM);
+      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
       trapDisease(o->getTrapDamAmount());
       return TRUE;
     case DOOR_TRAP_BOLT:
-      act(
-        "A canister pops out of $p and detonates, scattering hundreds of "
-        "sharp, tiny bolts.",
-        FALSE, this, o, 0, TO_CHAR);
-      act(
-        "A canister pops out of $p and detonates, scattering hundreds of "
-        "sharp, tiny bolts.",
-        FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are hit by the deadly bolts!", FALSE, tbt, o, 0, TO_CHAR);
-            act("$n is hit by the bolts.", FALSE, tbt, o, 0, TO_ROOM);
+            act(SPIKE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(SPIKE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
             rc = tbt->objDamage(DAMAGE_TRAP_PIERCE,
-              1 * o->getTrapDamAmount() / 2, o);
+              o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1285,8 +1499,8 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are perforated by the bolts!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is perforated by the bolts.", FALSE, this, o, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_PIERCE, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1294,22 +1508,18 @@ int TBeing::triggerTrap(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_PEBBLE:
-      act(
-        "A canister pops out of $p and detonates, spraying pebbles everywhere.",
-        FALSE, this, o, 0, TO_CHAR);
-      act(
-        "A canister pops out of $p and detonates, spraying pebbles everywhere.",
-        FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are hit by the fusillade!", FALSE, tbt, o, 0, TO_CHAR);
-            act("$n is hit by the pebbles.", FALSE, tbt, o, 0, TO_ROOM);
+            act(BLUNT_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(BLUNT_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
             rc = tbt->objDamage(DAMAGE_TRAP_BLUNT,
-              1 * o->getTrapDamAmount() / 2, o);
+              o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1318,8 +1528,8 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are hit by the fusillade!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is hit by the pebbles.", FALSE, this, o, 0, TO_ROOM);
+      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_BLUNT, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1327,25 +1537,18 @@ int TBeing::triggerTrap(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_DISK:
-      act(
-        "A canister pops out of $p and detonates, throwing razor-disks in all "
-        "directions.",
-        FALSE, this, o, 0, TO_CHAR);
-      act(
-        "A canister pops out of $p and detonates, throwing razor-disks in all "
-        "directions.",
-        FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are hit by the slashing disks!", FALSE, tbt, o, 0,
-              TO_CHAR);
-            act("$n is hit by the razors.", FALSE, tbt, o, 0, TO_ROOM);
+            act(BLADE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(BLADE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
             rc = tbt->objDamage(DAMAGE_TRAP_SLASH,
-              1 * o->getTrapDamAmount() / 2, o);
+              o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1354,32 +1557,26 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are slashed by the razor-disks!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is slashed by the razor-disks.", FALSE, this, o, 0, TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_SLASH, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_TNT:
-      act(
-        "A canister pops out of $p and detonates spraying white hot shrapnel "
-        "and bomb fragments everywhere.",
-        FALSE, this, o, 0, TO_CHAR);
-      act(
-        "A canister pops out of $p and detonates spraying white hot shrapnel "
-        "and bomb fragments everywhere.",
-        FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are hit by the flak!", FALSE, tbt, o, 0, TO_CHAR);
-            act("$n is hit by the flak.", FALSE, tbt, o, 0, TO_ROOM);
+            act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
             rc =
-              tbt->objDamage(DAMAGE_TRAP_TNT, 1 * o->getTrapDamAmount() / 2, o);
+              tbt->objDamage(DAMAGE_TRAP_TNT, o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1388,8 +1585,8 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are blasted by $p!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is blasted by fragments from $p.", FALSE, this, o, 0, TO_ROOM);
+      act(TNT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_TNT, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1404,12 +1601,10 @@ int TBeing::triggerTrap(TTrap* o) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are surrounded by the frosty cloud!", FALSE, tbt, o, 0,
-              TO_CHAR);
-            act("$n is surrounded by the frozen cloud.", FALSE, tbt, o, 0,
-              TO_ROOM);
+            act(FROST_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(FROST_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
             rc = tbt->objDamage(DAMAGE_TRAP_FROST,
-              1 * o->getTrapDamAmount() / 2, o);
+              o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1418,8 +1613,8 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are frozen by the icy cloud!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is frozen by the icy cloud.", FALSE, this, o, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FROST, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1431,20 +1626,18 @@ int TBeing::triggerTrap(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_ENERGY:
-      act("$p glows with magic, before streams of plasma streak out of it.",
-        FALSE, this, o, 0, TO_CHAR);
-      act("$p glows with magic, before streams of plasma streak out of it.",
-        FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("You are blasted by the plasma!", FALSE, tbt, o, 0, TO_CHAR);
-            act("$n is blasted by the plasma.", FALSE, tbt, o, 0, TO_ROOM);
+            act(ENERGY_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(ENERGY_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
             rc = tbt->objDamage(DAMAGE_TRAP_ENERGY,
-              1 * o->getTrapDamAmount() / 2, o);
+              o->getTrapDamAmount() * ROOM_MOD, o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
               tbt = NULL;
@@ -1453,29 +1646,25 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are devastated by dozens of plasma bolts!", FALSE, this, o, 0,
-        TO_CHAR);
-      act("$n is devastated by dozens of plasma bolts.", FALSE, this, o, 0,
-        TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ENERGY, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_ACID:
-      act("A yellow-green cloud billows out of $p.", FALSE, this, o, 0,
-        TO_CHAR);
-      act("A yellow-green cloud billows out of $p.", FALSE, this, o, 0,
-        TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
         for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
           v = *(it++);
           tbt = dynamic_cast<TBeing*>(v);
           if (tbt && tbt->desc && tbt != this) {
-            act("The acid cloud surrounds you!", FALSE, tbt, o, 0, TO_CHAR);
-            act("The acid cloud surrounds $n.", FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_ACID, 1 * o->getTrapDamAmount() / 2,
+            act(ACID_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
+            act(ACID_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
+            rc = tbt->objDamage(DAMAGE_TRAP_ACID, o->getTrapDamAmount() * ROOM_MOD,
               o);
             if (IS_SET_DELETE(rc, DELETE_THIS)) {
               delete tbt;
@@ -1485,10 +1674,8 @@ int TBeing::triggerTrap(TTrap* o) {
         }
       }
 
-      act("You are surrounded by the horrid acid cloud!", FALSE, this, o, 0,
-        TO_CHAR);
-      act("$n is surrounded by the horrid acid cloud.", FALSE, this, o, 0,
-        TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ACID, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1521,7 +1708,7 @@ int TBeing::trapDoorTntDamage(int amnt, dirTypeT door) {
     t = *(it++);
     TBeing* tbt = dynamic_cast<TBeing*>(t);
     if (tbt && this != tbt) {
-      rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt / 2, NULL);
+      rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * ROOM_MOD, NULL);
       if (IS_SET_DELETE(rc, DELETE_THIS)) {
         delete tbt;
         tbt = NULL;
@@ -1540,7 +1727,7 @@ int TBeing::trapDoorTntDamage(int amnt, dirTypeT door) {
       t = *(it++);
       TBeing* tbt = dynamic_cast<TBeing*>(t);
       if (tbt && this != tbt) {
-        rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt / 4, NULL);
+        rc = tbt->objDamage(DAMAGE_TRAP_TNT, amnt * OTHER_SIDE_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           delete tbt;
           tbt = NULL;
@@ -1631,7 +1818,7 @@ int TBeing::trapDoorFrostDamage(int amnt, dirTypeT door) {
     if (tbt && this != tbt && !tbt->isImmortal()) {
       act("$n is chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_ROOM);
       act("You are chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_CHAR);
-      rc = tbt->objDamage(DAMAGE_TRAP_FROST, amnt / 2, NULL);
+      rc = tbt->objDamage(DAMAGE_TRAP_FROST, amnt * ROOM_MOD, NULL);
       if (IS_SET_DELETE(rc, DELETE_THIS)) {
         delete tbt;
         tbt = NULL;
@@ -1650,7 +1837,7 @@ int TBeing::trapDoorFrostDamage(int amnt, dirTypeT door) {
       if (tbt && this != tbt) {
         act("$n is chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_ROOM);
         act("You are chilled by the arctic blast.", TRUE, tbt, 0, 0, TO_CHAR);
-        rc = tbt->objDamage(DAMAGE_TRAP_FROST, amnt / 3, NULL);
+        rc = tbt->objDamage(DAMAGE_TRAP_FROST, amnt * OTHER_SIDE_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           delete tbt;
           tbt = NULL;
@@ -1686,7 +1873,7 @@ int TBeing::trapDoorEnergyDamage(int amnt, dirTypeT door) {
     if (tbt && this != tbt && !tbt->isImmortal()) {
       act("$n is hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_ROOM);
       act("You are hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_CHAR);
-      rc = tbt->objDamage(DAMAGE_TRAP_ENERGY, amnt / 2, NULL);
+      rc = tbt->objDamage(DAMAGE_TRAP_ENERGY, amnt * ROOM_MOD, NULL);
       if (IS_SET_DELETE(rc, DELETE_THIS)) {
         delete tbt;
         tbt = NULL;
@@ -1705,7 +1892,7 @@ int TBeing::trapDoorEnergyDamage(int amnt, dirTypeT door) {
       if (tbt && this != tbt) {
         act("$n is hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_ROOM);
         act("You are hit by the plasma bolts.", TRUE, tbt, 0, 0, TO_CHAR);
-        rc = tbt->objDamage(DAMAGE_TRAP_ENERGY, amnt / 3, NULL);
+        rc = tbt->objDamage(DAMAGE_TRAP_ENERGY, amnt * OTHER_SIDE_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           delete tbt;
           tbt = NULL;
@@ -1755,7 +1942,7 @@ int TBeing::trapDoorAcidDamage(int amnt, dirTypeT door) {
     t = *(it++);
     TBeing* tbt = dynamic_cast<TBeing*>(t);
     if (tbt && this != tbt) {
-      rc = tbt->objDamage(DAMAGE_TRAP_ACID, amnt / 2, NULL);
+      rc = tbt->objDamage(DAMAGE_TRAP_ACID, amnt * ROOM_MOD, NULL);
       if (IS_SET_DELETE(rc, DELETE_THIS)) {
         delete tbt;
         tbt = NULL;
@@ -1772,7 +1959,7 @@ int TBeing::trapDoorAcidDamage(int amnt, dirTypeT door) {
       t = *(it++);
       TBeing* tbt = dynamic_cast<TBeing*>(t);
       if (tbt && this != tbt) {
-        rc = tbt->objDamage(DAMAGE_TRAP_ACID, amnt / 3, NULL);
+        rc = tbt->objDamage(DAMAGE_TRAP_ACID, amnt * OTHER_SIDE_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           delete tbt;
           tbt = NULL;
@@ -1818,8 +2005,7 @@ int TBeing::trapSleep(int amt) {
   }
 
   if (!isLucky(levelLuckModifier(GetMaxLevel()))) {
-    // at 2 minutes per mudhour, let's not make this too painful
-    rc = rawSleep(0, (2 * Pulse::UPDATES_PER_MUDHOUR), 1, SAVE_NO);
+    rc = rawSleep(0, (SLEEP_DURATION_HOURS * Pulse::UPDATES_PER_MUDHOUR), 1, SAVE_NO);
   } else
     sendTo("You feel sleepy, but you recover.\n\r");
 
@@ -1834,7 +2020,8 @@ void TBeing::trapDisease(int amt) {
   aff.level = 0;
   aff.location = APPLY_NONE;
   aff.bitvector = 0;
-  aff.duration = 4 * Pulse::UPDATES_PER_MUDHOUR;
+
+  aff.duration = DISEASE_DURATION_HOURS * Pulse::UPDATES_PER_MUDHOUR;
 
   if (isImmortal() || isImmune(IMMUNE_DISEASE, WEAR_BODY)) {
     act("Hmmm, lucky you, it doesn't seem to have had any effect.", FALSE, this,
@@ -1847,11 +2034,11 @@ void TBeing::trapDisease(int amt) {
       FALSE, this, 0, 0, TO_CHAR);
     act("$n doesn't look so hot.", TRUE, this, 0, 0, TO_ROOM);
   } else if (!isLucky(amt) && !isTough()) {
-    aff.duration *= 4;
+    aff.duration *= SEVERE_DISEASE_MULTIPLIER;
     act("You feel VERY sick.", FALSE, this, 0, 0, TO_CHAR);
     act("$n doesn't look so hot.", TRUE, this, 0, 0, TO_ROOM);
   } else {
-    aff.duration *= 2;
+    aff.duration *= MODERATE_DISEASE_MULTIPLIER;
     act("$n doesn't look so hot.", TRUE, this, 0, 0, TO_ROOM);
     act("You feel sick.", TRUE, this, 0, 0, TO_CHAR);
   }
@@ -1863,8 +2050,9 @@ void TBeing::trapPoison(int amt) {
   affectedData af, af2;
 
   af.type = SPELL_POISON;
-  af.duration = 12 * Pulse::UPDATES_PER_MUDHOUR;
-  af.modifier = -20;
+
+  af.duration = POISON_DURATION_HOURS * Pulse::UPDATES_PER_MUDHOUR;
+  af.modifier = POISON_STR_MODIFIER;
   af.location = APPLY_STR;
   af.bitvector = AFF_POISON;
 
@@ -1947,78 +2135,62 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
     half_chop(task->orig_arg, buf1, buf2);
 
     trapdamage = getDoorTrapDam(trap_type);
-    trapdamage = dice(trapdamage, 8) / 3;
+    trapdamage = dice(trapdamage, TRAP_DICE_SIZE) / TRAP_GOOF_DAMAGE_DIVISOR;
 
     hasTrapComps(buf2, TRAP_TARG_DOOR, -1);  // delete comps
 
+    // Single goof message for ALL door trap cases
+    act(GOOF_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+    act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+
     switch (trap_type) {
       case DOOR_TRAP_POISON:
-        act("You knick yourself and got some of the poison in the wound.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n knicks $mself and gets some of the poison in the wound.", FALSE,
-          this, 0, 0, TO_ROOM);
+        act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapPoison(trapdamage);
         break;
       case DOOR_TRAP_SPIKE:
-        act("You jostle the frame, and your trap goes off in your face!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n jostles the frame, and $s trap goes off in $s face!", FALSE,
-          this, 0, 0, TO_ROOM);
-        act("You are impaled by the spikes!", FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pierced by $s trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage / 2, NULL);
+        rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_BLADE:
-        act("You jostle the frame, and your trap goes off in your face!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n jostles the frame, and $s trap goes off in $s face!", FALSE,
-          this, 0, 0, TO_ROOM);
-        act("Swinging blades slice into your body!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n is sliced by $s razor trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_SLASH, trapdamage / 2, NULL);
+        rc = objDamage(DAMAGE_TRAP_SLASH, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_HAMMER:
-        act("You jostle the frame, and your trap goes off in your face!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n jostles the frame, and $s trap goes off in $s face!", FALSE,
-          this, 0, 0, TO_ROOM);
-        act("Heavy weights fall on you!", FALSE, this, 0, 0, TO_CHAR);
-        act("$n is crushed by $s hammer trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_BLUNT, trapdamage / 2, NULL);
+        rc = objDamage(DAMAGE_TRAP_BLUNT, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_SLEEP:
-        act("You slip up and are caught in your own trap!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips up and is caught in $s own trap.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapSleep(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS))
           return DELETE_THIS;
         break;
       case DOOR_TRAP_DISEASE:
-        act("You slip up, and drop the spores.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own spore trap.", FALSE, this, 0,
-          0, TO_ROOM);
+        act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapDisease(trapdamage);
         break;
       case DOOR_TRAP_TELEPORT:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own teleport trap.", FALSE, this,
-          0, 0, TO_ROOM);
+        act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapTeleport(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
@@ -2026,48 +2198,36 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         break;
       case DOOR_TRAP_TNT:
       case DOOR_TRAP_FIRE:
-        act("You jostle the frame, and your trap goes off in your face!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n jostles the frame, and $s trap goes off in $s face!", FALSE,
-          this, 0, 0, TO_ROOM);
-        act("Your fiery trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's fiery trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_TNT, trapdamage / 2, NULL);
+        rc = objDamage(DAMAGE_TRAP_TNT, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_ACID:
-        act("You slip up and spill the acid on yourself!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips and spills caustic acid upon $mself.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_ACID, trapdamage / 2, NULL);
+        rc = objDamage(DAMAGE_TRAP_ACID, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_ENERGY:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own energy trap.", FALSE, this, 0,
-          0, TO_ROOM);
-        rc = objDamage(DAMAGE_TRAP_ENERGY, trapdamage / 2, NULL);
+        act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+        rc = objDamage(DAMAGE_TRAP_ENERGY, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_FROST:
-        act("You jostle the frame, and your trap goes off in your face!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n jostles the frame, and $s trap goes off in $s face!", FALSE,
-          this, 0, 0, TO_ROOM);
-        act("Your frost trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's frost trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_FROST, trapdamage / 2, NULL);
+        rc = objDamage(DAMAGE_TRAP_FROST, trapdamage * GOOF_MOD, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
@@ -2077,85 +2237,70 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         sendTo(
           "You slip up, and the trap you were setting goes off in your "
           "face.\n\r");
-        act("$n's trap explodes in $s face.", FALSE, this, 0, 0, TO_ROOM);
+        act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         break;
     }
     // door traps
   } else if (goof_type == TRAP_TARG_CONT) {
-    trapdamage = getContainerTrapDam(trap_type);
-    trapdamage = dice(trapdamage, 8) / 3;
     obj = task->obj;
+
+    trapdamage = getContainerTrapDam(trap_type);
+    trapdamage = dice(trapdamage, TRAP_DICE_SIZE) / TRAP_GOOF_DAMAGE_DIVISOR;
 
     hasTrapComps(task->orig_arg, TRAP_TARG_CONT, -1);  // delete comps
 
+    // Single goof message for ALL container trap cases
+    act(GOOF_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+    act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+
     switch (trap_type) {
       case DOOR_TRAP_POISON:
-        act("You knick yourself and got some of the poison in the wound.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n knicks $mself and gets some of the poison in the wound.", FALSE,
-          this, 0, 0, TO_ROOM);
+        act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapPoison(trapdamage);
         break;
       case DOOR_TRAP_SPIKE:
-        act("You jostle $p, and your trap goes off in your face!", FALSE, this,
-          obj, 0, TO_CHAR);
-        act("$n jostles $p, and $s trap goes off in $s face!", FALSE, this, obj,
-          0, TO_ROOM);
-        act("You are impaled by the spikes!", FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pierced by $s trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage / 2, obj);
+        rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_BLADE:
-        act("You jostle $p, and your trap goes off in your face!", FALSE, this,
-          obj, 0, TO_CHAR);
-        act("$n jostles $p, and $s trap goes off in $s face!", FALSE, this, obj,
-          0, TO_ROOM);
-        act("Swinging blades slice into your body!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n is sliced by $s razor trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_SLASH, trapdamage / 2, obj);
+        rc = objDamage(DAMAGE_TRAP_SLASH, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_PEBBLE:
-        act("You jostle $p, and your trap goes off in your face!", FALSE, this,
-          obj, 0, TO_CHAR);
-        act("$n jostles $p, and $s trap goes off in $s face!", FALSE, this, obj,
-          0, TO_ROOM);
-        act("Dozens of pebbles pelt you!", FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pelted by $s pebble trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_BLUNT, trapdamage / 2, obj);
+        rc = objDamage(DAMAGE_TRAP_BLUNT, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_SLEEP:
-        act("You slip up and are caught in your own trap!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips up and is caught in $s own trap.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapSleep(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS))
           return DELETE_THIS;
         break;
       case DOOR_TRAP_DISEASE:
-        act("You slip up, and drop the spores.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own spore trap.", FALSE, this, 0,
-          0, TO_ROOM);
+        act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapDisease(trapdamage);
         break;
       case DOOR_TRAP_TELEPORT:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own teleport trap.", FALSE, this,
-          0, 0, TO_ROOM);
+        act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapTeleport(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
@@ -2163,48 +2308,36 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         break;
       case DOOR_TRAP_TNT:
       case DOOR_TRAP_FIRE:
-        act("You jostle $p, and your trap goes off in your face!", FALSE, this,
-          obj, 0, TO_CHAR);
-        act("$n jostles $p, and $s trap goes off in $s face!", FALSE, this, obj,
-          0, TO_ROOM);
-        act("Your fiery trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's fiery trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_TNT, trapdamage / 2, obj);
+        rc = objDamage(DAMAGE_TRAP_TNT, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_ACID:
-        act("You slip up and spill the acid on yourself!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips and spills caustic acid upon $mself.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_ACID, trapdamage / 2, obj);
+        rc = objDamage(DAMAGE_TRAP_ACID, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_ENERGY:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own energy trap.", FALSE, this, 0,
-          0, TO_ROOM);
-        rc = objDamage(DAMAGE_TRAP_ENERGY, trapdamage / 2, obj);
+        act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+        rc = objDamage(DAMAGE_TRAP_ENERGY, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_FROST:
-        act("You jostle $p, and your trap goes off in your face!", FALSE, this,
-          obj, 0, TO_CHAR);
-        act("$n jostles $p, and $s trap goes off in $s face!", FALSE, this, obj,
-          0, TO_ROOM);
-        act("Your frost trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's frost trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
-        rc = objDamage(DAMAGE_TRAP_FROST, trapdamage / 2, obj);
+        rc = objDamage(DAMAGE_TRAP_FROST, trapdamage * GOOF_MOD, obj);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
@@ -2214,33 +2347,29 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         sendTo(
           "You slip up, and the trap you were setting goes off in your "
           "face.\n\r");
-        act("$n's trap explodes in $s face.", FALSE, this, 0, 0, TO_ROOM);
+        act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         break;
     }
     // cont traps
   } else if (goof_type == TRAP_TARG_MINE) {
     trapdamage = getMineTrapDam(trap_type);
-    trapdamage = dice(trapdamage, 8) / 3;
+    trapdamage = dice(trapdamage, TRAP_DICE_SIZE) / TRAP_GOOF_DAMAGE_DIVISOR;
 
     hasTrapComps(task->orig_arg, TRAP_TARG_MINE, -1);  // delete comps
 
+    // Single goof message for ALL mine trap cases
+    act(GOOF_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+    act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+
     switch (trap_type) {
       case DOOR_TRAP_POISON:
-        act("You knick yourself and got some of the poison in the wound.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n knicks $mself and gets some of the poison in the wound.", FALSE,
-          this, 0, 0, TO_ROOM);
+        act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapPoison(trapdamage);
         break;
       case DOOR_TRAP_BOLT:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act(
-          "You are perforated by the tiny bolts, as they go flying everywhere!",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pierced by $s trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2248,13 +2377,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_DISK:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Razor disks scatter everywhere and slice into your body!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n is sliced by $s disk trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_SLASH, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2262,12 +2386,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_PEBBLE:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Dozens of pebbles pelt you!", FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pelted by $s pebble trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_BLUNT, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2275,37 +2395,28 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_SLEEP:
-        act("You slip up and are caught in your own trap!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips up and is caught in $s own trap.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapSleep(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS))
           return DELETE_THIS;
         break;
       case DOOR_TRAP_DISEASE:
-        act("You slip up, and drop the spores.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own spore trap.", FALSE, this, 0,
-          0, TO_ROOM);
+        act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapDisease(trapdamage);
         break;
       case DOOR_TRAP_TELEPORT:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own teleport trap.", FALSE, this,
-          0, 0, TO_ROOM);
+        act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapTeleport(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_TNT:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Your explosive trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's explosive trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_TNT, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2313,12 +2424,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_FIRE:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Your fiery trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's fiery trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_FIRE, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2326,10 +2433,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_ACID:
-        act("You slip up and spill the acid on yourself!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips and spills caustic acid upon $mself.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_ACID, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2337,22 +2442,16 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_ENERGY:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own energy trap.", FALSE, this, 0,
-          0, TO_ROOM);
+        act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = objDamage(DAMAGE_TRAP_ENERGY, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_FROST:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Your frost trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's frost trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_FROST, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2369,27 +2468,23 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
     }
   } else if (goof_type == TRAP_TARG_GRENADE) {
     trapdamage = getGrenadeTrapDam(trap_type);
-    trapdamage = dice(trapdamage, 8) / 3;
+    trapdamage = dice(trapdamage, TRAP_DICE_SIZE) / TRAP_GOOF_DAMAGE_DIVISOR;
 
     hasTrapComps(task->orig_arg, TRAP_TARG_GRENADE, -1);  // delete comps
 
+    // Single goof message for ALL grenade trap cases
+    act(GOOF_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+    act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+
     switch (trap_type) {
       case DOOR_TRAP_POISON:
-        act("You knick yourself and got some of the poison in the wound.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n knicks $mself and gets some of the poison in the wound.", FALSE,
-          this, 0, 0, TO_ROOM);
+        act(POISON_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(POISON_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapPoison(trapdamage);
         break;
       case DOOR_TRAP_BOLT:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act(
-          "You are perforated by the tiny bolts, as they go flying everywhere!",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pierced by $s trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2397,13 +2492,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_DISK:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Razor disks scatter everywhere and slice into your body!", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n is sliced by $s disk trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLADE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLADE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_SLASH, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2411,12 +2501,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_PEBBLE:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Dozens of pebbles pelt you!", FALSE, this, 0, 0, TO_CHAR);
-        act("$n is pelted by $s pebble trap.", FALSE, this, 0, 0, TO_ROOM);
+        act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_BLUNT, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2424,37 +2510,28 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_SLEEP:
-        act("You slip up and are caught in your own trap!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips up and is caught in $s own trap.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapSleep(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS))
           return DELETE_THIS;
         break;
       case DOOR_TRAP_DISEASE:
-        act("You slip up, and drop the spores.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own spore trap.", FALSE, this, 0,
-          0, TO_ROOM);
+        act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         trapDisease(trapdamage);
         break;
       case DOOR_TRAP_TELEPORT:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own teleport trap.", FALSE, this,
-          0, 0, TO_ROOM);
+        act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = trapTeleport(trapdamage);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_TNT:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Your explosive trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's explosive trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(TNT_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(TNT_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_TNT, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2462,12 +2539,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_FIRE:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Your fiery trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's fiery trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(FIRE_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(FIRE_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_FIRE, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2475,10 +2548,8 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_ACID:
-        act("You slip up and spill the acid on yourself!", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n slips and spills caustic acid upon $mself.", FALSE, this, 0, 0,
-          TO_ROOM);
+        act(ACID_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ACID_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_ACID, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2486,22 +2557,16 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         }
         break;
       case DOOR_TRAP_ENERGY:
-        act("You slip up, and lose control of the magical forces.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n slips up and is caught in $s own energy trap.", FALSE, this, 0,
-          0, TO_ROOM);
+        act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
         rc = objDamage(DAMAGE_TRAP_ENERGY, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
           return DELETE_THIS;
         }
         break;
       case DOOR_TRAP_FROST:
-        act("You slip up, and your trap goes off in your face!", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n slips up, and $s trap goes off in $s face!", FALSE, this, 0, 0,
-          TO_ROOM);
-        act("Your frost trap engulfs you.", FALSE, this, 0, 0, TO_CHAR);
-        act("$n's frost trap engulfs $m.", FALSE, this, 0, 0, TO_ROOM);
+        act(FROST_EFFECT_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+        act(FROST_EFFECT_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
 
         rc = objDamage(DAMAGE_TRAP_FROST, trapdamage, NULL);
         if (IS_SET_DELETE(rc, DELETE_THIS)) {
@@ -2516,6 +2581,20 @@ int TBeing::goofUpTrap(doorTrapT trap_type, trap_targ_t goof_type) {
         act("$n's trap explodes in $s face.", FALSE, this, 0, 0, TO_ROOM);
         break;
     }
+  } else if (goof_type == TRAP_TARG_ARROW) {
+    trapdamage = getArrowTrapDam(trap_type);
+    trapdamage = dice(trapdamage, TRAP_DICE_SIZE) / TRAP_GOOF_DAMAGE_DIVISOR;
+
+    hasTrapComps(task->orig_arg, TRAP_TARG_ARROW, -1);  // delete comps
+
+    // Single goof message for ALL arrow trap cases
+    act(GOOF_CHAR_MSG, FALSE, this, 0, 0, TO_CHAR);
+    act(GOOF_ROOM_MSG, FALSE, this, 0, 0, TO_ROOM);
+
+    // Apply the goof damage and trap effect
+    rc = objDamage(DAMAGE_TRAP_PIERCE, trapdamage, NULL);
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
   }
   return FALSE;
 }
@@ -2524,128 +2603,16 @@ bool TBeing::hasTrapComps(const char* type, trap_targ_t targ, int amt,
   int* price) {
   int item1 = 0, item2 = 0, item3 = 0, item4 = 0;
 
-  if (is_abbrev(type, "fire")) {
-    item1 = Obj::ST_FLINT;
-    item2 = Obj::ST_SULPHUR;
-    item3 = Obj::ST_BAG;
-  } else if (is_abbrev(type, "explosive")) {
-    item1 = Obj::ST_FLINT;
-    item2 = Obj::ST_SULPHUR;
-    item3 = Obj::ST_HYDROGEN;
-  } else if (is_abbrev(type, "poison")) {
-    if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-      item1 = Obj::ST_NEEDLE;
-      item2 = Obj::ST_SPRING;
-      item3 = Obj::ST_POISON;
-    } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-      item1 = Obj::ST_CANISTER;
-      item2 = Obj::ST_SPRING;
-      item3 = Obj::ST_CON_POISON;
-    }
-  } else if (is_abbrev(type, "sleep")) {
-    item1 = Obj::ST_NOZZLE;
-    item2 = Obj::ST_GAS;
-    item3 = Obj::ST_HOSE;
-  } else if (is_abbrev(type, "acid")) {
-    if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-      item1 = Obj::ST_NOZZLE;
-      item2 = Obj::ST_ACID_VIAL;
-      item3 = Obj::ST_BELLOWS;
-    } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-      item1 = Obj::ST_CANISTER;
-      item2 = Obj::ST_SPRING;
-      item3 = Obj::ST_ACID_VIAL;
-    }
-  } else if (is_abbrev(type, "spore")) {
-    if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-      item1 = Obj::ST_FUNGUS;
-      item2 = Obj::ST_NOZZLE;
-      item3 = Obj::ST_BELLOWS;
-    } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-      item1 = Obj::ST_CANISTER;
-      item2 = Obj::ST_SPRING;
-      item3 = Obj::ST_FUNGUS;
-    }
-  } else if (is_abbrev(type, "spike")) {
-    if (targ != TRAP_TARG_DOOR && targ != TRAP_TARG_CONT)
-      vlogf(LOG_MISC,
-        format("spike trap being set  with trap targ: %d") % targ);
-
-    item1 = Obj::ST_SPIKE;
-    item2 = Obj::ST_SPRING;
-    item3 = Obj::ST_TRIPWIRE;
-  } else if (is_abbrev(type, "bolt")) {
-    if (targ != TRAP_TARG_MINE && targ != TRAP_TARG_GRENADE)
-      vlogf(LOG_MISC, format("bolt trap being set  with trap targ: %d") % targ);
-
-    item1 = Obj::ST_TUBING;
-    item2 = Obj::ST_CGAS;
-    item3 = Obj::ST_BOLTS;
-  } else if (is_abbrev(type, "blade")) {
-    if (targ != TRAP_TARG_DOOR && targ != TRAP_TARG_CONT)
-      vlogf(LOG_MISC,
-        format("blade trap being set  with trap targ: %d") % targ);
-
-    item1 = Obj::ST_RAZOR_BLADE;
-    item2 = Obj::ST_SPRING;
-    item3 = Obj::ST_TRIPWIRE;
-  } else if (is_abbrev(type, "disk")) {
-    if (targ != TRAP_TARG_MINE && targ != TRAP_TARG_GRENADE)
-      vlogf(LOG_MISC, format("disk trap being set  with trap targ: %d") % targ);
-
-    item1 = Obj::ST_RAZOR_DISK;
-    item2 = Obj::ST_SPRING;
-    item3 = Obj::ST_CANISTER;
-  } else if (is_abbrev(type, "hammer")) {
-    if (targ != TRAP_TARG_DOOR)
-      vlogf(LOG_MISC,
-        format("hammer trap being set  with trap targ: %d") % targ);
-
-    item1 = Obj::ST_CONCRETE;
-    item2 = Obj::ST_WEDGE;
-    item3 = Obj::ST_TRIPWIRE;
-  } else if (is_abbrev(type, "pebble")) {
-    if (targ != TRAP_TARG_CONT && targ != TRAP_TARG_MINE &&
-        targ != TRAP_TARG_GRENADE)
-      vlogf(LOG_MISC,
-        format("pebble trap being set  with trap targ: %d") % targ);
-
-    item1 = Obj::ST_TUBING;
-    item2 = Obj::ST_CGAS;
-    item3 = Obj::ST_PEBBLES;
-  } else if (is_abbrev(type, "frost")) {
-    item1 = Obj::ST_NOZZLE;
-    item2 = Obj::ST_HOSE;
-    item3 = Obj::ST_FROST;
-  } else if (is_abbrev(type, "teleport")) {
-    if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-      item1 = Obj::ST_PENTAGRAM;
-      item2 = Obj::ST_TRIPWIRE;
-      item3 = Obj::ST_BLINK;
-    } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-      item1 = Obj::ST_PENTAGRAM;
-      item2 = Obj::ST_CRYSTALINE;
-      item3 = Obj::ST_BLINK;
-    }
-  } else if (is_abbrev(type, "power")) {
-    if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-      item1 = Obj::ST_PENTAGRAM;
-      item2 = Obj::ST_TRIPWIRE;
-      item3 = Obj::ST_ATHANOR;
-    } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-      item1 = Obj::ST_PENTAGRAM;
-      item2 = Obj::ST_CRYSTALINE;
-      item3 = Obj::ST_ATHANOR;
-    }
-  } else {
+  if (!getTrapComponents(type, targ, item1, item2, item3)) {
     vlogf(LOG_MISC, format("Bad call to hasTrapComps() : %s") % type);
-    return FALSE;
+    return false;
   }
+
   item1 = real_object(item1);
   item2 = real_object(item2);
   item3 = real_object(item3);
 
-  TThing* com4 = NULL;
+  TThing* com4 = nullptr;
 
   if (targ == TRAP_TARG_MINE) {
     item4 = Obj::ST_CASE_MINE;
@@ -2679,20 +2646,37 @@ bool TBeing::hasTrapComps(const char* type, trap_targ_t targ, int amt,
   }
 
   if (amt == -1) {
-    // trap is finished, delete the items
+    // trap is finished, consume components
     if (!com1 || !com2 || !com3) {
       vlogf(LOG_BUG, "Serious error in hasTrapComps");
       return FALSE;
     }
-    delete com1;
-    delete com2;
-    delete com3;
+
+    // Helper to consume one component: decrement charge on TTrapComponent,
+    // or remove-and-delete for regular objects. Always --(*item) before delete.
+    auto consumeComponent = [](TThing* com) {
+      if (auto* trapComp = dynamic_cast<TTrapComponent*>(com)) {
+        trapComp->addToTrapComponentCharges(-1);
+        if (trapComp->getTrapComponentCharges() <= 0) {
+          --(*trapComp);
+          delete trapComp;
+        }
+      } else {
+        --(*com);
+        delete com;
+      }
+    };
+
+    consumeComponent(com1);
+    consumeComponent(com2);
+    consumeComponent(com3);
+
     if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
       if (!com4) {
         vlogf(LOG_BUG, "Serious error in hasTrapComps (2)");
         return FALSE;
       }
-      delete com4;
+      consumeComponent(com4);
     }
     return FALSE;
   }
@@ -2702,788 +2686,8 @@ bool TBeing::hasTrapComps(const char* type, trap_targ_t targ, int amt,
     return (com1 && com2 && com3);
 }
 
-void TBeing::sendTrapMessage(const char* type, trap_targ_t targ, int num) {
-  sstring buf;
+// Old sendTrapMessage function removed - replaced with sendStandardizedTrapMessage
 
-  if (is_abbrev(type, "fire")) {
-    if (num == 1) {
-      sendTo("You pour your sulphur into a small bag.\n\r");
-      act("$n pours some sulphur into a small bag.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      sendTo("You stick a flint halfway down into the bag of sulphur.\n\r");
-      act("$n puts a small flint down into a small bag.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 3) {
-      sendTo("You close the top of the bag around the flint.\n\r");
-      act("$n wraps the top of $s bag around a small flint.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You trap the %s with your bag.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n jimmys the %s with $s bag.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You trap $p with your bag.", FALSE, this, task->obj, 0, TO_CHAR);
-        act("$n jimmys $p with $s bag.", TRUE, this, task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act("You situate the bag inside the mine casing.", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n situates $s bag inside a mine casing.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act("You situate the bag inside the grenade casing.", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n situates $s bag inside a grenade casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "explosive")) {
-    if (num == 1) {
-      sendTo("You attach your sulphur to the hydrogen bottle's neck.\n\r");
-      act("$n attaches some sulphur to a bottle of hydrogen.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 2) {
-      sendTo("You wedge a piece of flint into the bottle's neck.\n\r");
-      act("$n wedges a piece of flint into $s bottle.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 3) {
-      sendTo("You pour some more sulphur around the piece of flint.\n\r");
-      act("$n pours some more sulphur around the flint.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You afix the bottle to the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n jimmys the %s with $s bottle.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You afix the bottle to $p.", FALSE, this, task->obj, 0, TO_CHAR);
-        act("$n jimmys $p with $s bottle.", TRUE, this, task->obj, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act("You situate the bottle inside the mine casing.", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n situates the bottle inside a mine casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act("You situate the bottle inside the grenade casing.", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n situates the bottle inside a grenade casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "poison")) {
-    if (num == 1) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You attach a needle to the tiny spring.\n\r");
-        act("$n attaches a thin needle to $s tiny spring.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You pour the contact poison into the canister.\n\r");
-        act("$n pours a murky liquid into a canister.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      }
-    } else if (num == 2) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You screw the needle apparatus into the vial of poison.\n\r");
-        act("$n screws the needle apparatus into the vial of poison.", TRUE,
-          this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You afix the spring to the canister.\n\r");
-        act("$n fiddles with a canister.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You release the poison into the needle.\n\r");
-        act("$n releases the poison into the needle.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        sendTo(
-          "You gently place the canister apparatus inside the mine "
-          "casing.\n\r");
-        act("$n puts the canister inside a mine casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You gently place the canister apparatus inside a grenade "
-          "casing.\n\r");
-        act("$n puts the canister inside a grenade casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(
-          format("You conceal the poisoned needle inside the %s's lock.\n\r") %
-          fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the poisoned needle inside the %s's lock.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the poisoned needle inside $p's lock.", FALSE, this,
-          task->obj, 0, TO_CHAR);
-        act("$n conceals the poisoned needle inside $p's lock.", TRUE, this,
-          task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        sendTo("You springload the canister and arm the land mine.\n\r");
-        act("$n fiddles with a land mine.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You take the safeties off the canister and prepare the grenade for "
-          "use.\n\r");
-        act("$n fiddles with a grenade.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "sleep")) {
-    if (num == 1) {
-      sendTo("You screw a small nozzle into a hose.\n\r");
-      act("$n screw a small nozzle into a hose.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      sendTo("You clamp the hose snuggly around the nozzle.\n\r");
-      act("$n clamps the hose snuggly around the nozzle.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 3) {
-      sendTo("You afix the hose to the vial of gas.\n\r");
-      act("$n afixes the hose to $s vial of gas.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You conceal the gas apparatus within the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the apparatus inside the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the gas apparatus inside $p's lock.", FALSE, this,
-          task->obj, 0, TO_CHAR);
-        act("$n conceals the gas apparatus inside $p's lock.", TRUE, this,
-          task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act("You conceal the gas apparatus inside a mine casing.", FALSE, this,
-          0, 0, TO_CHAR);
-        act("$n conceals the gas apparatus inside a mine casing.", TRUE, this,
-          NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act("You conceal the gas apparatus inside a grenade casing.", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n conceals the gas apparatus inside a grenade casing.", TRUE,
-          this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "frost")) {
-    if (num == 1) {
-      sendTo("You screw a small nozzle into a hose.\n\r");
-      act("$n screw a small nozzle into a hose.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      sendTo("You clamp the hose snuggly around the nozzle.\n\r");
-      act("$n clamps the hose snuggly around the nozzle.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 3) {
-      sendTo("You afix the hose to the cylinder of liquid frost.\n\r");
-      act("$n afixes the hose to $s cylinder of liquid frost.", TRUE, this,
-        NULL, NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You conceal the frost apparatus into the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the apparatus into the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the frost apparatus inside $p's lock.", FALSE, this,
-          task->obj, 0, TO_CHAR);
-        act("$n conceals the frost apparatus inside $p's lock.", TRUE, this,
-          task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act("You conceal the frost apparatus inside a mine casing.", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n conceals the frost apparatus inside a mine casing.", TRUE, this,
-          NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act("You conceal the frost apparatus inside a grenade casing.", FALSE,
-          this, 0, 0, TO_CHAR);
-        act("$n conceals the frost apparatus inside a grenade casing.", TRUE,
-          this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "acid")) {
-    if (num == 1) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You attach the vial of acid to the bellows.\n\r");
-        act("$n attach the vial of acid to your bellows.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You pour the acid into the canister.\n\r");
-        act("$n pours a bubbly liquid into a canister.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      }
-    } else if (num == 2) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You attach the nozzle to the end of the bellows.\n\r");
-        act("$n attaches the nozzle to $s bellows.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You afix the spring to the canister.\n\r");
-        act("$n fiddles with a canister.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You release the acid into the bellows.\n\r");
-        act("$n releases the acid into the bellows.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        sendTo(
-          "You gently place the canister apparatus inside the mine "
-          "casing.\n\r");
-        act("$n puts the canister inside a mine casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You gently place the canister apparatus inside a grenade "
-          "casing.\n\r");
-        act("$n puts the canister inside a grenade casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You conceal the trap inside the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the trap inside the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the trap inside $p.", FALSE, this, task->obj, 0,
-          TO_CHAR);
-        act("$n conceals the trap inside $p.", TRUE, this, task->obj, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        sendTo("You springload the canister and arm the land mine.\n\r");
-        act("$n fiddles with a land mine.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You take the safeties off the canister and prepare the grenade for "
-          "use.\n\r");
-        act("$n fiddles with a grenade.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "spore")) {
-    if (num == 1) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You carefully stuff the fungus into the bellows.\n\r");
-        act("$n stuffs some fungus into $s bellows.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You pour the fungus spores into the canister.\n\r");
-        act("$n pours some fungus spores into a canister.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 2) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You cap the end of the bellows with a nozzle.\n\r");
-        act("$n caps the bellows with a nozzle.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You afix the spring to the canister.\n\r");
-        act("$n fiddles with a canister.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo(
-          "You shake the bellows, causing the fungus within to release its "
-          "spores.\n\r");
-        act("$n shakes the bellows vigorously.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        sendTo(
-          "You gently place the canister apparatus inside the mine "
-          "casing.\n\r");
-        act("$n puts the canister inside a mine casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You gently place the canister apparatus inside a grenade "
-          "casing.\n\r");
-        act("$n puts the canister inside a grenade casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You conceal the trap inside the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the trap inside the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the trap inside $p.", FALSE, this, task->obj, 0,
-          TO_CHAR);
-        act("$n conceals the trap inside $p.", TRUE, this, task->obj, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        sendTo("You springload the canister and arm the land mine.\n\r");
-        act("$n fiddles with a land mine.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You take the safeties off the canister and prepare the grenade for "
-          "use.\n\r");
-        act("$n fiddles with a grenade.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "spike")) {
-    if (num == 1) {
-      sendTo("You afix the spring to your sharpened spike.\n\r");
-      act("$n afixes a spring to a sharpened spike.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You conceal the spike inside the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the spike inside the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the spike inside $p.", FALSE, this, task->obj, 0,
-          TO_CHAR);
-        act("$n conceals the spike inside $p.", TRUE, this, task->obj, NULL,
-          TO_ROOM);
-        return;
-      }
-    } else if (num == 3) {
-      sendTo(
-        "You tie the tripwire to the spike apparatus and springload it.\n\r");
-      act("$n ties a tripwire to the spike and fiddles with it some more.",
-        TRUE, this, NULL, NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(
-          format("You stretch the tripwire across the %s and tie it off.\n\r") %
-          fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n stretches a tripwire across the %s and ties it off.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You stretch the tripwire across $p's lock and tie it off.", FALSE,
-          this, task->obj, 0, TO_CHAR);
-        act("$n stretches $s tripwire across $p's lock and ties it off.", TRUE,
-          this, task->obj, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "bolt")) {
-    if (num == 1) {
-      act("You attach some tubing to the outlet valve of the compressed gas.",
-        FALSE, this, 0, 0, TO_CHAR);
-      act("$n fiddles with some tubing and a vial.", TRUE, this, 0, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      act("You pour the bolts into the tubing.", FALSE, this, 0, 0, TO_CHAR);
-      act("$n pours some bolts into the tubing.", TRUE, this, 0, NULL, TO_ROOM);
-      return;
-    } else if (num == 3) {
-      act("You arm the trigger mechanism on the compressed gas.", FALSE, this,
-        0, 0, TO_CHAR);
-      act("$n arm the trigger mechanism on the compressed gas.", TRUE, this, 0,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_MINE) {
-        act("You conceal the tubing inside the mine casing.", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n fiddles with a mine casing.", TRUE, this, 0, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act("You conceal the tubing inside the grenade casing.", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n fiddles with a grenade casing.", TRUE, this, 0, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "blade")) {
-    if (num == 1) {
-      sendTo("You afix the spring to your razor sharp blade.\n\r");
-      act("$n afixes a spring to $s razor blade.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You conceal the razor blade inside the %s.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n conceals the razor blade inside the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You conceal the razor blade inside $p.", FALSE, this, task->obj, 0,
-          TO_CHAR);
-        act("$n conceals the razor blade inside $p.", TRUE, this, task->obj,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 3) {
-      sendTo(
-        "You tie the tripwire to the razor apparatus and springload it.\n\r");
-      act("$n ties a tripwire to the razor and fiddles with it some more.",
-        TRUE, this, NULL, NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(
-          format("You stretch the tripwire across the %s and tie it off.\n\r") %
-          fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n stretches a tripwire across the %s and ties it off.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You stretch the tripwire across $p's lock and tie it off.", FALSE,
-          this, task->obj, 0, TO_CHAR);
-        act("$n stretches $s tripwire across $p's lock and ties it off.", TRUE,
-          this, task->obj, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "disk")) {
-    if (num == 1) {
-      sendTo("You pour the razor sharp disks into the canister.\n\r");
-      act("$n pours some razor sharp disks into a canister.", TRUE, this, NULL,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 2) {
-      sendTo("You afix the spring to the canister.\n\r");
-      act("$n fiddles with a canister.", TRUE, this, NULL, NULL, TO_ROOM);
-      return;
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_MINE) {
-        sendTo(
-          "You gently place the canister apparatus inside the mine "
-          "casing.\n\r");
-        act("$n puts the canister inside a mine casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You gently place the canister apparatus inside a grenade "
-          "casing.\n\r");
-        act("$n puts the canister inside a grenade casing.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_MINE) {
-        sendTo("You springload the canister and arm the land mine.\n\r");
-        act("$n fiddles with a land mine.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        sendTo(
-          "You take the safeties off the canister and prepare the grenade for "
-          "use.\n\r");
-        act("$n fiddles with a grenade.", TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "hammer")) {
-    if (num == 1) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You pry open the frame of a %s with your wedge.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n pries at a %s's frame.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 2) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You shove the concrete up above the %s's frame.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n stuffs something bulky above the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo("You tie the tripwire to the frame wedge.\n\r");
-        act("$n ties a tripwire to $s booby trap.", TRUE, this, NULL, NULL,
-          TO_ROOM);
-        return;
-      }
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(
-          format("You stretch the tripwire across the %s and tie it off.\n\r") %
-          fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n stretches a tripwire across the %s and ties it off.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "pebble")) {
-    if (num == 1) {
-      act("You attach some tubing to the outlet valve of the compressed gas.",
-        FALSE, this, 0, 0, TO_CHAR);
-      act("$n fiddles with some tubing and a vial.", TRUE, this, 0, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 2) {
-      act("You pour the pebbles into the tubing.", FALSE, this, 0, 0, TO_CHAR);
-      act("$n pours some stones into the tubing.", TRUE, this, 0, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 3) {
-      act("You arm the trigger mechanism on the compressed gas.", FALSE, this,
-        0, 0, TO_CHAR);
-      act("$n arm the trigger mechanism on the compressed gas.", TRUE, this, 0,
-        NULL, TO_ROOM);
-      return;
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_CONT) {
-        act("You conceal the tubing on $p.", FALSE, this, task->obj, 0,
-          TO_CHAR);
-        act("$n fiddles with $p.", TRUE, this, task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act("You conceal the tubing inside the mine casing.", FALSE, this, 0, 0,
-          TO_CHAR);
-        act("$n fiddles with a mine casing.", TRUE, this, 0, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act("You conceal the tubing inside the grenade casing.", FALSE, this, 0,
-          0, TO_CHAR);
-        act("$n fiddles with a grenade casing.", TRUE, this, 0, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "teleport")) {
-    if (num == 1) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You plaster a pentagram to the %s to focus the magical "
-                      "forces.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n plasters a pentagram to the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You plaster a pentagram to $p to focus the magical forces.", FALSE,
-          this, task->obj, 0, TO_CHAR);
-        act("$n plasters a pentagram to $p.", TRUE, this, task->obj, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act(
-          "You plaster a pentagram to a mine casing to focus the magical "
-          "forces.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n plasters a pentagram to a mine casing.", TRUE, this, 0, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act(
-          "You plaster a pentagram to a grenade casing to focus the magical "
-          "forces.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n plasters a pentagram to a grenade casing.", TRUE, this, 0, NULL,
-          TO_ROOM);
-        return;
-      }
-    } else if (num == 2) {
-      sendTo(
-        "You sprinkle the blink powder around the edges of the pentagram.\n\r");
-      act("$n sprinkles some dust on the pentagram.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You bond the tripwire to one side of the pentagram.\n\r");
-        act("$n fiddles with a bit of wire and $s pentagram.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You trace along the pentagram with the crystalline.\n\r");
-        act("$n fiddles with a crystal and $s pentagram.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(
-          format("You stretch the tripwire across the %s and tie it off.\n\r") %
-          fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n stretches a tripwire across the %s and ties it off.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You stretch the tripwire across $p's lock and tie it off.", FALSE,
-          this, task->obj, 0, TO_CHAR);
-        act("$n stretches $s tripwire across $p's lock and ties it off.", TRUE,
-          this, task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        act(
-          "You snap the crystalline, activating the magical forces in the "
-          "pentagram.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act(
-          "As $n snaps $s crystalline in half, the pentagram glows with magic.",
-          TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  } else if (is_abbrev(type, "power")) {
-    if (num == 1) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(format("You plaster a pentagram to the %s to focus the magical "
-                      "forces.\n\r") %
-               fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n plasters a pentagram to the %s.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You plaster a pentagram to $p to focus the magical forces.", FALSE,
-          this, task->obj, 0, TO_CHAR);
-        act("$n plasters a pentagram to $p.", TRUE, this, task->obj, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE) {
-        act(
-          "You plaster a pentagram to a mine casing to focus the magical "
-          "forces.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n plasters a pentagram to a mine casing.", TRUE, this, 0, NULL,
-          TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_GRENADE) {
-        act(
-          "You plaster a pentagram to a grenade casing to focus the magical "
-          "forces.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act("$n plasters a pentagram to a grenade casing.", TRUE, this, 0, NULL,
-          TO_ROOM);
-        return;
-      }
-    } else if (num == 2) {
-      sendTo(
-        "You position the refined athanor in the center of the pentagram.\n\r");
-      act("$n puts something inside the pentagram.", TRUE, this, NULL, NULL,
-        TO_ROOM);
-      return;
-    } else if (num == 3) {
-      if (targ == TRAP_TARG_DOOR || targ == TRAP_TARG_CONT) {
-        sendTo("You bond the tripwire to one side of the pentagram.\n\r");
-        act("$n fiddles with a bit of wire and $s pentagram.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        sendTo("You trace along the pentagram with the crystalline.\n\r");
-        act("$n fiddles with a crystal and $s pentagram.", TRUE, this, NULL,
-          NULL, TO_ROOM);
-        return;
-      }
-    } else if (num == 4) {
-      if (targ == TRAP_TARG_DOOR) {
-        sendTo(
-          format("You stretch the tripwire across the %s and tie it off.\n\r") %
-          fname(roomp->dir_option[task->flags]->keyword));
-        buf = format("$n stretches a tripwire across the %s and ties it off.") %
-              fname(roomp->dir_option[task->flags]->keyword);
-        act(buf, TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_CONT) {
-        act("You stretch the tripwire across $p's lock and tie it off.", FALSE,
-          this, task->obj, 0, TO_CHAR);
-        act("$n stretches $s tripwire across $p's lock and ties it off.", TRUE,
-          this, task->obj, NULL, TO_ROOM);
-        return;
-      } else if (targ == TRAP_TARG_MINE || targ == TRAP_TARG_GRENADE) {
-        act(
-          "You snap the crystalline, activating the magical forces in the "
-          "pentagram.",
-          FALSE, this, 0, 0, TO_CHAR);
-        act(
-          "As $n snaps $s crystalline in half, the pentagram glows with magic.",
-          TRUE, this, NULL, NULL, TO_ROOM);
-        return;
-      }
-    }
-  }
-
-  vlogf(LOG_BUG, format("Bad trap type (%s, %d, %d) with character %s") % type %
-                   targ % num % getName());
-}
 
 void TBeing::throwGrenade(TTrap* o, dirTypeT dir) {
   char buf[256];
@@ -3533,20 +2737,20 @@ int TBeing::grenadeHit(TTrap* o) {
 
   switch (o->getTrapDamType()) {
     case DOOR_TRAP_POISON:
-      act("You are sprayed with contact poison!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is sprayed with contact poison!", FALSE, this, o, 0, TO_ROOM);
+      act(POISON_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(POISON_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
       trapPoison(o->getTrapDamAmount());
       return TRUE;
     case DOOR_TRAP_SLEEP:
-      act("You are surrounded by a noxious mist!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is surrounded by a noxious mist!", FALSE, this, o, 0, TO_ROOM);
+      act(SLEEP_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(SLEEP_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
       rc = trapSleep(o->getTrapDamAmount());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_FIRE:
-      act("You are burned by the flames!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is burned by the flames.", FALSE, this, o, 0, TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FIRE, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -3558,23 +2762,21 @@ int TBeing::grenadeHit(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_TELEPORT:
-      act("You find yourself sucked into the vortex!", FALSE, this, o, 0,
-        TO_CHAR);
-      act("$n flails wildly, but falls into the vortex.", FALSE, this, o, 0,
-        TO_ROOM);
+      act(TELEPORT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(TELEPORT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = trapTeleport(o->getTrapDamAmount());
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_DISEASE:
-      act("You are surrounded by the thick cloud!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is surrounded by the thick cloud!", FALSE, this, o, 0, TO_ROOM);
+      act(DISEASE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(DISEASE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
       trapDisease(o->getTrapDamAmount());
       return TRUE;
     case DOOR_TRAP_BOLT:
-      act("You are perforated by the bolts!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is perforated by the bolts.", FALSE, this, o, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_PIERCE, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -3582,8 +2784,8 @@ int TBeing::grenadeHit(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_PEBBLE:
-      act("You are hit by the fusillade!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is hit by the pebbles.", FALSE, this, o, 0, TO_ROOM);
+      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_BLUNT, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -3591,24 +2793,24 @@ int TBeing::grenadeHit(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_DISK:
-      act("You are slashed by the razor-disks!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is slashed by the razor-disks.", FALSE, this, o, 0, TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_SLASH, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_TNT:
-      act("You are blasted by $p!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is blasted by fragments from $p.", FALSE, this, o, 0, TO_ROOM);
+      act(TNT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_TNT, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_FROST:
-      act("You are frozen by the icy cloud!", FALSE, this, o, 0, TO_CHAR);
-      act("$n is frozen by the icy cloud.", FALSE, this, o, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FROST, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -3620,20 +2822,16 @@ int TBeing::grenadeHit(TTrap* o) {
 
       return TRUE;
     case DOOR_TRAP_ENERGY:
-      act("You are devastated by dozens of plasma bolts!", FALSE, this, o, 0,
-        TO_CHAR);
-      act("$n is devastated by dozens of plasma bolts.", FALSE, this, o, 0,
-        TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ENERGY, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
       return TRUE;
     case DOOR_TRAP_ACID:
-      act("You are surrounded by the horrid acid cloud!", FALSE, this, o, 0,
-        TO_CHAR);
-      act("$n is surrounded by the horrid acid cloud.", FALSE, this, o, 0,
-        TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ACID, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -3722,178 +2920,90 @@ int TObj::grenadeHit(TTrap* o) {
   return FALSE;
 }
 
+namespace {
+  // Door trap damage modifiers
+  constexpr int getDoorTrapDamageModifier(doorTrapT trap_type) {
+    switch (trap_type) {
+      case DOOR_TRAP_TNT: return 3;
+      case DOOR_TRAP_POISON: return -1;
+      case DOOR_TRAP_SLEEP: return 1;
+      case DOOR_TRAP_ACID: return 1;
+      case DOOR_TRAP_DISEASE: return 3;
+      case DOOR_TRAP_FROST: return 3;
+      case DOOR_TRAP_SPIKE: return -5;
+      case DOOR_TRAP_BOLT: return 1;
+      case DOOR_TRAP_BLADE: return -3;
+      case DOOR_TRAP_DISK: return 3;
+      case DOOR_TRAP_HAMMER: return -10;
+      case DOOR_TRAP_PEBBLE: return -5;
+      case DOOR_TRAP_ENERGY: return 5;
+      case DOOR_TRAP_TELEPORT: return 5;
+      default: return 0;
+    }
+  }
+
+  // Helper function for room-wide trap effects with simple effects (no return value)
+  template<typename SimpleEffect>
+  void applySimpleRoomEffect(TBeing* caster, TRoom* room, TTrap* trap_obj,
+                            const char* char_msg, const char* room_msg,
+                            SimpleEffect effect_func) {
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end();) {
+      TThing* v = *(it++);
+      TBeing* tbt = dynamic_cast<TBeing*>(v);
+      if (tbt && tbt->desc && tbt != caster) {
+        act(char_msg, FALSE, tbt, trap_obj, 0, TO_CHAR);
+        act(room_msg, FALSE, tbt, trap_obj, 0, TO_ROOM);
+        effect_func(tbt, trap_obj->getTrapDamAmount() * STATUS_ROOM_MOD);
+      }
+    }
+  }
+
+  // Helper function for room-wide trap effects with complex effects (return DELETE_THIS)
+  template<typename ComplexEffect>
+  void applyComplexRoomEffect(TBeing* caster, TRoom* room, TTrap* trap_obj,
+                             const char* char_msg, const char* room_msg,
+                             ComplexEffect effect_func) {
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end();) {
+      TThing* v = *(it++);
+      TBeing* tbt = dynamic_cast<TBeing*>(v);
+      if (tbt && tbt->desc && tbt != caster) {
+        act(char_msg, FALSE, tbt, trap_obj, 0, TO_CHAR);
+        act(room_msg, FALSE, tbt, trap_obj, 0, TO_ROOM);
+        const int rc = effect_func(tbt, trap_obj->getTrapDamAmount() * STATUS_ROOM_MOD);
+        if (IS_SET_DELETE(rc, DELETE_THIS)) {
+          delete tbt;
+          tbt = nullptr;
+        }
+      }
+    }
+  }
+}
+
 int TBeing::getDoorTrapDam(doorTrapT trap_type) {
-  // this is number of d8 to use when calculating damage
   // base range: 10 - 35
   int damage = 10 + getSkillLevel(SKILL_SET_TRAP_DOOR) / 2;
-
   damage *= getDoorTrapLearn(trap_type);
   damage /= 100;
-
-  switch (trap_type) {
-    case DOOR_TRAP_TNT:
-      damage += 3;
-      break;
-    case DOOR_TRAP_POISON:
-      damage -= 1;
-      break;
-    case DOOR_TRAP_SLEEP:
-      damage += 1;
-      break;
-    case DOOR_TRAP_ACID:
-      damage += 1;
-      break;
-    case DOOR_TRAP_DISEASE:
-      damage += 3;
-      break;
-    case DOOR_TRAP_FROST:
-      damage += 3;
-      break;
-    case DOOR_TRAP_SPIKE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_BOLT:
-      damage += 1;
-      break;
-    case DOOR_TRAP_BLADE:
-      damage -= 3;
-      break;
-    case DOOR_TRAP_DISK:
-      damage += 3;
-      break;
-    case DOOR_TRAP_HAMMER:
-      damage -= 10;
-      break;
-    case DOOR_TRAP_PEBBLE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_ENERGY:
-      damage += 5;
-      break;
-    case DOOR_TRAP_TELEPORT:
-      damage += 5;
-      break;
-    default:
-      break;
-  }
-  damage = min(max(damage, 1), 50);
-  return damage;
+  damage += getDoorTrapDamageModifier(trap_type);
+  return min(max(damage, 1), 50);
 }
 
 int TBeing::getContainerTrapDam(doorTrapT trap_type) {
-  // this is number of d8 to use when calculating damage
   // base range: 20 - 36
   int damage = 20 + getSkillLevel(SKILL_SET_TRAP_CONT) / 3;
-
   damage *= getContainerTrapLearn(trap_type);
   damage /= 100;
-
-  switch (trap_type) {
-    case DOOR_TRAP_TNT:
-      damage += 3;
-      break;
-    case DOOR_TRAP_POISON:
-      damage -= 1;
-      break;
-    case DOOR_TRAP_SLEEP:
-      damage += 1;
-      break;
-    case DOOR_TRAP_ACID:
-      damage += 1;
-      break;
-    case DOOR_TRAP_DISEASE:
-      damage += 3;
-      break;
-    case DOOR_TRAP_FROST:
-      damage += 3;
-      break;
-    case DOOR_TRAP_SPIKE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_BOLT:
-      damage += 1;
-      break;
-    case DOOR_TRAP_BLADE:
-      damage -= 3;
-      break;
-    case DOOR_TRAP_DISK:
-      damage += 3;
-      break;
-    case DOOR_TRAP_HAMMER:
-      damage -= 10;
-      break;
-    case DOOR_TRAP_PEBBLE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_ENERGY:
-      damage += 5;
-      break;
-    case DOOR_TRAP_TELEPORT:
-      damage += 5;
-      break;
-    default:
-      break;
-  }
-  damage = min(max(damage, 1), 50);
-  return damage;
+  damage += getDoorTrapDamageModifier(trap_type);  // Same modifiers as door traps
+  return min(max(damage, 1), 50);
 }
 
 int TBeing::getMineTrapDam(doorTrapT trap_type) {
-  // this is number of d8 to use when calculating damage
   // base range: 20 - 45
   int damage = 20 + getSkillLevel(SKILL_SET_TRAP_MINE) / 2;
-
   damage *= getMineTrapLearn(trap_type);
   damage /= 100;
-
-  switch (trap_type) {
-    case DOOR_TRAP_TNT:
-      damage += 3;
-      break;
-    case DOOR_TRAP_POISON:
-      damage -= 1;
-      break;
-    case DOOR_TRAP_SLEEP:
-      damage += 1;
-      break;
-    case DOOR_TRAP_ACID:
-      damage += 1;
-      break;
-    case DOOR_TRAP_DISEASE:
-      damage += 3;
-      break;
-    case DOOR_TRAP_FROST:
-      damage += 3;
-      break;
-    case DOOR_TRAP_SPIKE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_BOLT:
-      damage += 1;
-      break;
-    case DOOR_TRAP_BLADE:
-      damage -= 3;
-      break;
-    case DOOR_TRAP_DISK:
-      damage += 3;
-      break;
-    case DOOR_TRAP_HAMMER:
-      damage -= 10;
-      break;
-    case DOOR_TRAP_PEBBLE:
-      damage -= 5;
-      break;
-    case DOOR_TRAP_ENERGY:
-      damage += 5;
-      break;
-    case DOOR_TRAP_TELEPORT:
-      damage += 5;
-      break;
-    default:
-      break;
-  }
-  damage = min(max(damage, 1), 50);
-  return damage;
+  damage += getDoorTrapDamageModifier(trap_type);  // Same modifiers as door traps
+  return min(max(damage, 1), 50);
 }
 
 int TBeing::getGrenadeTrapDam(doorTrapT trap_type) {

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -87,6 +87,12 @@ namespace {
   constexpr const char* BLADE_EFFECT_ROOM_MSG = "$n is sliced by the razor blades.";
   constexpr const char* BLUNT_EFFECT_CHAR_MSG = "You are pummeled by the heavy weights!";
   constexpr const char* BLUNT_EFFECT_ROOM_MSG = "$n is pummeled by the heavy weights.";
+  constexpr const char* BOLT_EFFECT_CHAR_MSG = "You are perforated by the bolts!";
+  constexpr const char* BOLT_EFFECT_ROOM_MSG = "$n is perforated by the bolts.";
+  constexpr const char* DISK_EFFECT_CHAR_MSG = "You are slashed by the razor-disks!";
+  constexpr const char* DISK_EFFECT_ROOM_MSG = "$n is slashed by the razor-disks.";
+  constexpr const char* PEBBLE_EFFECT_CHAR_MSG = "You are hit by the fusillade!";
+  constexpr const char* PEBBLE_EFFECT_ROOM_MSG = "$n is hit by the pebbles.";
   constexpr const char* TELEPORT_EFFECT_CHAR_MSG = "You find yourself sucked into the vortex!";
   constexpr const char* TELEPORT_EFFECT_ROOM_MSG = "$n flails wildly, but falls into the vortex.";
   constexpr const char* DISEASE_EFFECT_CHAR_MSG = "You are surrounded by a cloud of spores!";
@@ -135,11 +141,11 @@ namespace {
     // DOOR_TRAP_ENERGY
     {DAMAGE_TRAP_ENERGY, ENERGY_EFFECT_CHAR_MSG, ENERGY_EFFECT_ROOM_MSG, nullptr},
     // DOOR_TRAP_BOLT
-    {DAMAGE_TRAP_PIERCE, SPIKE_EFFECT_CHAR_MSG, SPIKE_EFFECT_ROOM_MSG, nullptr},
+    {DAMAGE_TRAP_PIERCE, BOLT_EFFECT_CHAR_MSG, BOLT_EFFECT_ROOM_MSG, nullptr},
     // DOOR_TRAP_DISK
-    {DAMAGE_TRAP_SLASH, BLADE_EFFECT_CHAR_MSG, BLADE_EFFECT_ROOM_MSG, nullptr},
+    {DAMAGE_TRAP_SLASH, DISK_EFFECT_CHAR_MSG, DISK_EFFECT_ROOM_MSG, nullptr},
     // DOOR_TRAP_PEBBLE
-    {DAMAGE_TRAP_BLUNT, BLUNT_EFFECT_CHAR_MSG, BLUNT_EFFECT_ROOM_MSG, nullptr},
+    {DAMAGE_TRAP_BLUNT, PEBBLE_EFFECT_CHAR_MSG, PEBBLE_EFFECT_ROOM_MSG, nullptr},
   }};
 
   // Iterates a room's occupants and applies trap damage at a modifier.

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -1431,26 +1431,16 @@ int TBeing::triggerTrap(TTrap* o) {
       return TRUE;
     case DOOR_TRAP_FIRE:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(FIRE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(FIRE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_FIRE, o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(FIRE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(FIRE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(FIRE_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(FIRE_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FIRE, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1460,7 +1450,7 @@ int TBeing::triggerTrap(TTrap* o) {
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
 
-      return TRUE;
+      return true;
     case DOOR_TRAP_TELEPORT:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
       act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
@@ -1510,141 +1500,86 @@ int TBeing::triggerTrap(TTrap* o) {
       return TRUE;
     case DOOR_TRAP_BOLT:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(SPIKE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(SPIKE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_PIERCE,
-              o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(SPIKE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(SPIKE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(SPIKE_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(SPIKE_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_PIERCE, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
 
-      return TRUE;
+      return true;
     case DOOR_TRAP_PEBBLE:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(BLUNT_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(BLUNT_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_BLUNT,
-              o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(BLUNT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(BLUNT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(BLUNT_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(BLUNT_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_BLUNT, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
 
-      return TRUE;
+      return true;
     case DOOR_TRAP_DISK:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(BLADE_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(BLADE_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_SLASH,
-              o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(BLADE_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(BLADE_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(BLADE_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(BLADE_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_SLASH, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
-      return TRUE;
+      return true;
     case DOOR_TRAP_TNT:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(TNT_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(TNT_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc =
-              tbt->objDamage(DAMAGE_TRAP_TNT, o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(TNT_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(TNT_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(TNT_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(TNT_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_TNT, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
-      return TRUE;
+      return true;
     case DOOR_TRAP_FROST:
-      act("An icy cloud pours out of $p.", FALSE, this, o, 0, TO_CHAR);
-      act("An icy cloud pours out of $p.", FALSE, this, o, 0, TO_ROOM);
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(FROST_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(FROST_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_FROST,
-              o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(FROST_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(FROST_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(FROST_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(FROST_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_FROST, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1654,58 +1589,36 @@ int TBeing::triggerTrap(TTrap* o) {
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
 
-      return TRUE;
+      return true;
     case DOOR_TRAP_ENERGY:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(ENERGY_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(ENERGY_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_ENERGY,
-              o->getTrapDamAmount() * ROOM_MOD, o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(ENERGY_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(ENERGY_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(ENERGY_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(ENERGY_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ENERGY, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
-      return TRUE;
+      return true;
     case DOOR_TRAP_ACID:
       sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
-      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), FALSE, this, 0, 0, TO_ROOM);
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
 
       if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
-        for (StuffIter it = roomp->stuff.begin(); it != roomp->stuff.end();) {
-          v = *(it++);
-          tbt = dynamic_cast<TBeing*>(v);
-          if (tbt && tbt->desc && tbt != this) {
-            act(ACID_EFFECT_CHAR_MSG, FALSE, tbt, o, 0, TO_CHAR);
-            act(ACID_EFFECT_ROOM_MSG, FALSE, tbt, o, 0, TO_ROOM);
-            rc = tbt->objDamage(DAMAGE_TRAP_ACID, o->getTrapDamAmount() * ROOM_MOD,
-              o);
-            if (IS_SET_DELETE(rc, DELETE_THIS)) {
-              delete tbt;
-              tbt = NULL;
-            }
-          }
-        }
+        applyRoomWideDamage(this, roomp, trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())],
+                            o->getTrapDamAmount(), ROOM_MOD, o,
+                            [](TBeing* b) { return !b->desc; });
       }
 
-      act(ACID_EFFECT_CHAR_MSG, FALSE, this, o, 0, TO_CHAR);
-      act(ACID_EFFECT_ROOM_MSG, FALSE, this, o, 0, TO_ROOM);
+      act(ACID_EFFECT_CHAR_MSG, false, this, o, 0, TO_CHAR);
+      act(ACID_EFFECT_ROOM_MSG, false, this, o, 0, TO_ROOM);
 
       rc = objDamage(DAMAGE_TRAP_ACID, o->getTrapDamAmount(), o);
       if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -1715,7 +1628,7 @@ int TBeing::triggerTrap(TTrap* o) {
       if (IS_SET_DELETE(rc, DELETE_THIS))
         return DELETE_THIS;
 
-      return TRUE;
+      return true;
     default:
       vlogf(LOG_BUG, format("Unknown trap type %d in triggerTrap (%s:%d)") %
                        o->getTrapDamType() % o->getName() % o->objVnum());

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -5,6 +5,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include <array>
+#include <functional>
 #include <stdio.h>
 
 #include "handler.h"
@@ -94,6 +96,103 @@ namespace {
   // Consolidated trap goof messages
   constexpr const char* GOOF_CHAR_MSG = "Your hand slips and you fall victim to your own device!";
   constexpr const char* GOOF_ROOM_MSG = "$n's hand slips and $e falls victim to $s own device!";
+
+  // Maps each doorTrapT to its intrinsic properties.
+  // Status-only types (poison, sleep, disease, teleport) have damageType = 0
+  // since they use dedicated functions with varied return semantics.
+  struct TrapTypeInfo {
+    spellNumT damageType;
+    const char* charMsg;
+    const char* roomMsg;
+    int (TBeing::*engulfedFn)();
+  };
+
+  constexpr std::array<TrapTypeInfo, MAX_TRAP_TYPES> trapTypeInfo = {{
+    // DOOR_TRAP_NONE
+    {TYPE_UNDEFINED, nullptr, nullptr, nullptr},
+    // DOOR_TRAP_POISON (status-only)
+    {TYPE_UNDEFINED, POISON_EFFECT_CHAR_MSG, POISON_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_SPIKE
+    {DAMAGE_TRAP_PIERCE, SPIKE_EFFECT_CHAR_MSG, SPIKE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_SLEEP (status-only)
+    {TYPE_UNDEFINED, SLEEP_EFFECT_CHAR_MSG, SLEEP_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_TNT
+    {DAMAGE_TRAP_TNT, TNT_EFFECT_CHAR_MSG, TNT_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_BLADE
+    {DAMAGE_TRAP_SLASH, BLADE_EFFECT_CHAR_MSG, BLADE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_FIRE
+    {DAMAGE_TRAP_FIRE, FIRE_EFFECT_CHAR_MSG, FIRE_EFFECT_ROOM_MSG, &TBeing::flameEngulfed},
+    // DOOR_TRAP_ACID
+    {DAMAGE_TRAP_ACID, ACID_EFFECT_CHAR_MSG, ACID_EFFECT_ROOM_MSG, &TBeing::acidEngulfed},
+    // DOOR_TRAP_DISEASE (status-only)
+    {TYPE_UNDEFINED, DISEASE_EFFECT_CHAR_MSG, DISEASE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_HAMMER
+    {DAMAGE_TRAP_BLUNT, BLUNT_EFFECT_CHAR_MSG, BLUNT_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_FROST
+    {DAMAGE_TRAP_FROST, FROST_EFFECT_CHAR_MSG, FROST_EFFECT_ROOM_MSG, &TBeing::frostEngulfed},
+    // DOOR_TRAP_TELEPORT (status-only)
+    {TYPE_UNDEFINED, TELEPORT_EFFECT_CHAR_MSG, TELEPORT_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_ENERGY
+    {DAMAGE_TRAP_ENERGY, ENERGY_EFFECT_CHAR_MSG, ENERGY_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_BOLT
+    {DAMAGE_TRAP_PIERCE, SPIKE_EFFECT_CHAR_MSG, SPIKE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_DISK
+    {DAMAGE_TRAP_SLASH, BLADE_EFFECT_CHAR_MSG, BLADE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_PEBBLE
+    {DAMAGE_TRAP_BLUNT, BLUNT_EFFECT_CHAR_MSG, BLUNT_EFFECT_ROOM_MSG, nullptr},
+  }};
+
+  // Iterates a room's occupants and applies trap damage at a modifier.
+  // Skips triggerer and any being for which filter returns true.
+  // Handles DELETE_THIS by deleting dead bystanders inline.
+  void applyRoomWideDamage(TBeing* triggerer, TRoom* room,
+                           const TrapTypeInfo& info, int dam, double mod,
+                           TObj* trapObj,
+                           std::function<bool(TBeing*)> filter = nullptr) {
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end();) {
+      TThing* t = *(it++);
+      if (auto* tbt = dynamic_cast<TBeing*>(t)) {
+        if (tbt == triggerer)
+          continue;
+        if (filter && filter(tbt))
+          continue;
+        act(info.charMsg, false, tbt, 0, 0, TO_CHAR);
+        act(info.roomMsg, false, tbt, 0, 0, TO_ROOM);
+        int rc = tbt->objDamage(info.damageType, static_cast<int>(dam * mod), trapObj);
+        if (IS_SET_DELETE(rc, DELETE_THIS)) {
+          delete tbt;
+          tbt = nullptr;
+        }
+      }
+    }
+  }
+
+  // Applies trap damage to beings in the room on the other side of a door.
+  // Always uses OTHER_SIDE_MOD. No filter — old code didn't check immortality
+  // on the other side.
+  void applyOtherSideDamage(TBeing* triggerer, TRoom* otherRoom,
+                            const TrapTypeInfo& info, int dam) {
+    for (StuffIter it = otherRoom->stuff.begin(); it != otherRoom->stuff.end();) {
+      TThing* t = *(it++);
+      if (auto* tbt = dynamic_cast<TBeing*>(t)) {
+        if (tbt == triggerer)
+          continue;
+        act(info.charMsg, false, tbt, 0, 0, TO_CHAR);
+        act(info.roomMsg, false, tbt, 0, 0, TO_ROOM);
+        int rc = tbt->objDamage(info.damageType, static_cast<int>(dam * OTHER_SIDE_MOD), nullptr);
+        if (IS_SET_DELETE(rc, DELETE_THIS)) {
+          delete tbt;
+          tbt = nullptr;
+        }
+      }
+    }
+  }
+
+  // Door trap types that produce area effects (room-wide + other-side).
+  constexpr bool isDoorAreaTrap(doorTrapT type) {
+    return type == DOOR_TRAP_TNT || type == DOOR_TRAP_FROST
+        || type == DOOR_TRAP_ENERGY || type == DOOR_TRAP_ACID;
+  }
 
   // Standardized trap creation messages
   constexpr const char* TRAP_START_CHAR_MSG = "You start working on your trap.";

--- a/code/code/misc/trap.h
+++ b/code/code/misc/trap.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "sstring.h"
+
 const unsigned int TRAP_EFF_MOVE = (1 << 0);     // 1  trigger on movement
 const unsigned int TRAP_EFF_OBJECT = (1 << 1);   // 2  trigger on get or put
 const unsigned int TRAP_EFF_ROOM = (1 << 2);     // 4  affect all in room
@@ -64,3 +66,13 @@ extern const int TrapDir[];
 extern const char* const trap_effects[MAX_TRAP_EFF];
 extern doorTrapT mapFileToDoorTrap(int);
 extern int mapDoorTrapToFile(doorTrapT);
+
+// Forward declaration
+class TBeing;
+
+// Returns the 3 component vnums for a given trap type and target context.
+extern bool getTrapComponents(const char* trap_type, trap_targ_t targ,
+                              int& item1, int& item2, int& item3);
+
+// Standardized trap creation message function
+extern void sendTrapMessage(TBeing* ch, const char* trap_type, trap_targ_t targ, int step);

--- a/code/code/obj/obj_base_container.cc
+++ b/code/code/obj/obj_base_container.cc
@@ -72,7 +72,8 @@ int TBaseContainer::getCarriedVolume() const {
   // to worry about subcontainers (unsupported on sneezy), so we don't
   // need to use getTotalVolume() here
   for (StuffIter it = stuff.begin(); it != stuff.end() && (t = *it); ++it) {
-    if (t->getKind() == TThing::TThingKind::TComponent)
+    if (t->getKind() == TThing::TThingKind::TComponent ||
+        t->getKind() == TThing::TThingKind::TTrapComponent)
       total += (int)(t->getReducedVolume(this) * 0.10);
     else {
       total += t->getReducedVolume(this);

--- a/code/code/obj/obj_trap_component.cc
+++ b/code/code/obj/obj_trap_component.cc
@@ -285,14 +285,19 @@ bool TTrapComponent::splitMe(TBeing* ch, const sstring& tString) {
 
   // Set up the split component
   tComponent->setTrapComponentCharges(tCount);
-  tComponent->obj_flags.cost = (obj_flags.cost * tCount) / getTrapComponentCharges();
+  // Temporarily zero cost so willMerge rejects the re-merge when added to inventory
+  tComponent->obj_flags.cost = 0;
 
   // Reduce this component's charges and cost
+  int splitCost = (obj_flags.cost * tCount) / getTrapComponentCharges();
   addToTrapComponentCharges(-tCount);
-  obj_flags.cost -= tComponent->obj_flags.cost;
+  obj_flags.cost -= splitCost;
 
-  // Give the split component to the player
+  // Give the split component to the player (cost=0 prevents auto-merge)
   *ch += *tComponent;
+
+  // Now set the real cost
+  tComponent->obj_flags.cost = splitCost;
 
   ch->sendTo(format("You split off %d charges into a new component.\n\r") % tCount);
   return true;

--- a/code/code/obj/obj_trap_component.cc
+++ b/code/code/obj/obj_trap_component.cc
@@ -1,0 +1,415 @@
+//////////////////////////////////////////////////////////////////////////
+//
+// SneezyMUD - All rights reserved, SneezyMUD Coding Team
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "handler.h"
+#include "extern.h"
+#include "room.h"
+#include "being.h"
+#include "monster.h"
+#include "obj_trap_component.h"
+#include "shop.h"
+#include "shopowned.h"
+#include "materials.h"
+#include "comm.h"
+
+TThing::TThingKind TTrapComponent::getKind() const {
+  return TThing::TThingKind::TTrapComponent;
+}
+
+TTrapComponent::TTrapComponent() :
+  TMergeable(),
+  charges(1),
+  trap_comp_type(0) {}
+
+TTrapComponent::TTrapComponent(const TTrapComponent& a) :
+  TMergeable(a),
+  charges(a.charges),
+  trap_comp_type(a.trap_comp_type) {}
+
+TTrapComponent& TTrapComponent::operator=(const TTrapComponent& a) {
+  if (this == &a)
+    return *this;
+  TMergeable::operator=(a);
+  charges = a.charges;
+  trap_comp_type = a.trap_comp_type;
+  return *this;
+}
+
+TTrapComponent::~TTrapComponent() {}
+
+bool TTrapComponent::willMerge(TMergeable* tm) {
+  TTrapComponent* tComp;
+
+  // Merge components of the same type that are:
+  // Same VNum, same material, both have cost > 0, total charges <= 100
+  if (!(tComp = dynamic_cast<TTrapComponent*>(tm)) || tComp == this ||
+      (tComp->objVnum() != objVnum()) ||
+      (tComp->getMaterial() != getMaterial()) ||
+      tComp->obj_flags.cost <= 0 ||
+      obj_flags.cost <= 0 ||
+      tComp->getTrapComponentCharges() + getTrapComponentCharges() > 100) {
+    return false;
+  }
+  return true;
+}
+
+void TTrapComponent::doMerge(TMergeable* tm) {
+  TRoom* rp = nullptr;
+  TTrapComponent* tComp;
+
+  if (!(tComp = dynamic_cast<TTrapComponent*>(tm)) || !willMerge(tm))
+    return;
+
+  // Find the room for messaging
+  if (!(rp = roomp)) {
+    if (parent) {
+      rp = parent->roomp;
+    } else {
+      if (!(rp = tComp->roomp)) {
+        if (tComp->parent) {
+          rp = tComp->parent->roomp;
+        }
+      }
+    }
+  }
+
+  // Send merge message to room
+  if (rp) {
+    sstring str = sstring(shortDescr);
+    sendrpf(COLOR_BASIC, rp, "%s combines with %s.\n\r",
+      str.cap().c_str(), str.c_str());
+  }
+
+  // Merge charges and cost
+  addToTrapComponentCharges(tComp->getTrapComponentCharges());
+  obj_flags.cost += tComp->obj_flags.cost;
+
+  // Remove and delete the merged component
+  --(*tComp);
+  delete tComp;
+}
+
+void TTrapComponent::assignFourValues(int x1, int x2, int x3, int x4) {
+  setTrapComponentCharges(x1);
+  setTrapComponentType(x4);
+}
+
+void TTrapComponent::getFourValues(int* x1, int* x2, int* x3, int* x4) const {
+  *x1 = getTrapComponentCharges();
+  *x2 = 0;
+  *x3 = 0;
+  *x4 = getTrapComponentType();
+}
+
+sstring TTrapComponent::statObjInfo() const {
+  return format("Charges: %d, Type: %d") % getTrapComponentCharges() % getTrapComponentType();
+}
+
+sstring TTrapComponent::getNameForShow(bool useColor, bool useName, const TBeing* ch) const {
+  sstring buf = TMergeable::getNameForShow(useColor, useName, ch);
+  
+  if (getTrapComponentCharges() != 1) {
+    buf += format(" (%d uses)") % getTrapComponentCharges();
+  }
+  
+  return buf;
+}
+
+void TTrapComponent::describeObjectSpecifics(const TBeing* ch) const {
+  ch->sendTo(COLOR_OBJECTS, format("%s has about %d uses left.\n\r") %
+                              sstring(getName()).cap() % getTrapComponentCharges());
+}
+
+int TTrapComponent::getTrapComponentCharges() const {
+  return charges;
+}
+
+void TTrapComponent::setTrapComponentCharges(int n) {
+  charges = max(0, n);
+}
+
+void TTrapComponent::addToTrapComponentCharges(int n) {
+  charges = max(0, charges + n);
+}
+
+int TTrapComponent::getTrapComponentType() const {
+  return trap_comp_type;
+}
+
+void TTrapComponent::setTrapComponentType(int n) {
+  trap_comp_type = n;
+}
+
+void TTrapComponent::addTrapComponentType(int n) {
+  trap_comp_type |= n;
+}
+
+void TTrapComponent::remTrapComponentType(int n) {
+  trap_comp_type &= ~n;
+}
+
+bool TTrapComponent::isTrapComponentType(int n) const {
+  return IS_SET(trap_comp_type, n);
+}
+
+bool TTrapComponent::objectRepair(TBeing* ch, TMonster* repair, silentTypeT silent) {
+  if (!silent) {
+    repair->doTell(fname(ch->getName()),
+      "I don't repair trap components. Try a tinker or alchemist!");
+  }
+  return true;
+}
+
+void TTrapComponent::lowCheck() {
+  if (!isname("component", name)) {
+    vlogf(LOG_LOW, format("Trap component without COMPONENT in name (%s : %d)") %
+                     getName() % objVnum());
+  }
+  
+  int sp = suggestedPrice();
+  if ((obj_flags.cost != sp) && sp > 0) {
+    vlogf(LOG_LOW, format("trap component (%s:%d) with bad price %d should be %d.") %
+                     getName() % objVnum() % obj_flags.cost % sp);
+    obj_flags.cost = sp;
+  }
+
+  TMergeable::lowCheck();
+}
+
+int TTrapComponent::suggestedPrice() const {
+  // Base price calculation: charges * base_cost_per_charge
+  int base_price = getTrapComponentCharges() * 10; // 10 talens per charge base
+
+  // TODO: Add material pricing adjustment once material_nums issue is resolved
+  // base_price = (int)(base_price * material_nums[getMaterial()].price);
+
+  return max(1, base_price);
+}
+
+void TTrapComponent::purchaseMe(TBeing* ch, TMonster* keeper, int cost, int shop_nr) {
+  TShopOwned tso(shop_nr, keeper, ch);
+  tso.doBuyTransaction(cost, getName(), TX_BUYING, this);
+}
+
+void TTrapComponent::sellMeMoney(TBeing* ch, TMonster* keeper, int cost, int shop_nr) {
+  TShopOwned tso(shop_nr, keeper, ch);
+  tso.doSellTransaction(cost, getName(), TX_SELLING);
+}
+
+double TTrapComponent::priceMultiplier() const {
+  // Trap components are moderately valuable
+  return 2.0;
+}
+
+int TTrapComponent::pricePerUnit() const {
+  if (getTrapComponentCharges() <= 0)
+    return 0;
+  return obj_flags.cost / getTrapComponentCharges();
+}
+
+void TTrapComponent::boottimeInit() {
+  // Nothing special needed at boottime
+}
+
+void TTrapComponent::update(int use) {
+  // Trap components don't decay over time like spell components
+  for (StuffIter it = stuff.begin(); it != stuff.end(); ++it)
+    (*it)->update(use);
+}
+
+void TTrapComponent::decayMe() {
+  // Trap components are stable and don't decay
+}
+
+TThing& TTrapComponent::operator--() {
+  TMergeable::operator--();
+  return *this;
+}
+
+void TTrapComponent::evaluateMe(TBeing* ch) const {
+  ch->sendTo(format("You estimate that %s has about %d uses remaining.\n\r") %
+             getName() % getTrapComponentCharges());
+}
+
+void TTrapComponent::changeObjValue4(TBeing* ch) {
+  ch->sendTo("Trap component type flags:\n\r");
+  ch->sendTo("This is for advanced builders only.\n\r");
+}
+
+void TTrapComponent::objMenu(const TBeing* ch) const {
+  ch->sendTo("Trap component menu options:\n\r");
+  ch->sendTo("  split <component> <charges> - Split charges into new component\n\r");
+}
+
+bool TTrapComponent::sellMeCheck(TBeing* ch, TMonster* keeper, int, int) const {
+  if (getTrapComponentCharges() <= 0) {
+    keeper->doTell(ch->getName(), "I don't buy empty trap components.");
+    return true;
+  }
+  return false;
+}
+
+bool TTrapComponent::splitMe(TBeing* ch, const sstring& tString) {
+  int tCount = 0;
+  TTrapComponent* tComponent;
+  sstring tStString(""), tStBuffer("");
+
+  tStString = tString.word(0);
+  tStBuffer = tString.word(1);
+
+  if (tString.empty() || ((tCount = convertTo<int>(tStBuffer)) <= 0)) {
+    ch->sendTo("Syntax: split <component> <charges>\n\r");
+    return true;
+  }
+
+  if (tCount >= getTrapComponentCharges()) {
+    ch->sendTo(format("Charges must be between 1 and %d.\n\r") %
+               (getTrapComponentCharges() - 1));
+    return true;
+  }
+
+  if (!obj_flags.cost || objVnum() < 0) {
+    ch->sendTo("This component is special, it can not be split up.\n\r");
+    return true;
+  }
+
+  // Create new component with split charges
+  tComponent = dynamic_cast<TTrapComponent*>(read_object(objVnum(), VIRTUAL));
+  if (!tComponent) {
+    ch->sendTo("Unable to create split component.\n\r");
+    return true;
+  }
+
+  // Set up the split component
+  tComponent->setTrapComponentCharges(tCount);
+  tComponent->obj_flags.cost = (obj_flags.cost * tCount) / getTrapComponentCharges();
+
+  // Reduce this component's charges and cost
+  addToTrapComponentCharges(-tCount);
+  obj_flags.cost -= tComponent->obj_flags.cost;
+
+  // Give the split component to the player
+  *ch += *tComponent;
+
+  ch->sendTo(format("You split off %d charges into a new component.\n\r") % tCount);
+  return true;
+}
+
+int TTrapComponent::trapComponentSell(TBeing* ch, TMonster* keeper, int shop_nr, TThing* sub) {
+  return sellMe(ch, keeper, shop_nr);
+}
+
+int TTrapComponent::trapComponentNumSell(TBeing* ch, TMonster* keeper, int shop_nr, TThing* sub, int num) {
+  return sellMe(ch, keeper, shop_nr, num);
+}
+
+int TTrapComponent::trapComponentValue(TBeing* ch, TMonster* keeper, int shop_nr, TThing* sub) {
+  valueMe(ch, keeper, shop_nr);
+  return FALSE;
+}
+
+int TTrapComponent::trapComponentNumValue(TBeing* ch, TMonster* keeper, int shop_nr, TThing* sub, int num) {
+  valueMe(ch, keeper, shop_nr, num);
+  return FALSE;
+}
+
+int TTrapComponent::sellMe(TBeing* ch, TMonster* tKeeper, int tShop, int num) {
+  if (sellMeCheck(ch, tKeeper, tShop, num))
+    return -1;
+
+  num = max(0, min(num, getTrapComponentCharges()));
+  if (num <= 0)
+    return -1;
+
+  int cost = sellPrice(num, tShop, 1.0, ch);
+  sellMeMoney(ch, tKeeper, cost, tShop);
+
+  if (num >= getTrapComponentCharges()) {
+    // Selling all charges, delete the component
+    --(*this);
+    delete this;
+  } else {
+    // Selling partial charges
+    addToTrapComponentCharges(-num);
+    obj_flags.cost = (obj_flags.cost * getTrapComponentCharges()) / (getTrapComponentCharges() + num);
+  }
+
+  return cost;
+}
+
+int TTrapComponent::buyMe(TBeing* ch, TMonster* tKeeper, int tNum, int tShop) {
+  if ((ch->getCarriedVolume() + getTotalVolume()) > ch->carryVolumeLimit()) {
+    ch->sendTo(format("%s: You can not carry that much volume.\n\r") % fname(name));
+    return -1;
+  }
+
+  if (compareWeights(getTotalWeight(TRUE),
+        (ch->carryWeightLimit() - ch->getCarriedWeight())) == -1) {
+    ch->sendTo(format("%s: You can not carry that much weight.\n\r") % fname(name));
+    return -1;
+  }
+
+  int charges = getTrapComponentCharges();
+  if (tNum > charges) {
+    tKeeper->doTell(ch->getName(),
+      format("I don't have %d charges of %s.  Here %s the %d I do have.") %
+        tNum % getName() % ((charges > 2) ? "are" : "is") % charges);
+    tNum = charges;
+  }
+
+  int tCost = shopPrice(tNum, tShop, 1.0, ch);
+
+  TObj* tObj;
+  if (charges == tNum) {
+    // Buying all charges — hand over the whole object
+    tObj = this;
+    --(*tObj);
+  } else {
+    // Partial purchase — split off a new object with requested charges
+    tObj = read_object(objVnum(), VIRTUAL);
+    if (!tObj)
+      return -1;
+
+    if (auto* splitComp = dynamic_cast<TTrapComponent*>(tObj)) {
+      int cost_per = pricePerUnit();
+      splitComp->setTrapComponentCharges(tNum);
+      addToTrapComponentCharges(-tNum);
+
+      splitComp->obj_flags.cost = tNum * cost_per;
+      obj_flags.cost = getTrapComponentCharges() * cost_per;
+    }
+  }
+
+  tObj->purchaseMe(ch, tKeeper, tCost, tShop);
+  *ch += *tObj;
+
+  return tCost;
+}
+
+void TTrapComponent::valueMe(TBeing* ch, TMonster* keeper, int shop_nr, int num) {
+  int cost = sellPrice(num, shop_nr, 1.0, ch);
+  ch->sendTo(format("%s will pay you %d talens for %d charges of %s.\n\r") %
+             keeper->getName() % cost % num % getName());
+}
+
+int TTrapComponent::shopPrice(int num, int shop_nr, float, const TBeing*) const {
+  if (getTrapComponentCharges() <= 0) {
+    vlogf(LOG_BUG, format("TTrapComponent::shopPrice called with 0 charges (%s:%d)") %
+                     getName() % objVnum());
+    return 0;
+  }
+  return (obj_flags.cost * num) / getTrapComponentCharges();
+}
+
+int TTrapComponent::sellPrice(int num, int shop_nr, float, const TBeing*) {
+  if (getTrapComponentCharges() <= 0) {
+    vlogf(LOG_BUG, format("TTrapComponent::sellPrice called with 0 charges (%s:%d)") %
+                     getName() % objVnum());
+    return 0;
+  }
+  int base_price = (obj_flags.cost * num) / getTrapComponentCharges();
+  return static_cast<int>(base_price * 0.5);
+}

--- a/code/code/obj/obj_trap_component.h
+++ b/code/code/obj/obj_trap_component.h
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////////////////////
+//
+// SneezyMUD - All rights reserved, SneezyMUD Coding Team
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "obj_mergeable.h"
+
+class TTrapComponent : public TMergeable {
+  private:
+    int charges;
+    int trap_comp_type;  // which trap types this component can be used for
+
+  public:
+    virtual void assignFourValues(int, int, int, int);
+    virtual void getFourValues(int*, int*, int*, int*) const;
+    virtual itemTypeT itemType() const { return ITEM_TRAP_COMPONENT; }
+    virtual sstring statObjInfo() const;
+    virtual sstring getNameForShow(bool, bool, const TBeing*) const;
+    virtual void purchaseMe(TBeing*, TMonster*, int, int);
+    virtual void sellMeMoney(TBeing*, TMonster*, int, int);
+    virtual bool objectRepair(TBeing*, TMonster*, silentTypeT);
+    virtual void lowCheck();
+    virtual void evaluateMe(TBeing*) const;
+    virtual void changeObjValue4(TBeing*);
+    virtual void boottimeInit();
+    virtual void update(int);
+    virtual void describeObjectSpecifics(const TBeing*) const;
+    virtual void decayMe();
+    virtual bool sellMeCheck(TBeing*, TMonster*, int, int) const;
+    virtual int trapComponentSell(TBeing*, TMonster*, int, TThing*);
+    virtual int trapComponentNumSell(TBeing*, TMonster*, int, TThing*, int);
+    virtual int trapComponentValue(TBeing*, TMonster*, int, TThing*);
+    virtual int trapComponentNumValue(TBeing*, TMonster*, int, TThing*, int);
+    virtual bool splitMe(TBeing*, const sstring&);
+    virtual int suggestedPrice() const;
+    virtual void objMenu(const TBeing*) const;
+    double priceMultiplier() const;
+    virtual int sellMe(TBeing* ch, TMonster* tKeeper, int tShop, int num = 1);
+    virtual int buyMe(TBeing*, TMonster*, int, int);
+    virtual void valueMe(TBeing* ch, TMonster* keeper, int shop_nr, int num = 1);
+    virtual int shopPrice(int, int, float, const TBeing*) const;
+    virtual int sellPrice(int, int, float, const TBeing*);
+
+    virtual bool willMerge(TMergeable*);
+    virtual void doMerge(TMergeable*);
+
+    int getTrapComponentCharges() const;
+    void setTrapComponentCharges(int n);
+    void addToTrapComponentCharges(int n);
+    int getTrapComponentType() const;
+    void setTrapComponentType(int n);
+    void addTrapComponentType(int n);
+    void remTrapComponentType(int n);
+    bool isTrapComponentType(int n) const;
+    int pricePerUnit() const;
+
+    virtual TThingKind getKind() const;
+    TTrapComponent();
+    TTrapComponent(const TTrapComponent& a);
+    TTrapComponent& operator=(const TTrapComponent& a);
+    virtual ~TTrapComponent();
+    virtual TThing& operator--();
+};

--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -19,6 +19,7 @@
 #include "mail.h"
 #include "spec_mobs.h"
 #include "obj_component.h"
+#include "obj_trap_component.h"
 #include "extern.h"
 #include "loadset.h"
 #include "sys_loot.h"
@@ -3900,6 +3901,8 @@ TObj* makeNewObj(itemTypeT tmp) {
       return new TKeyring();
     case ITEM_COMPONENT:
       return new TComponent();
+    case ITEM_TRAP_COMPONENT:
+      return new TTrapComponent();
     case ITEM_BOOK:
       return new TBook();
     case ITEM_PORTAL:

--- a/code/code/task/task_trap.cc
+++ b/code/code/task/task_trap.cc
@@ -111,19 +111,19 @@ int task_trap_door(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
 
       switch (ch->task->timeLeft) {
         case 3:
-          ch->sendTrapMessage(buf2, TRAP_TARG_DOOR, 1);
+          sendTrapMessage(ch, buf2, TRAP_TARG_DOOR, 1);
           ch->task->timeLeft--;
           break;
         case 2:
-          ch->sendTrapMessage(buf2, TRAP_TARG_DOOR, 2);
+          sendTrapMessage(ch, buf2, TRAP_TARG_DOOR, 2);
           ch->task->timeLeft--;
           break;
         case 1:
-          ch->sendTrapMessage(buf2, TRAP_TARG_DOOR, 3);
+          sendTrapMessage(ch, buf2, TRAP_TARG_DOOR, 3);
           ch->task->timeLeft--;
           break;
         case 0:
-          ch->sendTrapMessage(buf2, TRAP_TARG_DOOR, 4);
+          sendTrapMessage(ch, buf2, TRAP_TARG_DOOR, 4);
           ch->task->timeLeft--;
           break;
       }
@@ -215,19 +215,19 @@ int task_trap_container(TBeing* ch, cmdTypeT cmd, const char*, int pulse,
 
       switch (ch->task->timeLeft) {
         case 3:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 1);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_CONT, 1);
           ch->task->timeLeft--;
           break;
         case 2:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 2);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_CONT, 2);
           ch->task->timeLeft--;
           break;
         case 1:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 3);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_CONT, 3);
           ch->task->timeLeft--;
           break;
         case 0:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 4);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_CONT, 4);
           ch->task->timeLeft--;
           break;
       }
@@ -349,19 +349,19 @@ int task_trap_mine(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
 
       switch (ch->task->timeLeft) {
         case 3:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_MINE, 1);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_MINE, 1);
           ch->task->timeLeft--;
           break;
         case 2:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_MINE, 2);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_MINE, 2);
           ch->task->timeLeft--;
           break;
         case 1:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_MINE, 3);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_MINE, 3);
           ch->task->timeLeft--;
           break;
         case 0:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_MINE, 4);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_MINE, 4);
           ch->task->timeLeft--;
           break;
       }
@@ -407,7 +407,7 @@ int task_trap_arrow(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
   TArrow* arrow;
 
   if (ch->isLinkdead() || (ch->in_room != ch->task->wasInRoom) ||
-      !ch->hasTrapComps(ch->task->orig_arg, TRAP_TARG_CONT, 0) ||
+      !ch->hasTrapComps(ch->task->orig_arg, TRAP_TARG_ARROW, 0) ||
       (ch->getPosition() <= POSITION_SITTING) ||
       !ch->getDiscipline(DISC_LOOTING)) {
     if (ch->getPosition() >= POSITION_RESTING) {
@@ -439,7 +439,7 @@ int task_trap_arrow(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
 
     ch->sendTo("You have successfully constructed an arrow trap!\n\r");
     int price;
-    ch->hasTrapComps(ch->task->orig_arg, TRAP_TARG_CONT, -1, &price);
+    ch->hasTrapComps(ch->task->orig_arg, TRAP_TARG_ARROW, -1, &price);
 
     // set price on the trap to that of the components
     arrow->obj_flags.cost = price;
@@ -457,19 +457,19 @@ int task_trap_arrow(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
 
       switch (ch->task->timeLeft) {
         case 3:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 1);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_ARROW, 1);
           ch->task->timeLeft--;
           break;
         case 2:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 2);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_ARROW, 2);
           ch->task->timeLeft--;
           break;
         case 1:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 3);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_ARROW, 3);
           ch->task->timeLeft--;
           break;
         case 0:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_CONT, 4);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_ARROW, 4);
           ch->task->timeLeft--;
           break;
       }
@@ -582,19 +582,19 @@ int task_trap_grenade(TBeing* ch, cmdTypeT cmd, const char*, int pulse, TRoom*,
 
       switch (ch->task->timeLeft) {
         case 3:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_GRENADE, 1);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_GRENADE, 1);
           ch->task->timeLeft--;
           break;
         case 2:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_GRENADE, 2);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_GRENADE, 2);
           ch->task->timeLeft--;
           break;
         case 1:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_GRENADE, 3);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_GRENADE, 3);
           ch->task->timeLeft--;
           break;
         case 0:
-          ch->sendTrapMessage(ch->task->orig_arg, TRAP_TARG_GRENADE, 4);
+          sendTrapMessage(ch, ch->task->orig_arg, TRAP_TARG_GRENADE, 4);
           ch->task->timeLeft--;
           break;
       }

--- a/docs/superpowers/plans/2026-04-02-trap-damage-centralization.md
+++ b/docs/superpowers/plans/2026-04-02-trap-damage-centralization.md
@@ -1,0 +1,575 @@
+# Trap Damage Centralization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize duplicated room-wide and other-side-of-door trap damage iteration into a data-driven table and shared helpers, restoring lost behavioral regressions and eliminating ~15 copies of the same iteration pattern.
+
+**Architecture:** A `TrapTypeInfo` lookup table maps each `doorTrapT` to its damage type, effect messages, and engulfed function. Two helper functions (`applyRoomWideDamage`, `applyOtherSideDamage`) encapsulate the room iteration pattern. All five trigger functions use the table and helpers instead of inline iteration.
+
+**Tech Stack:** C++20, existing MUD framework (TBeing, TThing, TRoom, act(), objDamage(), DELETE flag system)
+
+**Spec:** `docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md`
+
+---
+
+### Task 1: Fix sendTo newline issue in message constants
+
+The source message constants used with `sendTo(format(...))` are missing `\n\r`. `sendTo` does not auto-append newlines. This affects ~48 call sites.
+
+**Files:**
+- Modify: `code/code/misc/trap.cc:58-67` (message constants)
+
+- [ ] **Step 1: Add `\n\r` to all source message constants**
+
+In the anonymous namespace at the top of `trap.cc`, update these constants:
+
+```cpp
+  // Standardized trap source messages - WHERE the trap comes from
+  constexpr const char* DOOR_TRAP_CHAR_MSG = "A mechanism in the %s triggers!\n\r";
+  constexpr const char* DOOR_TRAP_ROOM_MSG = "A mechanism in the %s triggers!";
+  constexpr const char* PORTAL_TRAP_CHAR_MSG = "A mechanism in the %s triggers!\n\r";
+  constexpr const char* PORTAL_TRAP_ROOM_MSG = "A mechanism in the %s triggers!";
+  constexpr const char* CONTAINER_TRAP_CHAR_MSG = "The %s springs a trap!\n\r";
+  constexpr const char* CONTAINER_TRAP_ROOM_MSG = "The %s springs a trap!";
+  constexpr const char* MINE_TRAP_CHAR_MSG = "The %s detonates!\n\r";
+  constexpr const char* MINE_TRAP_ROOM_MSG = "The %s detonates!";
+  constexpr const char* ARROW_TRAP_CHAR_MSG = "The %s releases its trapped payload!\n\r";
+  constexpr const char* ARROW_TRAP_ROOM_MSG = "The %s releases its trapped payload!";
+```
+
+Only the `*_CHAR_MSG` variants need `\n\r` — they're used with `sendTo()`. The `*_ROOM_MSG` variants are used with `act()` which handles newlines.
+
+- [ ] **Step 2: Build and verify**
+
+Run: `make`
+Expected: Clean compile, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add code/code/misc/trap.cc
+git commit -m "fix: add missing newlines to trap source message constants
+
+sendTo() does not auto-append newlines like act() does. All
+CHAR_MSG constants used with sendTo(format(...)) were missing
+the trailing newline, producing garbled single-line output."
+```
+
+---
+
+### Task 2: Add TrapTypeInfo table and applyRoomWideDamage helper
+
+**Files:**
+- Modify: `code/code/misc/trap.cc:29-97` (anonymous namespace, add after existing constants)
+
+- [ ] **Step 1: Add the TrapTypeInfo struct and lookup table**
+
+Add inside the existing anonymous namespace in `trap.cc`, after the message constants (after line ~97):
+
+```cpp
+  // Maps each doorTrapT to its intrinsic properties.
+  // Status-only types (poison, sleep, disease, teleport) have damageType = 0
+  // since they use dedicated functions with varied return semantics.
+  struct TrapTypeInfo {
+    int damageType;
+    const char* charMsg;
+    const char* roomMsg;
+    int (TBeing::*engulfedFn)();
+  };
+
+  constexpr std::array<TrapTypeInfo, MAX_TRAP_TYPES> trapTypeInfo = {{
+    // DOOR_TRAP_NONE
+    {0, nullptr, nullptr, nullptr},
+    // DOOR_TRAP_POISON (status-only)
+    {0, POISON_EFFECT_CHAR_MSG, POISON_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_SPIKE
+    {DAMAGE_TRAP_PIERCE, SPIKE_EFFECT_CHAR_MSG, SPIKE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_SLEEP (status-only)
+    {0, SLEEP_EFFECT_CHAR_MSG, SLEEP_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_TNT
+    {DAMAGE_TRAP_TNT, TNT_EFFECT_CHAR_MSG, TNT_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_BLADE
+    {DAMAGE_TRAP_SLASH, BLADE_EFFECT_CHAR_MSG, BLADE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_FIRE
+    {DAMAGE_TRAP_FIRE, FIRE_EFFECT_CHAR_MSG, FIRE_EFFECT_ROOM_MSG, &TBeing::flameEngulfed},
+    // DOOR_TRAP_ACID
+    {DAMAGE_TRAP_ACID, ACID_EFFECT_CHAR_MSG, ACID_EFFECT_ROOM_MSG, &TBeing::acidEngulfed},
+    // DOOR_TRAP_DISEASE (status-only)
+    {0, DISEASE_EFFECT_CHAR_MSG, DISEASE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_HAMMER
+    {DAMAGE_TRAP_BLUNT, BLUNT_EFFECT_CHAR_MSG, BLUNT_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_FROST
+    {DAMAGE_TRAP_FROST, FROST_EFFECT_CHAR_MSG, FROST_EFFECT_ROOM_MSG, &TBeing::frostEngulfed},
+    // DOOR_TRAP_TELEPORT (status-only)
+    {0, TELEPORT_EFFECT_CHAR_MSG, TELEPORT_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_ENERGY
+    {DAMAGE_TRAP_ENERGY, ENERGY_EFFECT_CHAR_MSG, ENERGY_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_BOLT
+    {DAMAGE_TRAP_PIERCE, SPIKE_EFFECT_CHAR_MSG, SPIKE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_DISK
+    {DAMAGE_TRAP_SLASH, BLADE_EFFECT_CHAR_MSG, BLADE_EFFECT_ROOM_MSG, nullptr},
+    // DOOR_TRAP_PEBBLE
+    {DAMAGE_TRAP_BLUNT, BLUNT_EFFECT_CHAR_MSG, BLUNT_EFFECT_ROOM_MSG, nullptr},
+  }};
+```
+
+Note: The `DAMAGE_TRAP_*` constants are negative ints defined in `damage.h` (already included via headers). The array needs `#include <array>` — check if it's already included, add if not.
+
+- [ ] **Step 2: Add the applyRoomWideDamage helper**
+
+Add after the `TrapTypeInfo` table, still in the anonymous namespace:
+
+```cpp
+  // Iterates a room's occupants and applies trap damage at a modifier.
+  // Skips triggerer and any being for which filter returns true.
+  // Handles DELETE_THIS by deleting dead bystanders inline.
+  void applyRoomWideDamage(TBeing* triggerer, TRoom* room,
+                           const TrapTypeInfo& info, int dam, double mod,
+                           TObj* trapObj,
+                           std::function<bool(TBeing*)> filter = nullptr) {
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end();) {
+      TThing* t = *(it++);
+      if (auto* tbt = dynamic_cast<TBeing*>(t)) {
+        if (tbt == triggerer)
+          continue;
+        if (filter && filter(tbt))
+          continue;
+        act(info.charMsg, false, tbt, 0, 0, TO_CHAR);
+        act(info.roomMsg, false, tbt, 0, 0, TO_ROOM);
+        int rc = tbt->objDamage(info.damageType, static_cast<int>(dam * mod), trapObj);
+        if (IS_SET_DELETE(rc, DELETE_THIS)) {
+          delete tbt;
+          tbt = nullptr;
+        }
+      }
+    }
+  }
+```
+
+Add `#include <functional>` at the top of trap.cc if not already present.
+
+- [ ] **Step 3: Add the applyOtherSideDamage helper**
+
+Add after `applyRoomWideDamage`, still in the anonymous namespace:
+
+```cpp
+  // Applies trap damage to beings in the room on the other side of a door.
+  // Always uses OTHER_SIDE_MOD. No filter — old code didn't check immortality
+  // on the other side.
+  void applyOtherSideDamage(TBeing* triggerer, TRoom* otherRoom,
+                            const TrapTypeInfo& info, int dam) {
+    for (StuffIter it = otherRoom->stuff.begin(); it != otherRoom->stuff.end();) {
+      TThing* t = *(it++);
+      if (auto* tbt = dynamic_cast<TBeing*>(t)) {
+        if (tbt == triggerer)
+          continue;
+        act(info.charMsg, false, tbt, 0, 0, TO_CHAR);
+        act(info.roomMsg, false, tbt, 0, 0, TO_ROOM);
+        int rc = tbt->objDamage(info.damageType, static_cast<int>(dam * OTHER_SIDE_MOD), nullptr);
+        if (IS_SET_DELETE(rc, DELETE_THIS)) {
+          delete tbt;
+          tbt = nullptr;
+        }
+      }
+    }
+  }
+
+  // Door trap types that produce area effects (room-wide + other-side).
+  constexpr bool isDoorAreaTrap(doorTrapT type) {
+    return type == DOOR_TRAP_TNT || type == DOOR_TRAP_FROST
+        || type == DOOR_TRAP_ENERGY || type == DOOR_TRAP_ACID;
+  }
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `make`
+Expected: Clean compile. The new code is not yet called — just defined.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add code/code/misc/trap.cc
+git commit -m "add TrapTypeInfo table and room-wide damage helpers
+
+Data-driven lookup table mapping doorTrapT to damage type,
+effect messages, and engulfed function. Two helper functions
+encapsulate the room-wide and other-side iteration patterns
+that were duplicated ~15 times across trigger functions."
+```
+
+---
+
+### Task 3: Refactor triggerDoorTrap to use table and helpers
+
+This is the most critical change — it restores room-wide and other-side damage for frost, energy, and acid door traps while eliminating the inline switch bloat.
+
+**Files:**
+- Modify: `code/code/misc/trap.cc:1063-1221` (`triggerDoorTrap` function)
+
+- [ ] **Step 1: Rewrite triggerDoorTrap**
+
+Replace the entire function body (lines 1063-1221) with:
+
+```cpp
+// returns DELETE_THIS or FALSE
+int TBeing::triggerDoorTrap(dirTypeT door) {
+  roomDirData *exitp, *back = nullptr;
+  TRoom* rp = nullptr;
+  int rc;
+
+  exitp = exitDir(door);
+  int dam = dice(exitp->trap_dam, TRAP_DICE_SIZE);
+
+  REMOVE_BIT(exitp->condition, EXIT_TRAPPED);
+  if ((rp = real_roomp(exitp->to_room)) &&
+      (back = rp->dir_option[rev_dir(door)])) {
+    REMOVE_BIT(back->condition, EXIT_TRAPPED);
+  }
+
+  act(STRANGE_NOISE_MSG, true, this, 0, 0, TO_ROOM);
+  act(STRANGE_NOISE_MSG, true, this, 0, 0, TO_CHAR);
+
+  const auto trapType = static_cast<doorTrapT>(exitp->trap_info);
+  const auto& info = trapTypeInfo[trapType];
+
+  // Source message — where the trap is
+  sendTo(format(DOOR_TRAP_CHAR_MSG) % fname(exitp->keyword));
+  act(format(DOOR_TRAP_ROOM_MSG) % fname(exitp->keyword), false, this, 0, 0, TO_ROOM);
+
+  // Status-only types: dispatch to dedicated functions
+  switch (trapType) {
+    case DOOR_TRAP_POISON:
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+      trapPoison(dam);
+      return false;
+    case DOOR_TRAP_SLEEP:
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+      rc = trapSleep(dam);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      return false;
+    case DOOR_TRAP_DISEASE:
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+      trapDisease(dam);
+      return false;
+    case DOOR_TRAP_TELEPORT:
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+      rc = trapTeleport(dam);
+      if (IS_SET_DELETE(rc, DELETE_THIS))
+        return DELETE_THIS;
+      return rc;
+    default:
+      break;
+  }
+
+  // Damage types: use table-driven path
+
+  // TNT special: destroy the door
+  if (trapType == DOOR_TRAP_TNT)
+    exitp->destroyDoor(door, in_room);
+
+  // Room-wide damage for area trap types
+  if (isDoorAreaTrap(trapType)) {
+    // Frost and energy skip immortals in the same room; TNT and acid do not
+    std::function<bool(TBeing*)> filter = nullptr;
+    if (trapType == DOOR_TRAP_FROST || trapType == DOOR_TRAP_ENERGY)
+      filter = [](TBeing* b) { return b->isImmortal(); };
+
+    applyRoomWideDamage(this, roomp, info, dam, ROOM_MOD, nullptr, filter);
+
+    // Other-side-of-door damage
+    if (rp)
+      applyOtherSideDamage(this, rp, info, dam);
+  }
+
+  // Effect messages and direct damage to triggerer
+  act(info.charMsg, false, this, 0, 0, TO_CHAR);
+  act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+  rc = objDamage(info.damageType, dam, nullptr);
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    return DELETE_THIS;
+
+  // Engulfed effect (fire, frost, acid)
+  if (info.engulfedFn) {
+    rc = (this->*(info.engulfedFn))();
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      return DELETE_THIS;
+  }
+
+  return false;
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `make`
+Expected: Clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add code/code/misc/trap.cc
+git commit -m "refactor triggerDoorTrap to use TrapTypeInfo table and helpers
+
+Restores room-wide damage for frost/energy/acid door traps and
+other-side-of-door damage for TNT/frost/energy/acid. Replaces
+~160 lines of switch cases with table-driven dispatch."
+```
+
+---
+
+### Task 4: Refactor triggerTrap (mines) to use table and helpers
+
+The mine trigger function has the most room-wide iteration copies. The damage-type cases can use `applyRoomWideDamage`. The status-effect cases already use the template helpers (`applySimpleRoomEffect`/`applyComplexRoomEffect`) and stay as-is.
+
+**Files:**
+- Modify: `code/code/misc/trap.cc` — the `triggerTrap` function (the large TTrap trigger, not `springTrap`)
+
+- [ ] **Step 1: Identify the damage-type mine cases that have room-wide iteration**
+
+These cases in `triggerTrap` have inline room-wide iteration loops that should use `applyRoomWideDamage`: FIRE, BOLT, PEBBLE, DISK, TNT, FROST, ENERGY, ACID. Each has the pattern:
+
+```cpp
+if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
+  for (StuffIter it = roomp->stuff.begin(); ...) {
+    // ... iterate, damage, delete dead
+  }
+}
+```
+
+Replace each with:
+
+```cpp
+if (o->isTrapEffectType(TRAP_EFF_ROOM)) {
+  const auto& info = trapTypeInfo[trapType];
+  applyRoomWideDamage(this, roomp, info, o->getTrapDamAmount(), ROOM_MOD, o,
+                      [](TBeing* b) { return !b->desc; });
+}
+```
+
+The `[](TBeing* b) { return !b->desc; }` filter preserves the old behavior of only affecting players (beings with descriptors).
+
+- [ ] **Step 2: Fix the mine frost message**
+
+The FROST case at line ~1596 still uses old-style messages. Update to standardized constants:
+
+```cpp
+    case DOOR_TRAP_FROST:
+      sendTo(format(MINE_TRAP_CHAR_MSG) % fname(o->getName()));
+      act(format(MINE_TRAP_ROOM_MSG) % fname(o->getName()), false, this, 0, 0, TO_ROOM);
+```
+
+- [ ] **Step 3: Use trapTypeInfo for effect messages in all mine damage cases**
+
+For each damage-type case, replace hardcoded effect message constants with table lookups:
+
+```cpp
+      const auto& info = trapTypeInfo[static_cast<doorTrapT>(o->getTrapDamType())];
+      act(info.charMsg, false, this, 0, 0, TO_CHAR);
+      act(info.roomMsg, false, this, 0, 0, TO_ROOM);
+```
+
+This ensures consistency between the messages sent to bystanders (via `applyRoomWideDamage`) and the triggerer.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `make`
+Expected: Clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add code/code/misc/trap.cc
+git commit -m "refactor triggerTrap (mines) to use applyRoomWideDamage helper
+
+Replaces 8 inline room-wide iteration loops with helper calls.
+Fixes mine frost trap using old-style messages instead of
+standardized constants."
+```
+
+---
+
+### Task 5: Refactor triggerContTrap, triggerArrowTrap, triggerPortalTrap
+
+These three functions only have room-wide iteration for TNT. Replace those inline loops with `applyRoomWideDamage` calls and use the table for effect messages where possible.
+
+**Files:**
+- Modify: `code/code/misc/trap.cc` — three trigger functions
+
+- [ ] **Step 1: Refactor triggerContTrap TNT case**
+
+Replace the room-wide loop in the TNT case (~lines 810-822) with:
+
+```cpp
+      // fry people in room
+      applyRoomWideDamage(this, roomp, trapTypeInfo[DOOR_TRAP_TNT],
+                          amnt, ROOM_MOD, obj);
+```
+
+- [ ] **Step 2: Refactor triggerArrowTrap TNT case**
+
+Replace the room-wide loop in the TNT case (~lines 995-1007) with:
+
+```cpp
+      applyRoomWideDamage(this, roomp, trapTypeInfo[DOOR_TRAP_TNT],
+                          amnt, ROOM_MOD, obj,
+                          [](TBeing* b) { return b->isImmortal(); });
+```
+
+Note: arrow TNT filtered immortals in the old code, unlike container TNT.
+
+- [ ] **Step 3: Refactor triggerPortalTrap TNT case**
+
+Replace the room-wide loop in the portal TNT case (~lines 685-705) with:
+
+```cpp
+      applyRoomWideDamage(this, roomp, trapTypeInfo[DOOR_TRAP_TNT],
+                          amnt, ROOM_MOD, o,
+                          [](TBeing* b) { return b->isImmortal(); });
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `make`
+Expected: Clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add code/code/misc/trap.cc
+git commit -m "refactor container/arrow/portal TNT traps to use applyRoomWideDamage
+
+Replaces 3 more inline room-wide iteration loops with the
+shared helper function."
+```
+
+---
+
+### Task 6: Consolidate damage modifiers and delete dead code
+
+**Files:**
+- Modify: `code/code/misc/trap.cc:2925-2943` (rename function), `code/code/misc/trap.cc:3019-3064` (grenade inline switch), `code/code/misc/trap.cc:3076-3118` (arrow inline switch)
+- Modify: `code/code/misc/trap.cc:1699-1976` (delete 8 dead functions)
+- Modify: `code/code/misc/being.h:1070-1077` (delete 8 dead declarations)
+
+- [ ] **Step 1: Rename getDoorTrapDamageModifier to getTrapDamageModifier**
+
+In `trap.cc`, rename the function at line ~2925:
+
+```cpp
+  constexpr int getTrapDamageModifier(doorTrapT trap_type) {
+```
+
+Update all three existing call sites (lines ~2987, ~2996, ~3005) from `getDoorTrapDamageModifier` to `getTrapDamageModifier`. Remove the "Same modifiers as door traps" comments since it's now obviously shared.
+
+- [ ] **Step 2: Replace grenade inline switch with getTrapDamageModifier call**
+
+In `getGrenadeTrapDam` (~line 3019-3064), replace the entire switch block with:
+
+```cpp
+  damage += getTrapDamageModifier(trap_type);
+  damage = min(max(damage, 1), 50);
+  return damage;
+```
+
+- [ ] **Step 3: Replace arrow inline switch with getTrapDamageModifier call**
+
+In `getArrowTrapDam` (~line 3076-3118), replace the entire switch block with:
+
+```cpp
+  damage += getTrapDamageModifier(trap_type);
+  damage = min(max(damage, 1), 50);
+  return damage;
+```
+
+- [ ] **Step 4: Delete the 8 dead trapDoor*Damage functions**
+
+Delete these functions from `trap.cc` (lines ~1699-1976):
+- `trapDoorTntDamage`
+- `trapDoorPierceDamage`
+- `trapDoorHammerDamage`
+- `trapDoorSlashDamage`
+- `trapDoorFrostDamage`
+- `trapDoorEnergyDamage`
+- `trapDoorFireDamage`
+- `trapDoorAcidDamage`
+
+- [ ] **Step 5: Delete the 8 dead declarations from being.h**
+
+Remove lines 1070-1077 from `being.h`:
+
+```cpp
+    int trapDoorSlashDamage(int, dirTypeT);
+    int trapDoorFireDamage(int, dirTypeT);
+    int trapDoorPierceDamage(int, dirTypeT);
+    int trapDoorTntDamage(int, dirTypeT);
+    int trapDoorAcidDamage(int, dirTypeT);
+    int trapDoorHammerDamage(int, dirTypeT);
+    int trapDoorEnergyDamage(int, dirTypeT);
+    int trapDoorFrostDamage(int, dirTypeT);
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `make`
+Expected: Clean compile, no warnings about unused functions.
+
+- [ ] **Step 7: Run tests**
+
+Run: `make test`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add code/code/misc/trap.cc code/code/misc/being.h
+git commit -m "consolidate damage modifiers and remove dead trap functions
+
+Rename getDoorTrapDamageModifier to getTrapDamageModifier and
+use it in all five get*TrapDam functions. Delete 8 dead
+trapDoor*Damage member functions whose logic is now handled
+by the table-driven helpers."
+```
+
+---
+
+### Task 7: Final review and format
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run code review agent**
+
+Dispatch the `superpowers:code-reviewer` agent against the full set of changes since the start of this implementation (before Task 1). Verify:
+- All door trap types that should have room-wide damage do
+- All door trap types that should have other-side damage do
+- DELETE flag handling is correct in the new helpers
+- No remaining dead code
+- Message constants all have proper `\n\r` where needed
+
+- [ ] **Step 2: Format changed files**
+
+```bash
+make format FILE=code/code/misc/trap.cc
+make format FILE=code/code/misc/being.h
+```
+
+- [ ] **Step 3: Final build and test**
+
+```bash
+make && make test
+```
+
+Expected: Clean compile, all tests pass.
+
+- [ ] **Step 4: Commit any formatting changes**
+
+```bash
+git add code/code/misc/trap.cc code/code/misc/being.h
+git commit -m "style: format trap centralization changes"
+```

--- a/docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md
+++ b/docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md
@@ -105,29 +105,9 @@ Append `\n\r` to all source message constants (`DOOR_TRAP_CHAR_MSG`, `PORTAL_TRA
 
 ## Consolidated Damage Modifiers
 
-The old code had identical per-type modifier switches duplicated across all five `get*TrapDam` functions. The refactor extracted `getDoorTrapDamageModifier` for door/container/mine but changed several values, while grenade/arrow kept separate inline switches with the old values. This created a divergence.
+The old code had identical per-type modifier switches duplicated across all five `get*TrapDam` functions. The refactor extracted the shared switch into `getDoorTrapDamageModifier` for door/container/mine, but grenade and arrow kept their own inline copies. The values are identical across all five — the duplication is purely mechanical.
 
-Resolution: consolidate into a single `getTrapDamageModifier` function used by all five `get*TrapDam` functions. Values are the max (higher damage) of old and new for each type:
-
-| Trap Type | Old (all) | New (door) | Consolidated |
-|-----------|-----------|------------|-------------|
-| TNT | +3 | +3 | +3 |
-| Poison | -1 | -1 | -1 |
-| Sleep | +1 | +1 | +1 |
-| Acid | +1 | +1 | +1 |
-| Disease | +3 | -1 | +3 |
-| Frost | +3 | 0 | +3 |
-| Fire | 0 | +1 | +1 |
-| Hammer | -10 | +2 | +2 |
-| Blade | -3 | +1 | +1 |
-| Spike | -5 | 0 | 0 |
-| Teleport | +5 | 0 | +5 |
-| Energy | +5 | +1 | +5 |
-| Bolt | +1 | 0 | +1 |
-| Disk | +3 | 0 | +3 |
-| Pebble | -5 | 0 | 0 |
-
-The grenade and arrow functions drop their inline switches and call `getTrapDamageModifier` like the others.
+Consolidation: rename `getDoorTrapDamageModifier` → `getTrapDamageModifier`, then replace the grenade and arrow inline switches with calls to the shared function. No value changes needed — all five already match.
 
 ## Additional Fixes
 

--- a/docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md
+++ b/docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md
@@ -1,0 +1,110 @@
+# Trap Damage Centralization
+
+Centralizes the duplicated room-wide and other-side-of-door trap damage iteration into a data-driven table + shared helper functions. Fixes critical behavioral regressions where the refactor accidentally dropped room-wide and other-side damage for several door trap types, and fixes missing `\n\r` on `sendTo` calls.
+
+## Context
+
+The trap system refactor on the `trapRefactor` branch consolidated trap messaging and reduced ~750 lines, but introduced two critical regressions:
+
+1. Door traps for frost, energy, and acid lost room-wide area damage (50% modifier to bystanders).
+2. Door traps for TNT, frost, energy, and acid lost other-side-of-door damage (33% modifier through the door).
+
+The old behavior lived in eight `trapDoor*Damage` member functions that are now dead code. The room-wide iteration pattern (iterate `roomp->stuff`, skip self, apply damage at a multiplier, handle DELETE_THIS cleanup) is copy-pasted ~15 times across the five trigger functions (`triggerDoorTrap`, `triggerTrap`, `triggerContTrap`, `triggerArrowTrap`, `triggerPortalTrap`).
+
+## Design
+
+### TrapTypeInfo Table
+
+A `constexpr std::array<TrapTypeInfo, MAX_TRAP_TYPES>` indexed by `doorTrapT` captures the intrinsic properties of each trap type — things that should never vary between trigger contexts:
+
+```cpp
+struct TrapTypeInfo {
+  int damageType;               // DAMAGE_TRAP_FIRE, etc. 0 for status-only types
+  const char* charMsg;          // effect message to triggerer (TO_CHAR)
+  const char* roomMsg;          // effect message to room (TO_ROOM)
+  int (TBeing::*engulfedFn)();  // flameEngulfed/frostEngulfed/acidEngulfed, or nullptr
+};
+```
+
+Design choices:
+- Status-only types (poison, sleep, disease, teleport) have `damageType = 0`. They're dispatched through their dedicated functions (`trapPoison`, `trapSleep`, etc.) which have varied return types and semantics that don't fit a generic table-driven path.
+- Engulfed functions are member function pointers. Only fire, frost, and acid have them.
+- Messages are the already-existing `*_EFFECT_CHAR_MSG`/`*_EFFECT_ROOM_MSG` constants wired to their trap type.
+- DOOR_TRAP_BOLT/DISK/PEBBLE map to existing damage types (pierce/slash/blunt).
+- DOOR_TRAP_NONE gets a zero-initialized entry.
+
+The table does NOT include room-wide flags, other-side flags, damage multipliers, or bystander filters — those are context-dependent decisions made by the trigger functions.
+
+### Helper Functions
+
+Two free functions in the `trap.cc` anonymous namespace.
+
+**`applyRoomWideDamage`** iterates a room's occupants and applies trap damage at a modifier:
+
+```cpp
+void applyRoomWideDamage(TBeing* triggerer, TRoom* room,
+                         const TrapTypeInfo& info, int dam, double mod,
+                         TObj* trapObj,
+                         std::function<bool(TBeing*)> filter = nullptr);
+```
+
+Behavior:
+1. Iterates `room->stuff` with post-increment pattern for iterator safety
+2. Skips non-TBeing and skips `triggerer`
+3. Applies optional filter predicate (returns true to skip) — handles `isImmortal()` check for door frost/energy, `!desc` check for mines
+4. Sends effect messages via `act()` using `info.charMsg`/`info.roomMsg`
+5. Calls `tbt->objDamage(info.damageType, dam * mod, trapObj)`
+6. Handles DELETE_THIS: delete + null
+
+Returns `void` because it only processes bystanders — dead bystanders are deleted inline and the triggerer is never affected.
+
+**`applyOtherSideDamage`** is door-specific, same pattern on the room through the door:
+
+```cpp
+void applyOtherSideDamage(TBeing* triggerer, TRoom* otherRoom,
+                          const TrapTypeInfo& info, int dam,
+                          TObj* trapObj = nullptr);
+```
+
+Always uses `OTHER_SIDE_MOD` (1/3). No filter predicate — the old code didn't check immortality on the other side.
+
+Status-effect mine room-wide loops (sleep, teleport, disease, poison) stay inline in `triggerTrap` since they call different functions with varied return semantics. The helpers only cover the `objDamage` path, which is ~12 of the 15 duplicated loops.
+
+### Trigger Function Changes
+
+**`triggerDoorTrap`**: Status-only cases (poison, sleep, disease, teleport) stay as short inline cases. TNT stays as a special case (calls `destroyDoor()`). All other damage cases use the table for messages/damType and call the helpers for room-wide/other-side. A local predicate determines which types produce area effects:
+
+```cpp
+constexpr bool isDoorAreaTrap(doorTrapT type) {
+    return type == DOOR_TRAP_TNT || type == DOOR_TRAP_FROST
+        || type == DOOR_TRAP_ENERGY || type == DOOR_TRAP_ACID;
+}
+```
+
+Frost and energy pass `[](TBeing* b) { return b->isImmortal(); }` as the room-wide filter, matching the old behavior where immortals were skipped in the same room but not on the other side.
+
+**`triggerTrap` (mines)**: The 12 damage-type cases collapse their inline iteration to a `TRAP_EFF_ROOM` check + `applyRoomWideDamage` call with `[](TBeing* b) { return !b->desc; }` filter. The 4 status-effect cases keep their inline loops.
+
+**`triggerContTrap`, `triggerArrowTrap`, `triggerPortalTrap`**: Only TNT has room-wide — its case calls `applyRoomWideDamage`. Other cases use `info.charMsg`/`info.roomMsg` from the table for consistency.
+
+**Dead functions**: All eight `trapDoor*Damage` member functions are deleted, along with their declarations in `being.h`.
+
+### sendTo Newline Fix
+
+Append `\n\r` to all source message constants (`DOOR_TRAP_CHAR_MSG`, `PORTAL_TRAP_CHAR_MSG`, `CONTAINER_TRAP_CHAR_MSG`, `MINE_TRAP_CHAR_MSG`, `ARROW_TRAP_CHAR_MSG`). These are used with `sendTo(format(...))` which does not auto-append newlines.
+
+## Behavioral Restoration
+
+| Door Trap Type | Room-Wide (restored) | Other-Side (restored) | Filter |
+|---|---|---|---|
+| TNT | `ROOM_MOD` (0.5) | `OTHER_SIDE_MOD` (1/3) | none |
+| Frost | `ROOM_MOD` (0.5) | `OTHER_SIDE_MOD` (1/3) | room-wide skips immortals |
+| Energy | `ROOM_MOD` (0.5) | `OTHER_SIDE_MOD` (1/3) | room-wide skips immortals |
+| Acid | `ROOM_MOD` (0.5) | `OTHER_SIDE_MOD` (1/3) | none |
+| Pierce/Blade/Hammer/Fire | none | none | n/a |
+
+## Files Changed
+
+- `code/code/misc/trap.cc` — Add TrapTypeInfo table, helper functions, refactor trigger functions, delete dead functions, fix message constants
+- `code/code/misc/trap.h` — Add TrapTypeInfo struct declaration (if needed externally, otherwise stays in anonymous namespace)
+- `code/code/misc/being.h` — Remove dead `trapDoor*Damage` declarations

--- a/docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md
+++ b/docs/superpowers/specs/2026-04-02-trap-damage-centralization-design.md
@@ -103,8 +103,38 @@ Append `\n\r` to all source message constants (`DOOR_TRAP_CHAR_MSG`, `PORTAL_TRA
 | Acid | `ROOM_MOD` (0.5) | `OTHER_SIDE_MOD` (1/3) | none |
 | Pierce/Blade/Hammer/Fire | none | none | n/a |
 
+## Consolidated Damage Modifiers
+
+The old code had identical per-type modifier switches duplicated across all five `get*TrapDam` functions. The refactor extracted `getDoorTrapDamageModifier` for door/container/mine but changed several values, while grenade/arrow kept separate inline switches with the old values. This created a divergence.
+
+Resolution: consolidate into a single `getTrapDamageModifier` function used by all five `get*TrapDam` functions. Values are the max (higher damage) of old and new for each type:
+
+| Trap Type | Old (all) | New (door) | Consolidated |
+|-----------|-----------|------------|-------------|
+| TNT | +3 | +3 | +3 |
+| Poison | -1 | -1 | -1 |
+| Sleep | +1 | +1 | +1 |
+| Acid | +1 | +1 | +1 |
+| Disease | +3 | -1 | +3 |
+| Frost | +3 | 0 | +3 |
+| Fire | 0 | +1 | +1 |
+| Hammer | -10 | +2 | +2 |
+| Blade | -3 | +1 | +1 |
+| Spike | -5 | 0 | 0 |
+| Teleport | +5 | 0 | +5 |
+| Energy | +5 | +1 | +5 |
+| Bolt | +1 | 0 | +1 |
+| Disk | +3 | 0 | +3 |
+| Pebble | -5 | 0 | 0 |
+
+The grenade and arrow functions drop their inline switches and call `getTrapDamageModifier` like the others.
+
+## Additional Fixes
+
+- **Mine frost trap message**: `triggerTrap()` FROST case still uses old-style `act("An icy cloud pours out of $p.", ...)` instead of standardized `MINE_TRAP_CHAR_MSG` + `FROST_EFFECT_CHAR_MSG`. Update to match all other mine cases.
+
 ## Files Changed
 
-- `code/code/misc/trap.cc` — Add TrapTypeInfo table, helper functions, refactor trigger functions, delete dead functions, fix message constants
+- `code/code/misc/trap.cc` — Add TrapTypeInfo table, helper functions, refactor trigger functions, delete dead functions, fix message constants, consolidate damage modifiers, fix mine frost message
 - `code/code/misc/trap.h` — Add TrapTypeInfo struct declaration (if needed externally, otherwise stays in anonymous namespace)
 - `code/code/misc/being.h` — Remove dead `trapDoor*Damage` declarations


### PR DESCRIPTION
## Summary

The trap system had ~15 copy-pasted iterations of the same room-wide damage pattern across 5 trigger functions, plus 8 nearly-identical `trapDoor*Damage` member functions on TBeing. This PR consolidates all of that into a data-driven lookup table and two shared helper functions, adds a new trap component object type with disarm-salvaging mechanics, and fixes a bug in arrow trap setup.

## What changed

### New: `TrapTypeInfo` lookup table
A `constexpr std::array` mapping each `doorTrapT` enum to its intrinsic properties:
- **Damage type** (`spellNumT`) — or `TYPE_UNDEFINED` for status-only traps
- **Effect messages** (char + room) — what the victim sees/others see
- **Engulfed function pointer** — for fire, frost, acid aftereffects

This replaces the old approach where every trigger function had its own switch statement mapping trap types to damage types and messages.

### New: `applyRoomWideDamage()` and `applyOtherSideDamage()` helpers
Two functions that encapsulate the room-occupant iteration pattern:
- Safe `*(it++)` iteration with inline DELETE_THIS handling
- Configurable damage modifier (50% for bystanders, 33% through doors)
- Optional filter lambda (e.g., skip immortals for frost/energy door traps, skip linkdead for mines)

### Refactored: All 5 trigger functions
- **`triggerDoorTrap`** — status traps dispatch to dedicated functions; damage traps use table for messages/damage type, helpers for area effects
- **`triggerTrap` (mines)** — status traps still use manual iteration (different modifier: 2/3 vs 1/2); damage traps use `applyRoomWideDamage`
- **`triggerContTrap`** — only TNT uses area damage; all types now use table for effect messages
- **`triggerArrowTrap`** — same pattern as containers
- **`triggerPortalTrap`** — same pattern as containers

### Removed: 8 `trapDoor*Damage` member functions from TBeing
`trapDoorTntDamage`, `trapDoorPierceDamage`, `trapDoorHammerDamage`, `trapDoorSlashDamage`, `trapDoorFrostDamage`, `trapDoorEnergyDamage`, `trapDoorFireDamage`, `trapDoorAcidDamage` — all replaced by the table-driven path in `triggerDoorTrap`.

### Consolidated: `getDoorTrapDamageModifier` → `getTrapDamageModifier`
The per-type damage modifier (added to base damage during trap-setting) was only used by door traps. Now all 5 `get*TrapDam()` functions use the same unified modifier, since the values are properties of the trap type, not the delivery mechanism.

### Preserved: Bolt, disk, and pebble distinct messages
These mine-only subtypes share damage types with spike, blade, and hammer but have their own entries in the table with unique effect messages ("perforated by the bolts", "slashed by the razor-disks", "hit by the fusillade") to keep them distinct for potential future trap effects.

### New: `TTrapComponent` object type
A new `TMergeable` subclass (`ITEM_TRAP_COMPONENT`, file type 77) for trap crafting materials:
- Has `charges` (1-100) and a `trap_comp_type` bitfield indicating which trap types it can be used for
- Full merge/split lifecycle for stacking in inventory and shops
- Registered in the type system (`obj.h`, `thing.h`, `db.cc`, `constants.cc`)

### New: Trap salvaging on disarm
When a thief disarms a trap and knows the matching trap-setting skill (e.g., `SKILL_SET_TRAP_MINE` for mines), they can now recover components:
- Recovery chance per component: `50 + (disarm_skill / 2)`
- Recovers up to 3 components + casing (for grenades/mines)
- Salvaged components get 1 charge and auto-merge with inventory
- Disarmed traps are now deleted from the world rather than having charges zeroed

### New: `getTrapComponents()` free function
Returns the 3 component vnums for a given trap type string and target context. Used by both the salvaging system and `sendTrapMessage()` (moved from `TBeing` member to free function).

### Bug fix: Arrow trap used wrong target type
`task_trap_arrow()` was using `TRAP_TARG_CONT` instead of `TRAP_TARG_ARROW` for component checks and progress messages, causing incorrect component validation and wrong assembly messages during arrow trap construction.

## Behavioral notes

- **Source messages** (what the trap looks like going off) are now generic per delivery context ("The \<name\> detonates!" for mines, "A mechanism in the \<door\> triggers!" for doors). The old code had unique per-type descriptions. This was a deliberate trade for uniformity and reduced code volume.
- **Door TNT other-side damage** changed from `amnt/4` to `amnt/3` (now uses the same `OTHER_SIDE_MOD` as frost/energy/acid). This is a minor buff (~33% more damage through walls for TNT specifically).
- **Immortality filter inconsistency** from the old code is preserved: frost/energy door traps skip immortals in the same room; TNT/acid do not.
- **Disarmed traps are now deleted** instead of having charges set to 0. This changes behavior for traps that had multiple charges — previously they'd remain in the world with 0 charges; now they're removed entirely.

## Test plan

- [x] Verify the project compiles cleanly (`make`)
- [x] Run unit tests (`make test`)
- [ ] Functional test: trigger each door trap type (poison, spike, sleep, TNT, fire, acid, disease, teleport, hammer, blade, energy, frost) and verify correct damage type, messages, and area effects
- [ ] Functional test: trigger mine traps with and without `TRAP_EFF_ROOM` flag — verify bystander damage uses correct modifier (2/3 for status, 1/2 for damage)
- [ ] Functional test: trigger container TNT trap — verify room-wide damage and container destruction
- [ ] Functional test: trigger arrow TNT trap — verify room-wide damage, immortal filter, and arrow destruction
- [ ] Functional test: trigger portal TNT trap — verify room-wide damage and portal destruction
- [ ] Functional test: verify trap goof (backfire) damage works for all 5 target types
- [ ] Functional test: verify bolt/disk/pebble mines show distinct messages from spike/blade/hammer
- [ ] Functional test: set traps using all `set trap` subcommands (door, container, mine, grenade, arrow) — verify component consumption and damage values
- [ ] Functional test: disarm a mine/grenade/container/door trap as a thief with the matching trap-setting skill — verify component salvaging works with correct recovery rates
- [ ] Functional test: disarm a trap without the matching trap-setting skill — verify "lack the knowledge" message
- [ ] Functional test: verify arrow trap construction uses correct components (was previously checking container components)
- [ ] Functional test: verify TTrapComponent merges correctly when multiple salvaged components stack in inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)