### PR TITLE
Improve hide behavior: feedback message and expanded whitelist

### DIFF
--- a/code/code/disc/disc_thief_stealth.cc
+++ b/code/code/disc/disc_thief_stealth.cc
@@ -936,7 +936,9 @@ int hide(TBeing* thief, spellNumT skill) {
 
   if (thief->bSuccess(bKnown, skill)) {
     SET_BIT(thief->specials.affectedBy, AFF_HIDE);
+    thief->sendTo("You slip into the shadows, concealed from view.\n\r");
   } else {
+    thief->sendTo("You fail to blend in with your surroundings.\n\r");
   }
   return TRUE;
 }

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -128,6 +128,14 @@ bool willBreakHide(cmdTypeT tCmd, bool isPre) {
     case CMD_ATTRIBUTE:
     case CMD_WORLD:
     case CMD_SPY:
+    case CMD_CONCEAL:
+    case CMD_REST:
+    case CMD_SIT:
+    case CMD_STAND:
+    case CMD_SIGN:
+    case CMD_PTELL:
+    case CMD_EAT:
+    case CMD_DRINK:
     case CMD_CLS:
     case CMD_PROMPT:
     case CMD_ALIAS:
@@ -353,8 +361,10 @@ int TBeing::doCommand(cmdTypeT cmd, const sstring& argument, TThing* vict,
       }
     }
 
-    if (IS_SET(specials.affectedBy, AFF_HIDE) && willBreakHide(cmd, true))
+    if (IS_SET(specials.affectedBy, AFF_HIDE) && willBreakHide(cmd, true)) {
+      sendTo("You move from your hiding spot.\n\r");
       REMOVE_BIT(specials.affectedBy, AFF_HIDE);
+    }
 
     rc = triggerSpecial(NULL, cmd, newarg.c_str());
     if (IS_SET_DELETE(rc, DELETE_THIS))
@@ -2063,10 +2073,10 @@ int TBeing::parseCommand(const sstring& orig_arg, bool typedIn, bool doAlias) {
     return FALSE;
   }
 
-  if (IS_SET(specials.affectedBy, AFF_HIDE) && cmd != CMD_BACKSTAB)
+  if (IS_SET(specials.affectedBy, AFF_HIDE) && willBreakHide(cmd, true)) {
+    sendTo("You move from your hiding spot.\n\r");
     REMOVE_BIT(specials.affectedBy, AFF_HIDE);
-  if (IS_SET(specials.affectedBy, AFF_HIDE) && cmd != CMD_SLIT)
-    REMOVE_BIT(specials.affectedBy, AFF_HIDE);
+  }
 
   if (getCaptiveOf()) {
     if (!sameRoom(*getCaptiveOf())) {


### PR DESCRIPTION
## Summary
- Adds "You move from your hiding spot." message when a player breaks hide, giving feedback instead of silently dropping the affect
- Expands the hide-preserving whitelist with thematically appropriate commands: rest, sit, stand, sign, ptell, conceal, eat, drink
- Fixes a bug in `parseCommand` where a legacy hide-removal path bypassed the `willBreakHide()` whitelist — two separate if-statements (one exempting backstab, one exempting slit) together exempted neither

## Test plan
- [ ] Hide, then use a whitelisted command (look, rest, sit, eat, etc.) — should stay hidden with no message
- [ ] Hide, then use a non-whitelisted command (say, move, cast) — should see "You move from your hiding spot." and lose hide
- [ ] Hide, then backstab/slit — should execute the attack from hiding, then break hide after

🤖 Generated with [Claude Code](https://claude.com/claude-code)