### PR TITLE
Fix getPlayerID() BUG spam on mobs

### DIFF
--- a/code/code/misc/being.cc
+++ b/code/code/misc/being.cc
@@ -558,20 +558,10 @@ charFile::charFile() :
 
 charFile::~charFile() {}
 
-// this returns the ID in the database, or creates a new one if needed
+// TMonster path: resolves through desc->original for switched/polyed
+// bodies. Returns 0 for normal mobs - callers must handle this.
 int TBeing::getPlayerID() const {
-  // Handle shapeshifted player
-  if (dynamic_cast<const TMonster*>(this) &&
-      IS_SET(specials.act, ACT_POLYSELF) && desc->original) {
-    if (desc->original->player.player_id == 0)
-      vlogf(LOG_BUG,
-        format("%s has no player ID!") % desc->original->getName());
-    return desc->original->player.player_id;
-  }
-
-  if (player.player_id == 0)
-    vlogf(LOG_BUG, format("%s has no player ID!") % getName());
-  return player.player_id;
+  return desc && desc->original ? desc->original->getPlayerID() : 0;
 }
 
 int TBeing::getAccountID() const {

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1564,7 +1564,9 @@ class TBeing : public TThing {
     virtual bool canSee(const TThing*, infraTypeT = INFRA_NO) const;
 
     // functions for protected member manipulation
-    virtual bool isPc() const { return ((specials.act & ACT_POLYSELF) != 0); }
+    virtual bool isPc() const {
+      return IS_SET(specials.act, ACT_POLYSELF) && desc && desc->original;
+    }
     void setCurLimbHealth(wearSlotT, unsigned short);
     unsigned short getCurLimbHealth(wearSlotT) const;
     void addCurLimbHealth(wearSlotT, int);

--- a/code/code/misc/person.cc
+++ b/code/code/misc/person.cc
@@ -4,6 +4,7 @@
 #include "pathfinder.h"
 #include "low.h"
 
+#include <cassert>
 #include <unordered_map>
 #include <queue>
 #include <set>
@@ -115,6 +116,14 @@ TPerson::~TPerson() {
   }
   delete d;
   d = nullptr;
+}
+
+int TPerson::getPlayerID() const {
+  // Set during character load (loadFromDb/loadFromSt), before the player
+  // enters the game. A zero here means loading failed silently, and every
+  // subsequent DB write using this ID would corrupt shared tables.
+  assert(player.player_id != 0);
+  return player.player_id;
 }
 
 std::pair<bool, int> TPerson::doPersonCommand(cmdTypeT cmd,

--- a/code/code/misc/person.h
+++ b/code/code/misc/person.h
@@ -141,6 +141,7 @@ class TPerson : public TBeing {
     virtual void doStat(const sstring& argument);
     virtual void doShow(const sstring& argument);
     virtual bool isPc() const { return TRUE; }
+    int getPlayerID() const override;
     virtual void logf(const char*, ...);
     virtual int manaGain();
     virtual int hitGain();

--- a/code/code/misc/shop.cc
+++ b/code/code/misc/shop.cc
@@ -101,7 +101,7 @@ float shopData::getProfitSell(const TObj* obj, const TBeing* ch) {
   }
 
   // check pricing for player
-  if (ch) {
+  if (ch && ch->isPc()) {
     if (auto it = sell_player_cache.find(ch->getPlayerID());
       it != sell_player_cache.end()) {
       profit = it->second;
@@ -261,7 +261,7 @@ int shopData::getMaxNum(const TBeing* ch, const TObj* o, int defaultMax) {
   if (o && buy_ratios_cache.count(o->objVnum()))
     return max_ratios_cache[o->objVnum()];
 
-  if (ch) {
+  if (ch && ch->isPc()) {
     if (auto it = max_player_cache.find(ch->getPlayerID());
       it != max_player_cache.end()) {
       return it->second;
@@ -301,7 +301,7 @@ float shopData::getProfitBuy(int vnum, sstring name, const TBeing* ch) {
     profit = profit_buy;
 
   // check for player specific modifiers
-  if (isOwned() && ch) {
+  if (isOwned() && ch && ch->isPc()) {
     if (auto it = buy_player_cache.find(ch->getPlayerID());
       it != buy_player_cache.end()) {
       profit = it->second;

--- a/code/code/misc/shopowned.cc
+++ b/code/code/misc/shopowned.cc
@@ -172,7 +172,7 @@ int getShopAccess(int shop_nr, TBeing* ch) {
   int access = 0;
   TDatabase db(DB_SNEEZY);
 
-  if (!ch)
+  if (!ch || !ch->isPc())
     return 0;
 
   db.query(

--- a/code/code/misc/talk.cc
+++ b/code/code/misc/talk.cc
@@ -972,14 +972,18 @@ int TBeing::doTell(const sstring& name, const sstring& message, bool visible) {
 
   d->output.push(cptr);
 
-  // Log tell history for player-to-player tells only
-  if (isPc() && vict->isPc()) {
+  // Log tell history for player-to-player tells only.
+  // getPlayerID() returns non-zero for TPerson, polyselfed mobs, and
+  // switched mobs (via desc->original). Plain mobs return 0.
+  {
     int fromId = getPlayerID();
     int victId = vict->getPlayerID();
 
-    queryqueue.push(format("insert into tellhistory (from_id, to_id, tell) "
-                           "values (%i, %i, '%s')") %
-                    fromId % victId % garbed.escape());
+    if (fromId > 0 && victId > 0) {
+      queryqueue.push(format("insert into tellhistory (from_id, to_id, tell) "
+                             "values (%i, %i, '%s')") %
+                      fromId % victId % garbed.escape());
+    }
   }
 
   if ((d && d->m_bIsClient) || IS_SET(d->prompt_d.type, PROMPT_CLIENT_PROMPT)) {

--- a/code/code/misc/talk.cc
+++ b/code/code/misc/talk.cc
@@ -972,24 +972,14 @@ int TBeing::doTell(const sstring& name, const sstring& message, bool visible) {
 
   d->output.push(cptr);
 
-  // For switched bodies (TMonster with desc but no ACT_POLYSELF),
-  // getPlayerID() returns 0. Resolve through desc->original instead.
-  {
+  // Log tell history for player-to-player tells only
+  if (isPc() && vict->isPc()) {
     int fromId = getPlayerID();
-    if (fromId == 0 && desc && desc->original) {
-      fromId = desc->original->getPlayerID();
-    }
-
     int victId = vict->getPlayerID();
-    if (victId == 0 && vict->desc && vict->desc->original) {
-      victId = vict->desc->original->getPlayerID();
-    }
 
-    if (fromId > 0 && victId > 0) {
-      queryqueue.push(format("insert into tellhistory (from_id, to_id, tell) "
-                             "values (%i, %i, '%s')") %
-                      fromId % victId % garbed.escape());
-    }
+    queryqueue.push(format("insert into tellhistory (from_id, to_id, tell) "
+                           "values (%i, %i, '%s')") %
+                    fromId % victId % garbed.escape());
   }
 
   if ((d && d->m_bIsClient) || IS_SET(d->prompt_d.type, PROMPT_CLIENT_PROMPT)) {

--- a/code/code/spec/spec_mobs_limbDispo.cc
+++ b/code/code/spec/spec_mobs_limbDispo.cc
@@ -207,11 +207,7 @@ int limbDispo(TBeing* ch, cmdTypeT cmd, const char* arg, TMonster* mob, TObj*) {
       int chopperId = getPlayerIdByName(chopper.c_str());
 
       // get team affiliation for cutesy message below
-      // getPlayerID handles polymorph; fall back to desc->original for switch
       int caddyId = ch->getPlayerID();
-      if (caddyId == 0 && ch->desc && ch->desc->original) {
-        caddyId = ch->desc->original->getPlayerID();
-      }
       sstring team;
       sstring caddyTeam;
       bool samaritan = false;

--- a/tests/functional/tests/tell-history.test.ts
+++ b/tests/functional/tests/tell-history.test.ts
@@ -9,7 +9,7 @@
  * in real-time during a session. So the mortal must re-login after
  * receiving tells to see them in `history` output.
  *
- * Required immortal powers: none beyond being immortal (for the tell command).
+ * Required immortal powers: POWER_SWITCH (for the switched-body test).
  * Uses an ephemeral account so tell history starts empty.
  */
 
@@ -149,6 +149,56 @@ describe("Tell History", () => {
         // Verify exactly 25 entries (the cap)
         const entries = output.match(/told you/gi) ?? [];
         expect(entries).toHaveLength(25);
+      } finally {
+        await mortal.close();
+      }
+    },
+    ACCOUNT_TEST_TIMEOUT,
+  );
+
+  it(
+    "records tell history when sender is switched into a mob",
+    async () => {
+      // Verifies that getPlayerID() resolves through desc->original for
+      // switched bodies. The immortal switches into a mob and tells the
+      // mortal; on re-login, the mortal should see the tell in history.
+
+      // Phase 1: mortal logs in, immortal switches into a mob and sends tell
+      let mortal = await MudClient.connect(config);
+      await mortal.login({
+        account,
+        character,
+        password: DEFAULT_PASSWORD,
+      });
+
+      await imm.command("switch load janitor");
+      await imm.readUntilIdle(1);
+
+      const marker = `switchtest${Date.now()}`;
+      await imm.command(`tell ${character} ${marker}`);
+      await imm.readUntilIdle(1);
+
+      await imm.command("return");
+      await imm.readUntilIdle(1);
+
+      // Drain and log out mortal
+      await mortal.readUntilIdle(1);
+      await mortal.send("rent");
+      await mortal.readUntilIdle(1);
+      await mortal.close();
+
+      // Phase 2: re-login mortal to load tell history from database
+      mortal = await MudClient.connect(config);
+      try {
+        await mortal.login({
+          account,
+          character,
+          password: DEFAULT_PASSWORD,
+        });
+
+        const output = await mortal.pagedCommand("history");
+        expect(output).toContainCaseInsensitive(marker);
+        expect(output).toContainCaseInsensitive("told you");
       } finally {
         await mortal.close();
       }


### PR DESCRIPTION
## Summary

- Split `getPlayerID()` into `TPerson` override (asserts non-zero) and `TBeing` base (returns 0 for normal mobs, resolves through `desc->original` for switched/polyed bodies)
- Add `isPc()` guards in `doTell` (tell history), shop pricing lookups, and `getShopAccess` to avoid calling `getPlayerID()` on mobs
- Tighten `TBeing::isPc()` to require `desc && desc->original` alongside `ACT_POLYSELF`
- Remove redundant `desc->original` fallback in `limbDispo` now handled by the base override

## Context

After merging fix/fix-database-design, production logs showed BUG spam like:
```
BUG: an orphaned gnome has no player ID!
```
on every shop interaction and mob death loot loading. The old `getPlayerID()` logged BUG whenever `player_id == 0`, which is normal for mobs. The refactored `doTell` in that branch also unconditionally called `getPlayerID()` on both sender and recipient before checking the return value.

Root causes:
1. `doTell` tell history called `getPlayerID()` on mob senders (shopkeeper doTell during buy/sell/list)
2. `read_object_buy_build` passes the dying mob as the buyer into shop pricing functions that call `getPlayerID()` for player-specific pricing lookups

## Test plan

- [x] Visit a shop and `list`/`buy`/`sell`/`value` - no BUG logs from shopkeeper doTell
- [x] Kill mobs that load equipment via loadset - no BUG logs from `read_object_buy_build` pricing
- [x] Verify tell history still works between two players (`tell` then check `history`)
- [x] Polymorph/switch as immortal and verify `getPlayerID()` resolves correctly