### PR TITLE
Skip C++ tests on exact cache hit when build directory doesn't exist

### DIFF
--- a/.github/actions/validate-pr/action.yml
+++ b/.github/actions/validate-pr/action.yml
@@ -18,7 +18,12 @@ runs:
 
     - name: Run C++ tests
       shell: bash
-      run: ctest --test-dir build/release-clang --output-on-failure
+      run: |
+        if [ -d build/release-clang ]; then
+          ctest --test-dir build/release-clang --output-on-failure
+        else
+          echo "Skipping C++ tests (no build directory; binary restored from cache)"
+        fi
 
     - name: Set up bun
       uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
validate-pr runs ctest against build/release-clang, but on an exact cache hit only code/sneezy and ccache are restored - the build directory is never created. This breaks PRs that only touch non-source files (e.g. lib/) where gameplay changes trigger validation but the source hash is unchanged.

On an exact cache hit no compiled code changed, so rerunning ctest would produce identical results to the previous CI run.