### PR TITLE
Add blizzard spell and room affect infrastructure

### DIFF
--- a/code/code/cmd/cmd_look.cc
+++ b/code/code/cmd/cmd_look.cc
@@ -129,6 +129,8 @@ void TBeing::lookDir(int keyword_no) {
         if (!isPlayerAction(PLR_BRIEF))
           sendRoomDesc(rp);
 
+        sendRoomAffectDescs(this, rp, false);
+
         listExits(rp);
         list_thing_in_room(rp->stuff, this);
       }
@@ -225,6 +227,9 @@ void TBeing::lookRoom(bool changedZones) {
   describeWeather(in_room);
   describeGround();
   describeRoomLight();
+
+  sendRoomAffectDescs(this, roomp, true);
+
   //  doEvaluate("room");
   listExits(roomp);
 
@@ -286,6 +291,7 @@ void TBeing::lookAtRoom() {
   sendRoomName(roomp);
   sendRoomDesc(roomp);
   describeWeather(in_room);
+  sendRoomAffectDescs(this, roomp, true);
   listExits(roomp);
 
   if (dynamic_cast<TPerson*>(this)) {

--- a/code/code/cmd/cmd_stat.cc
+++ b/code/code/cmd/cmd_stat.cc
@@ -1514,6 +1514,7 @@ void TBeing::statBeing(TBeing* k) {
       case SPELL_FROST_BREATH:
       case SPELL_WATERY_GRAVE:
       case SPELL_TSUNAMI:
+      case SPELL_BLIZZARD:
       case SPELL_CHLORINE_BREATH:
       case SPELL_DUST_BREATH:
       case SPELL_POISON_DEIKHAN:

--- a/code/code/disc/disc_mage_water.cc
+++ b/code/code/disc/disc_mage_water.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "extern.h"
 #include "room.h"
 #include "low.h"
@@ -1457,3 +1459,258 @@ int garmulsTail(TBeing* caster, TBeing* victim, int level, short bKnown) {
     return SPELL_FAIL;
   }
 }
+
+// ---- BLIZZARD ----
+
+int blizzard(TBeing* caster, int level, short bKnown, int adv_learn) {
+  TRoom* room = caster->roomp;
+  int orig_damage =
+    caster->getSkillDam(nullptr, SPELL_BLIZZARD, level, adv_learn);
+
+  if (caster->bSuccess(bKnown, SPELL_BLIZZARD)) {
+    act(
+      "$n raises $s arms and calls forth a <W>howling blizzard<z> of ice and "
+      "snow!",
+      false, caster, nullptr, nullptr, TO_ROOM, ANSI_CYAN);
+    act(
+      "You raise your arms and call forth a <W>howling blizzard<z> of ice and "
+      "snow!",
+      false, caster, nullptr, nullptr, TO_CHAR, ANSI_CYAN);
+
+    // Initial burst — lighter than a typical AoE at this level
+    int burst_damage = orig_damage / 2;
+
+    // Build target list first, then iterate (safety invariant)
+    std::vector<TBeing*> targets;
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end(); ++it) {
+      if (auto* victim = dynamic_cast<TBeing*>(*it))
+        targets.push_back(victim);
+    }
+
+    for (auto* victim : targets) {
+      if (!victim)
+        continue;
+      // Re-validate: an earlier victim's death cascade can free or move
+      // other beings in the room before we get to them.
+      if (std::find(room->stuff.begin(), room->stuff.end(), victim) ==
+          room->stuff.end())
+        continue;
+      if (victim->getPosition() == POSITION_DEAD)
+        continue;
+      if (victim == caster)
+        continue;
+      if (victim->isImmortal())
+        continue;
+      if (caster->inGroup(*victim))
+        continue;
+
+      caster->reconcileHurt(victim, discArray[SPELL_BLIZZARD]->alignMod);
+      int damage = burst_damage;
+
+      if (victim->isLucky(caster->spellLuckModifier(SPELL_BLIZZARD))) {
+        act("$N finds shelter from the worst of the blast!", false, caster,
+          nullptr, victim, TO_NOTVICT, ANSI_CYAN);
+        act("$N finds shelter from the worst of the blast!", false, caster,
+          nullptr, victim, TO_CHAR, ANSI_CYAN);
+        act("You find shelter from the worst of the blast!", false, caster,
+          nullptr, victim, TO_VICT, ANSI_CYAN);
+        damage /= 2;
+      } else {
+        act("$N is battered by the onslaught of ice and snow!", false, caster,
+          nullptr, victim, TO_NOTVICT, ANSI_CYAN);
+        act("$N is battered by the onslaught of ice and snow!", false, caster,
+          nullptr, victim, TO_CHAR, ANSI_CYAN);
+        act("You are battered by the onslaught of ice and snow!", false, caster,
+          nullptr, victim, TO_VICT, ANSI_CYAN);
+      }
+
+      if (caster->reconcileDamage(victim, damage, SPELL_BLIZZARD) == -1) {
+        delete victim;
+        victim = nullptr;
+      }
+    }
+
+    // Apply room affect for ongoing damage. duration is the number of damage
+    // ticks; tickRoomAffects fires that many onTick callbacks followed by one
+    // onExpire.
+    int per_tick_damage = max(1, orig_damage / 4);
+    int duration = 3 + min(4, level / 25);
+
+    if (auto* existing = room->getRoomAffect(SPELL_BLIZZARD)) {
+      // Refresh: update duration, damage, and caster
+      existing->duration = duration;
+      existing->modifier = per_tick_damage;
+      existing->casterID = caster->getPlayerID();
+      existing->level = level;
+    } else {
+      RoomAffectData affect;
+      affect.type = SPELL_BLIZZARD;
+      affect.duration = duration;
+      affect.level = level;
+      affect.modifier = per_tick_damage;
+      affect.casterID = caster->getPlayerID();
+      room->addRoomAffect(affect);
+    }
+
+    return SPELL_SUCCESS;
+  } else {
+    switch (critFail(caster, SPELL_BLIZZARD)) {
+      case CRIT_F_HITSELF:
+      case CRIT_F_HITOTHER:
+        CF(SPELL_BLIZZARD);
+        act("The spell backfires, engulfing $n in a blast of freezing air!",
+          false, caster, nullptr, nullptr, TO_ROOM, ANSI_CYAN);
+        act("The spell backfires, engulfing you in a blast of freezing air!",
+          false, caster, nullptr, nullptr, TO_CHAR, ANSI_CYAN);
+        if (caster->reconcileDamage(caster, orig_damage / 3, SPELL_BLIZZARD) ==
+            -1)
+          return SPELL_CRIT_FAIL + CASTER_DEAD;
+        return SPELL_CRIT_FAIL;
+      default:
+        act("Your spell fizzles and fails to conjure a blizzard.", true, caster,
+          nullptr, nullptr, TO_CHAR);
+        caster->nothingHappens(SILENT_YES);
+        return SPELL_FAIL;
+    }
+  }
+}
+
+int blizzard(TBeing* caster) {
+  if (!bPassMageChecks(caster, SPELL_BLIZZARD, nullptr))
+    return false;
+
+  if (caster->checkPeaceful(
+        "Such a destructive spell is not needed in this peaceful place.\n\r"))
+    return false;
+
+  lag_t rounds = discArray[SPELL_BLIZZARD]->lag;
+  taskDiffT diff = discArray[SPELL_BLIZZARD]->task;
+
+  start_cast(caster, nullptr, nullptr, caster->roomp, SPELL_BLIZZARD, diff, 1,
+    "", rounds, caster->in_room, 0, 0, true, 0);
+  return true;
+}
+
+int castBlizzard(TBeing* caster) {
+  int level = caster->getSkillLevel(SPELL_BLIZZARD);
+  int bKnown = caster->getSkillValue(SPELL_BLIZZARD);
+  int rc = 0;
+
+  int ret =
+    blizzard(caster, level, bKnown, caster->getAdvLearning(SPELL_BLIZZARD));
+  if (IS_SET(ret, CASTER_DEAD))
+    ADD_DELETE(rc, DELETE_THIS);
+  return rc;
+}
+
+namespace {
+  void blizzardRoomTick(TRoom* room, RoomAffectData& affect);
+  void blizzardRoomExpire(TRoom* room, const RoomAffectData&);
+
+  sstring blizzardLookDesc(bool here) {
+    return (
+      format("<c>A howling blizzard rages %s, pelting everything with ice "
+             "and snow.<z>\n\r") %
+      (here ? "here" : "there"))
+      .str();
+  }
+
+  const RoomAffectVTable kBlizzardRoomAffect = {
+    .onTick = &blizzardRoomTick,
+    .onExpire = &blizzardRoomExpire,
+    .lookDesc = &blizzardLookDesc,
+  };
+}  // namespace
+
+void registerBlizzardRoomAffect() {
+  registerRoomAffect(SPELL_BLIZZARD, &kBlizzardRoomAffect);
+}
+
+namespace {
+  void blizzardRoomTick(TRoom* room, RoomAffectData& affect) {
+    // Look up caster by player ID for the group exemption check. casterID == 0
+    // means the original caster wasn't a real player (TBeing::getPlayerID()
+    // returns 0 for normal mobs), so skip the lookup entirely — otherwise we'd
+    // match the first mob in character_list and exempt its followers.
+    TBeing* caster = nullptr;
+    if (affect.casterID > 0) {
+      for (TBeing* ch = character_list; ch; ch = ch->next) {
+        if (ch->getPlayerID() == affect.casterID) {
+          caster = ch;
+          break;
+        }
+      }
+    }
+
+    // Group exemption only applies while the caster is still in the room —
+    // if they walked out (or died), the blizzard damages everyone
+    // indiscriminately
+    const bool caster_in_room = caster && caster->roomp == room;
+
+    MakeNoise(room->in_room,
+      "<c>The blizzard rages, pelting everything with ice and snow!<z>\n\r",
+      "<c>You hear howling winds nearby.<z>\n\r");
+
+    // Build target list first (safety invariant: don't modify during iteration)
+    std::vector<TBeing*> targets;
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end(); ++it) {
+      if (auto* victim = dynamic_cast<TBeing*>(*it))
+        targets.push_back(victim);
+    }
+
+    for (auto* victim : targets) {
+      if (!victim)
+        continue;
+      // Re-validate: an earlier tick victim's death cascade (scripts, mount
+      // riders, charm chains) can free or move other beings in the room.
+      if (std::find(room->stuff.begin(), room->stuff.end(), victim) ==
+          room->stuff.end())
+        continue;
+      if (victim->getPosition() == POSITION_DEAD)
+        continue;
+      if (victim->isImmortal())
+        continue;
+
+      // Skip caster and their group only while the caster remains in the room
+      if (caster_in_room) {
+        if (victim == caster)
+          continue;
+        if (caster->inGroup(*victim))
+          continue;
+      }
+
+      // Honor cold immunity / type-specific resistances. applyDamage doesn't
+      // run the preProcDam pipeline that reconcileDamage does, so we have to
+      // call getActualDamage explicitly or cold-immune mobs would take full
+      // damage.
+      int damage = victim->getActualDamage(victim, nullptr, affect.modifier,
+        SPELL_BLIZZARD);
+      if (damage <= 0)
+        continue;
+
+      // Compute save using the caster's class level at cast time, stored on the
+      // affect. This matches spellLuckModifier()'s formula (class_level * 20)
+      // without needing the caster to still exist.
+      if (victim->isLucky(affect.level * 20))
+        damage /= 2;
+
+      // Environmental damage: the initial burst already built hatred against
+      // the caster. Ticks deal damage without re-attribution, so the behavior
+      // is identical whether the caster is present, gone, or logged out. This
+      // also avoids AFF_AGGRESSOR pollution from reconcileDamage's self-flag
+      // path.
+      int rc = victim->applyDamage(victim, damage, SPELL_BLIZZARD);
+      if (IS_SET_DELETE(rc, DELETE_VICT)) {
+        delete victim;
+        victim = nullptr;
+      }
+    }
+  }
+
+  void blizzardRoomExpire(TRoom* room, const RoomAffectData&) {
+    MakeNoise(room->in_room,
+      "<c>The blizzard subsides, leaving only a bitter chill in the "
+      "air.<z>\n\r",
+      "<c>The howling winds nearby fade to silence.<z>\n\r");
+  }
+}  // namespace

--- a/code/code/disc/disc_mage_water.h
+++ b/code/code/disc/disc_mage_water.h
@@ -7,6 +7,7 @@ class CDWater : public CDiscipline {
   public:
     CSkill skWateryGrave;  //      40th level individual
     CSkill skTsunami;      // NEW  36th level area affect
+    CSkill skBlizzard;
     CSkill skBreathOfSarahage;
     CSkill skPlasmaMirror;
     CSkill skGarmulsTail;
@@ -48,6 +49,11 @@ int iceStorm(TBeing*, int, short, int);
 int tsunami(TBeing*);
 int castTsunami(TBeing*);
 int tsunami(TBeing*, int, short, int);
+
+int blizzard(TBeing*);
+int castBlizzard(TBeing*);
+int blizzard(TBeing*, int, short, int);
+void registerBlizzardRoomAffect();
 
 int conjureElemWater(TBeing*);
 int castConjureElemWater(TBeing*);

--- a/code/code/misc/immunity.cc
+++ b/code/code/misc/immunity.cc
@@ -249,6 +249,7 @@ immuneTypeT getTypeImmunity(spellNumT type) {
     case SPELL_ARCTIC_BLAST:
     case SPELL_ICE_STORM:
     case SPELL_FROST_BREATH:
+    case SPELL_BLIZZARD:
     case DAMAGE_TRAP_FROST:
       bit = IMMUNE_COLD;
       break;

--- a/code/code/misc/info.cc
+++ b/code/code/misc/info.cc
@@ -1143,6 +1143,7 @@ sstring TBeing::describeAffects(TBeing* ch, showMeT showme,
       case SPELL_FROST_BREATH:
       case SPELL_WATERY_GRAVE:
       case SPELL_TSUNAMI:
+      case SPELL_BLIZZARD:
       case SPELL_CHLORINE_BREATH:
       case SPELL_DUST_BREATH:
       case SPELL_POISON_DEIKHAN:
@@ -4303,6 +4304,9 @@ void TBeing::doEvaluate(const char* argument) {
       sendTo("There is an out-of-control fire here.\n\r");
     if (roomp->isRoomFlag(ROOM_FLOODED))
       sendTo("The room is flooded with water.\n\r");
+
+    // room affect messages
+    sendRoomAffectDescs(this, roomp, true);
 
     int wetness = getRoomWetness(roomp);
     if (wetness != 0)  // show wetness

--- a/code/code/misc/makecorpse.cc
+++ b/code/code/misc/makecorpse.cc
@@ -239,6 +239,15 @@ TThing* TBeing::makeCorpse(spellNumT dmg_type, TBeing* tKiller,
         sprintf(buf, "The bloated, water-filled corpse of %s is here.",
           getName().c_str());
         break;
+      case SPELL_BLIZZARD: {
+        auto desc = (format("The frost-covered corpse of %s is here, frozen "
+                            "solid.") %
+                     getName())
+                      .str();
+        strncpy(buf, desc.c_str(), MAX_INPUT_LENGTH - 1);
+        buf[MAX_INPUT_LENGTH - 1] = '\0';
+        break;
+      }
       case SPELL_CARDIAC_STRESS:
       case DAMAGE_HEMORRHAGE:
         sprintf(buf,

--- a/code/code/misc/room.cc
+++ b/code/code/misc/room.cc
@@ -6,8 +6,11 @@
 
 // room.cc
 
-#include "room.h"
 #include <algorithm>
+#include <ranges>
+#include <unordered_map>
+
+#include "room.h"
 #include <functional>
 #include "extern.h"
 #include "being.h"
@@ -16,6 +19,26 @@
 #include "weather.h"
 #include "obj_organic.h"
 #include "obj_flame.h"
+
+namespace {
+  // Per-spell-type vtables for room affects, populated at boot via
+  // registerRoomAffect(). Generic dispatch (tick processing, look output)
+  // looks the vtable up here instead of switching on spellNumT.
+  std::unordered_map<int, const RoomAffectVTable*>& roomAffectRegistry() {
+    static std::unordered_map<int, const RoomAffectVTable*> registry;
+    return registry;
+  }
+
+  const RoomAffectVTable* getRoomAffectVTable(spellNumT type) {
+    auto& registry = roomAffectRegistry();
+    auto it = registry.find(static_cast<int>(type));
+    return it != registry.end() ? it->second : nullptr;
+  }
+}  // namespace
+
+void registerRoomAffect(spellNumT type, const RoomAffectVTable* vtable) {
+  roomAffectRegistry()[static_cast<int>(type)] = vtable;
+}
 
 bool TRoom::isCitySector() const {
   switch (getSectorType()) {
@@ -496,4 +519,71 @@ bool TRoom::hasCampfire() const {
     // Check for flame objects
     return dynamic_cast<const TFFlame*>(obj) != nullptr;
   });
+}
+
+bool TRoom::hasRoomAffect(spellNumT type) const {
+  return std::ranges::any_of(roomAffects,
+    [type](const auto& a) { return a.type == type; });
+}
+
+RoomAffectData* TRoom::getRoomAffect(spellNumT type) {
+  auto it = std::ranges::find_if(roomAffects,
+    [type](const auto& a) { return a.type == type; });
+  return it != roomAffects.end() ? &(*it) : nullptr;
+}
+
+void TRoom::addRoomAffect(const RoomAffectData& affect) {
+  roomAffects.push_back(affect);
+
+  if (std::ranges::find(affectedRooms_db, this) == affectedRooms_db.end())
+    affectedRooms_db.push_back(this);
+}
+
+void TRoom::removeRoomAffect(spellNumT type) {
+  std::erase_if(roomAffects, [type](const auto& a) { return a.type == type; });
+
+  if (roomAffects.empty())
+    std::erase(affectedRooms_db, this);
+}
+
+void sendRoomAffectDescs(TBeing* ch, TRoom* rp, bool here) {
+  if (!rp)
+    return;
+  for (const auto& affect : rp->getRoomAffects()) {
+    const RoomAffectVTable* vt = getRoomAffectVTable(affect.type);
+    if (!vt || !vt->lookDesc)
+      continue;
+    sstring desc = vt->lookDesc(here);
+    if (!desc.empty())
+      ch->sendTo(desc);
+  }
+}
+
+bool TRoom::tickRoomAffects() {
+  // duration semantics: number of damage ticks remaining. Tick first, then
+  // decrement, then expire when it hits 0. So a freshly-cast affect with
+  // duration N fires N onTick callbacks followed by one onExpire.
+  //
+  // Iterate backwards so we can erase expired entries safely. Re-acquire the
+  // reference after each callback since onTick can transitively call
+  // addRoomAffect (e.g. a death cascade triggers a mob spec proc that casts
+  // a room-affect spell), which may reallocate the vector.
+  for (int i = static_cast<int>(roomAffects.size()) - 1; i >= 0; --i) {
+    auto idx = static_cast<size_t>(i);
+    spellNumT type = roomAffects[idx].type;
+
+    if (const auto* vt = getRoomAffectVTable(type); vt && vt->onTick)
+      vt->onTick(this, roomAffects[idx]);
+
+    // Re-validate: callback may have mutated the vector.
+    if (idx >= roomAffects.size() || roomAffects[idx].type != type)
+      continue;
+
+    if (--roomAffects[idx].duration <= 0) {
+      if (const auto* vt = getRoomAffectVTable(type); vt && vt->onExpire)
+        vt->onExpire(this, roomAffects[idx]);
+      roomAffects.erase(roomAffects.begin() + static_cast<ptrdiff_t>(i));
+    }
+  }
+  return !roomAffects.empty();
 }

--- a/code/code/misc/room.h
+++ b/code/code/misc/room.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <functional>
+#include <vector>
+
 #include "sound.h"
 #include "ansi.h"
 #include "structs.h"
@@ -14,6 +17,37 @@
 #include "obj.h"
 
 class TRoom;
+
+// Transient affect applied to a room (e.g., blizzard, poison fog).
+// Does not persist across reboots.
+struct RoomAffectData {
+    spellNumT type = TYPE_UNDEFINED;
+    int duration = 0;   // number of remaining onTick callbacks; when this hits
+                        // zero, onExpire fires and the affect is removed
+    int level = 0;      // caster level at cast time
+    int modifier = 0;   // primary value (e.g., damage per tick)
+    int modifier2 = 0;  // secondary value (reserved for future use)
+    int casterID = 0;   // player ID for group exclusion and hatred
+};
+
+// Per-spell behavior table for room affects. Each spell that introduces a
+// room affect registers one of these at boot via registerRoomAffect(). The
+// generic processing/look/etc. paths look up the vtable by spell type instead
+// of switching on it.
+//
+// Function pointers (not std::function) keep dispatch trivially cheap and
+// avoid any per-pulse allocation. Any field may be left null; the dispatcher
+// just skips that callback.
+struct RoomAffectVTable {
+    void (*onTick)(TRoom*, RoomAffectData&) = nullptr;
+    void (*onExpire)(TRoom*, const RoomAffectData&) = nullptr;
+    // Returns the room-affect description shown when looking. `here` is true
+    // when standing in the affected room, false when looking in from an
+    // adjacent room. Return an empty string to render nothing.
+    sstring (*lookDesc)(bool here) = nullptr;
+};
+
+void registerRoomAffect(spellNumT type, const RoomAffectVTable* vtable);
 
 // cubic inches of burning material where room itself burns
 const int ROOM_FIRE_THRESHOLD = 20000;
@@ -29,6 +63,7 @@ extern std::vector<zoneData> zone_table;
 // actually  have special procs
 extern std::vector<TRoom*> roomspec_db;
 extern std::vector<TRoom*> roomsave_db;
+extern std::vector<TRoom*> affectedRooms_db;
 
 // this is used for track range
 const unsigned int MAX_ROOMS = 5000;
@@ -138,6 +173,12 @@ class TRoom : public TThing {
     unsigned short fished;         // how fished out the room is
     unsigned short logsHarvested;  // how deforested the room is
     int treetype;                  // the kind of tree growing in the room
+
+    // Room affects (transient spell effects on the room itself). Private to
+    // force all mutation through add/removeRoomAffect so affectedRooms_db
+    // registry stays in sync, and through tickRoomAffects for per-tick
+    // processing.
+    std::vector<RoomAffectData> roomAffects;
 
   public:
     TThing* tBornInsideMe;  // List of mobs born inside me.
@@ -264,6 +305,26 @@ class TRoom : public TThing {
     TThing* findInRoom(const std::function<bool(TThing*)>&);
     const TThing* findInRoom(const std::function<bool(const TThing*)>&) const;
     bool hasCampfire() const;
+
+    [[nodiscard]] bool hasRoomAffect(spellNumT type) const;
+    [[nodiscard]] RoomAffectData* getRoomAffect(spellNumT type);
+    [[nodiscard]] const std::vector<RoomAffectData>& getRoomAffects() const {
+      return roomAffects;
+    }
+    void addRoomAffect(const RoomAffectData& affect);
+    void removeRoomAffect(spellNumT type);
+
+    // Per-tick bookkeeping for room affects: invokes the registered onTick
+    // callback for each active affect, then decrements durations and invokes
+    // onExpire for any that reached zero (erasing them). A freshly-cast
+    // affect with duration N fires N onTick callbacks followed by one
+    // onExpire. Returns true if any affects remain after processing.
+    bool tickRoomAffects();
 };
+
+// Renders any active room-affect descriptions into the looker's output.
+// `here` controls the deictic ("here" for a room you're standing in, "there"
+// for one you're peering into from an adjacent room).
+void sendRoomAffectDescs(TBeing* ch, TRoom* rp, bool here);
 
 const int ZONE_MAX_TIME = 50;

--- a/code/code/misc/skill_dam.cc
+++ b/code/code/misc/skill_dam.cc
@@ -248,6 +248,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       break;
     case SPELL_SAND_BLAST:
     case SPELL_HELLFIRE:
+    case SPELL_BLIZZARD:
     case SPELL_ENERGY_DRAIN:
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
         2 * HARD_TO_FIND_COMPONENT, REDUCE_YES, !isPc(), TRIM_NO);

--- a/code/code/misc/skills.cc
+++ b/code/code/misc/skills.cc
@@ -353,6 +353,8 @@ CSkill* TBeing::getSkill(spellNumT skill) const {
       return &((CDWater*)cd)->skWateryGrave;
     case SPELL_TSUNAMI:
       return &((CDWater*)cd)->skTsunami;
+    case SPELL_BLIZZARD:
+      return &((CDWater*)cd)->skBlizzard;
     case SPELL_BREATH_OF_SARAHAGE:
       return &((CDWater*)cd)->skBreathOfSarahage;
     case SPELL_PLASMA_MIRROR:

--- a/code/code/misc/spell_info.cc
+++ b/code/code/misc/spell_info.cc
@@ -10,6 +10,7 @@
 /////////////////////////////////////////////////////////////////
 
 #include "discipline.h"
+#include "disc_mage_water.h"
 #include "extern.h"
 #include "spell2.h"
 #include "toggle.h"
@@ -1049,6 +1050,16 @@ void buildSpellArray() {
     COMP_GESTURAL | COMP_GESTURAL_RANDOM | COMP_VERBAL | COMP_VERBAL_RANDOM |
       COMP_MATERIAL | COMP_MATERIAL_END | SPELL_TASKED,
     0);
+
+  discArray[SPELL_BLIZZARD] = new spellInfo(SPELL_MAGE, DISC_WATER, DISC_WATER,
+    STAT_INT, "blizzard", TASK_DIFFICULT, LAG_5, POSITION_SITTING, MANA_50,
+    LIFEFORCE_0, PRAY_0, TAR_AREA | TAR_IGNORE | TAR_VIOLENT, SYMBOL_STRESS_0,
+    "", "", "", "", START_50, LEARN_2, START_DO_40, LEARN_DO_5, START_DO_NO,
+    LEARN_DO_NO, LEARN_DIFF_SPELLS, 0.04,
+    COMP_GESTURAL | COMP_GESTURAL_RANDOM | COMP_VERBAL | COMP_VERBAL_RANDOM |
+      COMP_MATERIAL | COMP_MATERIAL_END | SPELL_TASKED,
+    0);
+  registerBlizzardRoomAffect();
 
   discArray[SPELL_BREATH_OF_SARAHAGE] =
     new spellInfo(SPELL_MAGE, DISC_WATER, DISC_WATER, STAT_INT,

--- a/code/code/misc/spell_num.cc
+++ b/code/code/misc/spell_num.cc
@@ -298,6 +298,8 @@ int mapSpellnumToFile(spellNumT stt) {
       return 106;
     case SPELL_TRUE_SIGHT:
       return 107;
+    case SPELL_BLIZZARD:
+      return 108;
     case SPELL_WATERY_GRAVE:
       return 110;
     case SPELL_TSUNAMI:
@@ -1468,6 +1470,8 @@ spellNumT mapFileToSpellnum(int stt) {
       return SPELL_SILENCE;
     case 107:
       return SPELL_TRUE_SIGHT;
+    case 108:
+      return SPELL_BLIZZARD;
     case 110:
       return SPELL_WATERY_GRAVE;
     case 111:

--- a/code/code/misc/spell_parser.cc
+++ b/code/code/misc/spell_parser.cc
@@ -1253,6 +1253,7 @@ namespace {
     {SPELL_SILENCE, "SPELL_SILENCE"},
     {SPELL_WATERY_GRAVE, "SPELL_WATERY_GRAVE"},
     {SPELL_TSUNAMI, "SPELL_TSUNAMI"},
+    {SPELL_BLIZZARD, "SPELL_BLIZZARD"},
     {SPELL_BREATH_OF_SARAHAGE, "SPELL_BREATH_OF_SARAHAGE"},
     {SPELL_PLASMA_MIRROR, "SPELL_PLASMA_MIRROR"},
     {SPELL_GARMULS_TAIL, "SPELL_GARMULS_TAIL"},
@@ -2160,6 +2161,9 @@ int TBeing::doDiscipline(spellNumT which, const sstring& n1) {
       break;
     case SPELL_TSUNAMI:
       rc = tsunami(this);
+      break;
+    case SPELL_BLIZZARD:
+      rc = blizzard(this);
       break;
     case SPELL_CONJURE_WATER:
       conjureElemWater(this);

--- a/code/code/misc/spells.h
+++ b/code/code/misc/spells.h
@@ -173,6 +173,7 @@ enum spellNumT {
   SPELL_ETHER_GATE,
   SPELL_KNOT,
   SPELL_TRUE_SIGHT,
+  SPELL_BLIZZARD,
 
   // end of mage
   // start of cleric

--- a/code/code/misc/spelltask.cc
+++ b/code/code/misc/spelltask.cc
@@ -1335,6 +1335,7 @@ int TBeing::checkBadSpellCondition(TBeing* caster, int which) {
     case SPELL_ARCTIC_BLAST:
     case SPELL_ICE_STORM:
     case SPELL_TSUNAMI:
+    case SPELL_BLIZZARD:
     case SPELL_CONJURE_WATER:
     case SPELL_GUSHER:
       return FALSE;
@@ -2154,6 +2155,9 @@ int TBeing::doSpellCast(TBeing* caster, TBeing* victim, TObj* o, TRoom* room,
       break;
     case SPELL_TSUNAMI:
       rc = castTsunami(this);
+      break;
+    case SPELL_BLIZZARD:
+      rc = castBlizzard(this);
       break;
     case SPELL_CONJURE_WATER:
       rc = castConjureElemWater(this);

--- a/code/code/misc/structs.cc
+++ b/code/code/misc/structs.cc
@@ -538,6 +538,9 @@ TRoom::~TRoom() {
     }
   }
 
+  // remove room from affected rooms registry
+  std::erase(affectedRooms_db, this);
+
   // A whacky what-if contingency thing
   // save rooms 100 200
   // in clean state, goto 100 (creates room 100, puts in db)

--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -164,6 +164,7 @@ const char* const File::WIZNEWS_DIR =
 
 std::vector<TRoom*> roomspec_db(0);
 std::vector<TRoom*> roomsave_db(0);
+std::vector<TRoom*> affectedRooms_db;
 std::queue<sstring> queryqueue;
 
 struct cached_object {

--- a/code/code/sys/process.h
+++ b/code/code/sys/process.h
@@ -384,6 +384,12 @@ class procRoomPulse : public TProcess {
     procRoomPulse(const int&);
 };
 
+class procRoomAffects : public TProcess {
+  public:
+    void run(const TPulse&) const;
+    procRoomAffects(const int&);
+};
+
 class procWeightVolumeFumble : public TProcess {
   public:
     void run(const TPulse&) const;

--- a/code/code/sys/socket.cc
+++ b/code/code/sys/socket.cc
@@ -8,9 +8,12 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include <csignal>
 #include <cstdarg>
 #include <cmath>
+#include <ranges>
+#include <vector>
 #include <errno.h>
 #include <stdio.h>
 
@@ -1515,6 +1518,25 @@ void procRoomPulse::run(const TPulse& pl) const {
   }
 }
 
+procRoomAffects::procRoomAffects(const int& p) {
+  trigger_pulse = p;
+  name = "procRoomAffects";
+}
+
+void procRoomAffects::run(const TPulse&) const {
+  // Snapshot the room list before iterating: tick callbacks could
+  // (transitively) call addRoomAffect/removeRoomAffect, which mutate
+  // affectedRooms_db and would invalidate a live iterator. Re-check
+  // membership before dispatching in case a callback removed the room.
+  std::vector<TRoom*> snapshot(affectedRooms_db);
+  for (TRoom* room : snapshot) {
+    if (std::ranges::find(affectedRooms_db, room) == affectedRooms_db.end())
+      continue;
+    if (!room->tickRoomAffects())
+      std::erase(affectedRooms_db, room);
+  }
+}
+
 procCheckTask::procCheckTask(const int& p) {
   trigger_pulse = p;
   name = "procCheckTask";
@@ -1662,6 +1684,7 @@ int TMainSocket::gameLoop() {
   scheduler.add(new procCharDrowning(Pulse::SPEC_PROCS));
   scheduler.add(new procCharResponses(Pulse::SPEC_PROCS));
   scheduler.add(new procPaladinAura(Pulse::SPEC_PROCS));
+  scheduler.add(new procRoomAffects(Pulse::SPEC_PROCS));
 
   // pulse noises (4.8 seconds)
   scheduler.add(new procCharNoise(Pulse::NOISES));

--- a/lib/help/_spells/blizzard
+++ b/lib/help/_spells/blizzard
@@ -1,0 +1,10 @@
+Blizzard is a powerful water spell that calls forth a howling storm of ice
+and snow upon the caster's enemies.  The initial blast deals cold damage to
+all non-grouped creatures in the room, after which the blizzard persists for
+several rounds, continuing to batter anything caught within it.  The duration
+of the blizzard scales with the caster's level.
+
+If the caster leaves the room or dies, the blizzard continues to rage but
+will damage all creatures indiscriminately, including former allies.
+
+Recasting blizzard in the same room will refresh the storm's duration.

--- a/lib/txt/news.d/2026-04-06-new-water-discipline-spell-blizzard
+++ b/lib/txt/news.d/2026-04-06-new-water-discipline-spell-blizzard
@@ -1,0 +1,15 @@
+New Water Discipline Spell: Blizzard
+Water mages now have access to a powerful new area spell!
+
+Blizzard calls forth a howling storm of ice and snow upon the caster's
+enemies. The initial blast deals cold damage to all non-grouped
+creatures in the room, after which the blizzard persists for several
+rounds, continuing to batter anything caught within it. The duration
+of the blizzard scales with the caster's level.
+
+If the caster leaves the room or dies, the blizzard continues to rage
+but will damage all creatures indiscriminately, including former
+allies. Recasting blizzard in the same room will refresh the storm's
+duration.
+
+See 'help blizzard' for more details.


### PR DESCRIPTION
## Summary

Adds a new mage water discipline spell, **blizzard**, along with entirely new **room affect infrastructure** to support persistent, general-purpose effects attached to rooms. Blizzard is the first consumer, but the infrastructure is designed to support future spells (poison fog, consecrated ground, etc.).

## Intent

Blizzard is a high-level mage water area spell with two damage phases:
1. An initial cold burst to all non-grouped creatures in the room
2. A persistent storm that ticks cold damage every 3.6 seconds for several rounds

The spell is intended as a signature water-discipline AoE — slower to cast and lower burst than hellfire, but substantially higher total potential damage if targets remain in the room.

## Design Decisions & Rationale

### Room affects as new infrastructure (not invisible objects)

TRoom had no affect system prior to this PR. The quick path would have been to spawn an invisible object in the room as a carrier for the effect — a pattern used elsewhere in the codebase. We rejected that in favor of building a proper `RoomAffectData` struct on TRoom with a global registry (`affectedRooms_db`) and a dedicated TProcess (`procRoomAffects`).

**Why:** Per `.claude/rules/project.md`, new infrastructure should prefer architectural correctness over mimicking legacy patterns. Room affects are a real concept that belongs on the room, and we want future spells to build on a clean foundation rather than another hack. The struct is general-purpose (`type`, `duration`, `level`, `modifier`, `modifier2`, `casterID`) and not blizzard-specific.

### Encapsulated tick bookkeeping

`roomAffects` is private on TRoom. Per-tick processing goes through `TRoom::tickRoomAffects()`, which looks up each affect's registered `RoomAffectVTable` to dispatch `onTick` and `onExpire` callbacks internally. TRoom owns duration decrement, expiration, and erasure; spell-specific behavior lives in vtable entries registered at boot via `registerRoomAffect()`. This keeps the registry invariant (`affectedRooms_db` membership ↔ non-empty `roomAffects`) enforced in one place, and avoids `std::function` overhead on every pulse.

### Self-contained affect data — no victim-skill or live-caster dependencies in ticks

All data needed to resolve a tick is stored on `RoomAffectData` at cast time: caster class level, per-tick damage, and caster player ID. The tick handler:

- Uses `affect.level * 20` for the luck save — mirrors `spellLuckModifier()` without needing a live caster and avoids the bug where `victim->spellLuckModifier(SPELL_BLIZZARD)` would effectively auto-save any mob with 0 skill in the spell.
- Uses `affect.modifier` for damage — precomputed at cast time, never derived from the victim.
- Looks up the caster via `character_list` only to check `caster_in_room` and `inGroup()` for the group exemption. This is the single unavoidable live dependency, and it's intentionally dynamic because group membership changes over time.

### Tick damage is environmental, not attributed

Tick damage uses `victim->applyDamage(victim, damage, SPELL_BLIZZARD)`, not `reconcileDamage()`. The initial burst already establishes hatred against the caster via the normal attribution path; ticks are a pure environmental effect. This means:

- No `AFF_AGGRESSOR` pollution on the caster or the victim on every tick.
- Behavior is identical whether the caster is present, has left the room, has logged out, or is dead.
- Trade-off: mobs that wander into an active blizzard take damage but do not build hatred toward the caster, and the caster receives no xp for kills scored by tick damage alone. Considered acceptable given the architectural cleanliness and the reality that the caster is usually still present to finish anything the ticks soften up.

### Party exclusion via caster player ID

The affect stores the caster's player ID, not a raw `TBeing*`. The tick handler looks up the caster via `character_list` each tick. If the caster is in the room, their group is skipped; if not, the blizzard damages everything non-immortal in the room.

**Why:** Storing a raw pointer would dangle on caster deletion. Player ID is stable. Graceful degradation on caster loss was an explicit requirement and gives the spell interesting tactical consequences.

### Tick rate: `Pulse::SPEC_PROCS` (3.6s)

Matches the cadence of other periodic game systems and gives players time to react between ticks.

### Duration: 3 + min(4, level/25)

Scales from 3 ticks at low levels to 7 at high levels (level 50 PCs get 5). The tick loop fires `duration` onTick callbacks followed by one onExpire, so a duration of 5 means 5 damage ticks plus one expire message.

### Damage: initial burst + per-tick from room affect

- Initial burst: `getSkillDam() / 2` — half of a normal AoE to balance against the sustained damage
- Per tick: `getSkillDam() / 4` — tuned down during testing for total-potential-damage balance

For a level 50 caster with maxed water and max INT, the math works out to roughly:
- Initial burst: ~714
- Per-tick: ~357 × 5 ticks = ~1785
- **Total potential: ~2499**

Compared to hellfire (~771 one-shot burst). Blizzard has higher total damage but requires targets to stay in the room for the full duration, and has a longer cast time (LAG_5 vs LAG_2). DPS is comparable.

### Refresh over stack

Recasting blizzard in the same room refreshes duration, damage, and caster — it does not stack a second affect. Simplifies reasoning and avoids unbounded room affect growth.

### `skill_dam.cc` placement

SPELL_BLIZZARD is grouped with the `HARD_TO_FIND_COMPONENT` block alongside hellfire, sand blast, and energy drain (`2 * HARD_TO_FIND_COMPONENT` = 3.0 class_amt). This matches the component requirement and balances the spell similarly to hellfire.

### Adjacent-room messaging

Uses the existing `MakeNoise()` helper so players in rooms adjacent to the blizzard hear "howling winds nearby" (and "the howling winds nearby fade to silence" on expiration). Looking into the room (`look <direction>`) also shows the blizzard description, not just walking in.

## Test Plan

- [x] **Build**: `make -C ../../ dev-rebuild` compiles clean without warnings
- [x] **Basic cast**: A level 50 mage with maxed water can cast blizzard with the proper component
- [x] **Initial burst**: Non-group mobs in the room take cold damage immediately; grouped players and the caster are spared
- [x] **Persistent ticks**: The blizzard fires damage ticks every ~3.6 seconds
- [x] **Expire message**: After duration runs out, the room (and adjacent rooms) see the subsides/fade message and no more ticks fire
- [x] **Tick count**: Level 50 caster gets 5 damage ticks (6 total processing cycles)
- [x] **Room display — normal look**: `look` in the affected room shows "A howling blizzard rages here..."
- [x] **Room display — directional look**: `look west` into an affected adjacent room shows "A howling blizzard rages there..."
- [x] **Adjacent room noise**: Players in rooms adjacent to the blizzard see "You hear howling winds nearby"
- [x] **Caster leaves room**: Blizzard continues ticking after caster walks out
- [x] **Caster dies**: Blizzard continues ticking and damages former group members
- [x] **Refresh**: Casting blizzard in an already-affected room refreshes duration/damage/caster (does not stack)
- [x] **Peaceful room block**: Cannot cast in a peaceful room
- [x] **Component requirement**: Cast fails without the material component
- [x] **Frozen corpse**: Mobs killed by blizzard leave frost-covered corpses
- [x] **Immunity**: Creatures with cold immunity resist the damage appropriately
- [x] **Help file**: `help blizzard` returns the new help text
- [x] **News entry**: `news` shows the blizzard announcement
- [x] **Crit fail**: Failed casts backfire and damage the caster
