### PR TITLE
Add consecrate prayer for clerics

### DIFF
--- a/code/code/cmd/cmd_stat.cc
+++ b/code/code/cmd/cmd_stat.cc
@@ -1709,6 +1709,7 @@ void TBeing::statBeing(TBeing* k) {
       case SPELL_SANCTUARY:
       case SPELL_RELIVE:
       case SPELL_CRUSADE:
+      case SPELL_CONSECRATE:
       case SPELL_CURE_PARALYSIS:
       case SPELL_SECOND_WIND:
       case SPELL_HEROES_FEAST:
@@ -2340,6 +2341,14 @@ void TBeing::statBeing(TBeing* k) {
         str += "Aura of Might.\n\r";
         str += format("     Modifies %s by %ld points\n\r") %
                apply_types[aff->location].name % aff->modifier;
+        str += format("     Expires in %6d updates.\n\r") % aff->duration;
+        break;
+
+      case SPELL_CONSECRATE_AFFECT:
+        str += "Consecration.\n\r";
+        str += format("     Modifies %s to %s by %ld points\n\r") %
+               apply_types[aff->location].name %
+               immunity_names[aff->modifier] % aff->modifier2;
         str += format("     Expires in %6d updates.\n\r") % aff->duration;
         break;
 

--- a/code/code/disc/disc_cleric_aegis.cc
+++ b/code/code/disc/disc_cleric_aegis.cc
@@ -1384,3 +1384,193 @@ void bless(TBeing* c, TBeing* victim) {
 
   bless(c, victim, level, c->getSkillValue(spell), spell);
 }
+
+namespace {
+  // Sized so affectJoin's AVG_DUR_YES averaging stabilizes well above zero
+  // between room ticks; matches the deikhan aura pattern.
+  const int CONSECRATE_BUFF_DURATION = 9;
+
+  // Doubles paralysis recovery rate (room ticks every 3 combat pulses).
+  const int CONSECRATE_PARA_DECAY = 3;
+
+  void consecrateRoomTick(TRoom* room, RoomAffectData& affect);
+  void consecrateRoomExpire(TRoom* room, const RoomAffectData& affect);
+
+  sstring consecrateLookDesc(bool here) {
+    return (format("<Y>A circle of consecrated ground glows softly with holy "
+                   "light %s.<z>\n\r") %
+             (here ? "here" : "there"))
+      .str();
+  }
+
+  const RoomAffectVTable kConsecrateRoomAffect = {
+    .onTick = &consecrateRoomTick,
+    .onExpire = &consecrateRoomExpire,
+    .lookDesc = &consecrateLookDesc,
+  };
+}  // namespace
+
+void registerConsecrateRoomAffect() {
+  registerRoomAffect(SPELL_CONSECRATE, &kConsecrateRoomAffect);
+}
+
+namespace {
+  void applyConsecrateBuff(TBeing* victim, int level) {
+    struct ImmunityMod {
+        immuneTypeT type;
+        int amount;
+    };
+    // Negative HOLY immunity makes undead/demons (who usually carry strong
+    // holy resistance) take more damage from cleric attacks; PCs almost never
+    // have holy immunity so the debuff is effectively no-op for them.
+    const ImmunityMod mods[] = {
+      {IMMUNE_FEAR, 60},
+      {IMMUNE_PARALYSIS, 40},
+      {IMMUNE_DRAIN, 50},
+      {IMMUNE_HOLY, -10},
+    };
+    for (auto m : mods) {
+      affectedData aff;
+      // SPELL_CONSECRATE_AFFECT has no discArray entry, so the affect-update
+      // loop's renew/wear-off message paths early-return — silent refresh.
+      aff.type = SPELL_CONSECRATE_AFFECT;
+      aff.level = level;
+      aff.duration = CONSECRATE_BUFF_DURATION;
+      aff.location = APPLY_IMMUNITY;
+      aff.modifier = m.type;
+      aff.modifier2 = m.amount;
+      aff.bitvector = 0;
+      victim->affectJoin(victim, &aff, AVG_DUR_YES, AVG_EFF_YES, false);
+    }
+  }
+
+  void shortenParalysis(TBeing* victim) {
+    for (affectedData* af = victim->affected; af; af = af->next) {
+      if (af->type != SPELL_PARALYZE)
+        continue;
+      af->duration -= CONSECRATE_PARA_DECAY;
+      if (af->duration < 0)
+        af->duration = 0;
+    }
+  }
+
+  void consecrateRoomTick(TRoom* room, RoomAffectData& affect) {
+    // Ambient pulse to adjacent rooms every ~18s (5 ticks at SPEC_PROCS).
+    if (affect.duration % 5 == 0) {
+      MakeNoise(room->in_room, "",
+        "<Y>A warm holy light glows from nearby.<z>\n\r");
+    }
+
+    // Snapshot before iterating; victims may be removed mid-loop.
+    std::vector<TBeing*> targets;
+    for (StuffIter it = room->stuff.begin(); it != room->stuff.end(); ++it) {
+      if (auto* victim = dynamic_cast<TBeing*>(*it))
+        targets.push_back(victim);
+    }
+    for (auto* victim : targets) {
+      if (!victim)
+        continue;
+      if (std::find(room->stuff.begin(), room->stuff.end(), victim) ==
+          room->stuff.end())
+        continue;
+      if (victim->getPosition() == POSITION_DEAD)
+        continue;
+
+      applyConsecrateBuff(victim, affect.level);
+      shortenParalysis(victim);
+    }
+  }
+
+  void consecrateRoomExpire(TRoom* room, const RoomAffectData& affect) {
+    // modifier2 records whether this cast set ROOM_ALWAYS_LIT.
+    if (affect.modifier2 == 1)
+      room->removeRoomFlagBit(ROOM_ALWAYS_LIT);
+
+    MakeNoise(room->in_room,
+      "<Y>The holy light of the consecration fades away.<z>\n\r",
+      "<Y>The warm holy light from nearby fades away.<z>\n\r");
+  }
+}  // namespace
+
+void consecrate(TBeing* ch) {
+  if (!bPassClericChecks(ch, SPELL_CONSECRATE))
+    return;
+
+  if (ch->roomp->isRoomFlag(ROOM_NO_MAGIC)) {
+    ch->sendTo(
+      "Your prayer is rejected by some unholy force in this place.\n\r");
+    ch->deityIgnore(SILENT_YES);
+    return;
+  }
+
+  if (!ch->bSuccess(ch->getSkillValue(SPELL_CONSECRATE), ch->getPerc(),
+        SPELL_CONSECRATE)) {
+    ch->deityIgnore();
+    return;
+  }
+
+  int level = ch->getSkillLevel(SPELL_CONSECRATE);
+  TRoom* room = ch->roomp;
+
+  const int CONSECRATE_DURATION = 33;  // ~120s at SPEC_PROCS cadence
+
+  // Only mark ourselves as the light source if we actually set the flag.
+  int light_was_set = room->isRoomFlag(ROOM_ALWAYS_LIT) ? 0 : 1;
+  if (light_was_set)
+    room->setRoomFlagBit(ROOM_ALWAYS_LIT);
+
+  if (auto* existing = room->getRoomAffect(SPELL_CONSECRATE)) {
+    existing->duration = CONSECRATE_DURATION;
+    existing->level = level;
+    // Take ownership if this recast newly turned the flag on (e.g., the
+    // original cast was on an already-lit room and that source has since gone).
+    if (light_was_set)
+      existing->modifier2 = 1;
+  } else {
+    RoomAffectData affect;
+    affect.type = SPELL_CONSECRATE;
+    affect.duration = CONSECRATE_DURATION;
+    affect.level = level;
+    affect.modifier2 = light_was_set;
+    affect.casterID = ch->getPlayerID();
+    room->addRoomAffect(affect);
+  }
+
+  act("$n stands tall and consecrates the ground with <Y>blessed light<1>!",
+    TRUE, ch, 0, 0, TO_ROOM);
+  act("You stand tall and consecrate the ground with <Y>blessed light<1>!",
+    TRUE, ch, 0, 0, TO_CHAR);
+
+  MakeNoise(room->in_room, "",
+    "<Y>A warm holy light glows from nearby.<z>\n\r");
+
+  // Apply immunity buffs immediately so occupants are protected from the
+  // moment of cast, not only after the first room tick fires up to 3.6s
+  // later. Paralysis is deliberately not cleansed here; the tick handler
+  // shortens its duration instead, leaving cure paralysis as the only
+  // instant unstick.
+  std::vector<TBeing*> targets;
+  for (StuffIter it = room->stuff.begin(); it != room->stuff.end(); ++it) {
+    if (auto* victim = dynamic_cast<TBeing*>(*it))
+      targets.push_back(victim);
+  }
+  for (auto* victim : targets) {
+    if (!victim)
+      continue;
+    if (std::find(room->stuff.begin(), room->stuff.end(), victim) ==
+        room->stuff.end())
+      continue;
+    if (victim->getPosition() == POSITION_DEAD)
+      continue;
+
+    applyConsecrateBuff(victim, level);
+
+    if (victim->affectedBySpell(SPELL_FEAR)) {
+      victim->affectFrom(SPELL_FEAR);
+      act("$n's fear is washed away by the holy presence.", TRUE, victim, 0, 0,
+        TO_ROOM);
+      act("Your fear is washed away by the holy presence.", TRUE, victim, 0, 0,
+        TO_CHAR);
+    }
+  }
+}

--- a/code/code/disc/disc_cleric_aegis.h
+++ b/code/code/disc/disc_cleric_aegis.h
@@ -10,6 +10,7 @@ class CDAegis : public CDiscipline {
     CSkill skSecondWind;
     CSkill skRelive;
     CSkill skCrusade;
+    CSkill skConsecrate;
 
     virtual CDAegis* cloneMe() { return new CDAegis(*this); }
 
@@ -65,3 +66,6 @@ void cureDisease(TBeing*, TBeing*, TMagicItem*, spellNumT);
 void relive(TBeing*, TBeing*);
 
 void crusade(TBeing*);
+
+void consecrate(TBeing*);
+void registerConsecrateRoomAffect();

--- a/code/code/misc/info.cc
+++ b/code/code/misc/info.cc
@@ -1395,6 +1395,7 @@ sstring TBeing::describeAffects(TBeing* ch, showMeT showme,
       case SPELL_SANCTUARY:
       case SPELL_RELIVE:
       case SPELL_CRUSADE:
+      case SPELL_CONSECRATE:
       case SPELL_CURE_PARALYSIS:
       case SPELL_SECOND_WIND:
       case SPELL_HEROES_FEAST:
@@ -2007,6 +2008,13 @@ sstring TBeing::describeAffects(TBeing* ch, showMeT showme,
         }
         break;
       // Not in discarray since it's not a skill
+      case SPELL_CONSECRATE_AFFECT:
+        if (show && aff->shouldGenerateText()) {
+          str +=
+            format("Affected: Consecration.  Approx. duration : %s\n\r") %
+            describeDuration(this, aff->duration);
+        }
+        break;
       case SPELL_AURA_MIGHT:
         if (show && aff->shouldGenerateText()) {
           str += format("Affected: Aura of Might.  Approx. duration : %s\n\r") %

--- a/code/code/misc/skills.cc
+++ b/code/code/misc/skills.cc
@@ -472,6 +472,9 @@ CSkill* TBeing::getSkill(spellNumT skill) const {
       return &((CDAegis*)cd)->skRelive;
     case SPELL_CRUSADE:
       return &((CDAegis*)cd)->skCrusade;
+    case SPELL_CONSECRATE:
+    case SPELL_CONSECRATE_AFFECT:
+      return &((CDAegis*)cd)->skConsecrate;
 
       // disc_hand_of_god
 

--- a/code/code/misc/spell_info.cc
+++ b/code/code/misc/spell_info.cc
@@ -10,6 +10,7 @@
 /////////////////////////////////////////////////////////////////
 
 #include "discipline.h"
+#include "disc_cleric_aegis.h"
 #include "disc_mage_water.h"
 #include "extern.h"
 #include "spell2.h"
@@ -1457,6 +1458,13 @@ void buildSpellArray() {
     LIFEFORCE_0, PRAY_500, TAR_AREA | TAR_IGNORE, SYMBOL_STRESS_45, "", "", "",
     "", START_80, LEARN_5, START_DO_50, LEARN_DO_5, START_DO_NO, LEARN_DO_NO,
     LEARN_DIFF_PRAYERS, 0.02, COMP_GESTURAL | COMP_VERBAL, 0);
+
+  discArray[SPELL_CONSECRATE] = new spellInfo(SPELL_CLERIC, DISC_AEGIS,
+    DISC_AEGIS, STAT_WIS, "consecrate", TASK_NORMAL, LAG_3, POSITION_SITTING,
+    MANA_0, LIFEFORCE_0, PRAY_400, TAR_AREA | TAR_IGNORE, SYMBOL_STRESS_75, "",
+    "", "", "", START_60, LEARN_5, START_DO_50, LEARN_DO_5, START_DO_NO,
+    LEARN_DO_NO, LEARN_DIFF_PRAYERS, 0.04, COMP_GESTURAL | COMP_VERBAL, 0);
+  registerConsecrateRoomAffect();
 
   // disc_hand_of_god
 

--- a/code/code/misc/spell_num.cc
+++ b/code/code/misc/spell_num.cc
@@ -420,6 +420,10 @@ int mapSpellnumToFile(spellNumT stt) {
       return 204;
     case SPELL_CRUSADE:
       return 205;
+    case SPELL_CONSECRATE:
+      return 206;
+    case SPELL_CONSECRATE_AFFECT:
+      return 207;
     case SKILL_SLAM:
       return 217;
     case SKILL_BASH:
@@ -1592,6 +1596,10 @@ spellNumT mapFileToSpellnum(int stt) {
       return SPELL_RELIVE;
     case 205:
       return SPELL_CRUSADE;
+    case 206:
+      return SPELL_CONSECRATE;
+    case 207:
+      return SPELL_CONSECRATE_AFFECT;
     case 217:
       return SKILL_SLAM;
     case 218:

--- a/code/code/misc/spell_parser.cc
+++ b/code/code/misc/spell_parser.cc
@@ -1314,6 +1314,8 @@ namespace {
     {SPELL_KNIT_BONE, "SPELL_KNIT_BONE"},
     {SPELL_RELIVE, "SPELL_RELIVE"},
     {SPELL_CRUSADE, "SPELL_CRUSADE"},
+    {SPELL_CONSECRATE, "SPELL_CONSECRATE"},
+    {SPELL_CONSECRATE_AFFECT, "SPELL_CONSECRATE_AFFECT"},
     {SPELL_FLATULENCE, "SPELL_FLATULENCE"},
     {SPELL_ENLIVEN, "SPELL_ENLIVEN"},
     {SPELL_BLOOD_BOIL, "SPELL_BLOOD_BOIL"},
@@ -2450,6 +2452,9 @@ int TBeing::doDiscipline(spellNumT which, const sstring& n1) {
       break;
     case SPELL_CRUSADE:
       crusade(this);
+      break;
+    case SPELL_CONSECRATE:
+      consecrate(this);
       break;
     case SPELL_RELIVE:
       relive(this, ch);

--- a/code/code/misc/spells.h
+++ b/code/code/misc/spells.h
@@ -233,6 +233,8 @@ enum spellNumT {
   SPELL_KNIT_BONE,
   SPELL_RELIVE,
   SPELL_CRUSADE,
+  SPELL_CONSECRATE,
+  SPELL_CONSECRATE_AFFECT,
 
   // end of cleric
 

--- a/code/code/sys/sound.cc
+++ b/code/code/sys/sound.cc
@@ -82,15 +82,20 @@ void MakeNoise(int room, const char* local_snd, const char* distant_snd) {
   TRoom *rp = NULL, *orp = NULL;
   TThing* t = NULL;
 
+  const bool has_local = local_snd && *local_snd;
+  const bool has_distant = distant_snd && *distant_snd;
+
   if ((rp = real_roomp(room))) {
-    for (StuffIter it = rp->stuff.begin(); it != rp->stuff.end() && (t = *it);
-         ++it) {
-      ch = dynamic_cast<TBeing*>(t);
-      if (!ch) {
-        continue;
-      }
-      if (ch->awake()) {
-        ch->sendTo(COLOR_BASIC, local_snd);
+    if (has_local) {
+      for (StuffIter it = rp->stuff.begin(); it != rp->stuff.end() && (t = *it);
+           ++it) {
+        ch = dynamic_cast<TBeing*>(t);
+        if (!ch) {
+          continue;
+        }
+        if (ch->awake()) {
+          ch->sendTo(COLOR_BASIC, local_snd);
+        }
       }
     }
   }
@@ -99,6 +104,8 @@ void MakeNoise(int room, const char* local_snd, const char* distant_snd) {
       format("Testing log: No rp in MakeNoise for %s") % ch->name);
     return;
   }
+  if (!has_distant)
+    return;
   for (door = MIN_DIR; door < MAX_DIR; door++) {
     if (rp->dir_option[door] &&
         (orp = real_roomp(rp->dir_option[door]->to_room))) {

--- a/lib/help/_spells/consecrate
+++ b/lib/help/_spells/consecrate
@@ -1,0 +1,13 @@
+Consecrate is an aegis prayer that hallows the ground around the cleric,
+creating a circle of holy light that protects all within from the dark
+magicks favored by undead and other unholy creatures.
+
+While the consecration holds, every being in the room - friend or foe -
+gains substantial resistance to fear, drain, and paralysis, and becomes
+more vulnerable to holy damage.  Existing fear is cleansed on cast, and
+active paralysis recovers more quickly within the circle.
+
+The room is bathed in holy light for the duration.  The consecration
+fades after about two minutes; recasting refreshes it in place.
+
+Cure paralysis remains the only way to instantly free a held target.

--- a/lib/txt/news.d/2026-04-25-new-cleric-aegis-prayer-consecrate
+++ b/lib/txt/news.d/2026-04-25-new-cleric-aegis-prayer-consecrate
@@ -1,0 +1,14 @@
+New Cleric Aegis Prayer: Consecrate
+Clerics now have access to a new room-affecting protection prayer!
+
+Consecrate hallows the ground around the cleric, creating a circle of
+holy light that protects everyone within from fear, life drain, and
+paralysis - the favored attacks of undead and other unholy creatures.
+The consecration also makes those within more vulnerable to holy
+damage, giving clerics an edge when smiting evil.
+
+Existing fear is cleansed on cast, and active paralysis recovers more
+quickly within the circle.  The room is brightly lit for the duration
+(about two minutes), and recasting refreshes the consecration in place.
+
+See 'help consecrate' for more details.


### PR DESCRIPTION
## Summary

Adds a new cleric Aegis prayer, **consecrate**, the second consumer of the room-affect infrastructure landed in #719. Consecrate is a defensive area prayer aimed at the standard arsenal of undead and other unholy creatures (fear, life drain, paralysis), with a small offensive bite against holy-resistant enemies.

## Mechanics

| Field | Value |
|---|---|
| Class / Discipline | Cleric / Aegis |
| Levels | START_60, LEARN_5 (caps just before crusade at 80) |
| Cost | PRAY_400 (~20% piety), SYMBOL_STRESS_75 |
| Lag | LAG_3 |
| Position | POSITION_SITTING (matches peer prayers) |
| Targets | TAR_AREA \| TAR_IGNORE |
| Components | COMP_GESTURAL \| COMP_VERBAL |
| Duration | 33 SPEC_PROCS ticks (~120s) |
| Refresh | Recasting refreshes in place; does not stack |

**On cast:**
- Cleanses `SPELL_FEAR` from every occupant
- Sets `ROOM_ALWAYS_LIT` (tracked, only cleared on expire if we set it)
- Per-room `act` for caster + room, plus a `MakeNoise` to adjacent rooms

**Per tick (every 3.6s, the SPEC_PROCS cadence):**
- Reapplies a short-duration buff (9 combat pulses) to every occupant carrying:
  - `IMMUNE_FEAR +60`
  - `IMMUNE_DRAIN +50`
  - `IMMUNE_PARALYSIS +40`
  - `IMMUNE_HOLY -10`
- Subtracts 3 from any active `SPELL_PARALYZE` affect on each occupant — doubles paralysis recovery rate inside the circle
- Every 5 ticks (~18s), pulses `A warm holy light glows from nearby.` to adjacent rooms

**On expire:**
- Clears `ROOM_ALWAYS_LIT` only if this cast originally set it (tracked in `modifier2`)
- `MakeNoise` for local fade and adjacent fade

## Design Decisions & Rationale

### Universal scope — everyone in the room benefits, including enemies

Initial design assumed group- or alignment-gating. Rejected both: the prayer creates a holy *space*, not a friendly buff, so the rule is uniform — anyone standing in a consecrated room gets the same treatment. No `inGroup` checks, no `isEvil` checks. This deliberately means a cleric who casts paralyze on undead inside their own consecration will face the same ~40% resistance as the players do; we accepted this as the cost of a coherent rule.

The `IMMUNE_HOLY -10` line is the only nominally "offensive" piece, and it still respects the universal rule: it applies to everyone, but PCs essentially never carry holy immunity, so in practice only undead/demons feel the debuff. No targeting code, no special-case branching.

### Cleanse on cast for fear, but not paralysis

Fear is psychological — the holy presence drives it out instantly. Paralysis is physical — the body needs time to recover. The per-tick handler accelerates paralysis recovery (2× rate) but doesn't break it outright, leaving cure paralysis as the only way to *instantly* unstick a held target. This keeps the level-40 prayer relevant alongside the level-60 one.

### `SPELL_CONSECRATE_AFFECT` for per-character buffs

The first iteration used `SPELL_CONSECRATE` for both the room affect and the per-character buffs. This produced massive message spam — every `affectJoin` refresh hit the renew/wear-off message paths in `periodic.cc` / `magicutils.cc`, and even with `fadeAway = ""` the format string sent empty newlines. With 4 buffs × N occupants × refreshing every few seconds, the spam was constant.

Fix follows the deikhan aura pattern: split into a castable `SPELL_CONSECRATE` (with `discArray` entry) and an internal-only `SPELL_CONSECRATE_AFFECT` (no `discArray` entry) used solely as the buff carrier type. All three message paths (`spellWearOff`, `spellWearOffSoon`, "can be renewed") gate on `discArray[s]` and early-return for the affect type. Silent refresh.

### Per-character buff duration: 9 combat pulses

Sized to match the deikhan aura constant. With `affectJoin`'s `AVG_DUR_YES` averaging, duration converges to a stable ~6 pulses (~7s) between SPEC_PROCS room ticks. Step out of the room and protection drops within ~10s. Lower values like 4 collapsed to nothing in steady state due to the averaging math.

### Light flag tracked via `modifier2`

`ROOM_ALWAYS_LIT` is set on cast unless already present. `modifier2` records whether *this cast* added the flag (`1`) or it was already there (`0`); on expire we only clear if we set it, so naturally-lit rooms aren't accidentally darkened.

### Adjacent-room ambient pulse cadence

Blizzard pulses `MakeNoise` every tick (3.6s) because it's a violent ongoing storm. Consecration is a peaceful glow — every-tick would feel spammy. Settled on every 5 ticks (~18s) for ~6 ambient messages over the 120s window. Constant is the only knob.

### POSITION_SITTING, not POSITION_STANDING

Initial design said standing for flavor ("you stand to consecrate"). Reverted to sitting — every other Aegis prayer uses sitting as the minimum, and standing-only would be unique friction. The act emote still has the caster standing tall.

### No critical success / critical fail handling

Matches `crusade`'s pattern. The prayer either lands or doesn't; no special CS/CF branches. Easy to add later if testing reveals a need.

## Files changed

- `misc/spells.h` — `SPELL_CONSECRATE` and `SPELL_CONSECRATE_AFFECT` enum entries
- `misc/spell_num.cc`, `misc/spell_parser.cc`, `misc/skills.cc` — bidirectional spell-num mappings, name table, CSkill lookup
- `misc/info.cc`, `cmd/cmd_stat.cc` — affect display cases (so the `affects` and imm `stat` commands describe the buff)
- `misc/spell_info.cc` — `discArray` entry, `registerConsecrateRoomAffect()` call, include for the aegis header
- `disc/disc_cleric_aegis.h` — `skConsecrate` member, `consecrate()` and `registerConsecrateRoomAffect()` declarations
- `disc/disc_cleric_aegis.cc` — cast function, room-affect tick/expire/lookDesc handlers, vtable, registration
- `lib/help/_spells/consecrate` — help file
- `lib/txt/news.d/2026-04-25-new-cleric-aegis-prayer-consecrate` — news entry

## Test Plan

### Basic cast and display
- [x] Cleric ≥ level 60 with the prayer learned can cast `pray consecrate`
- [x] Cast emote fires for caster (`You stand tall and consecrate the ground...`) and room (`$n stands tall...`)
- [x] `look` in the affected room shows `A circle of consecrated ground glows softly with holy light here.`
- [x] `look <direction>` from an adjacent room shows the same message with `there.`
- [x] Casting in `ROOM_NO_MAGIC` rejects with `Your prayer is rejected by some unholy force...`
- [x] Failed cast (skill check) results in `deityIgnore`, no room affect created

### Room flag tracking
- [x] In a previously-dark room: cast → room shows `This area is brightly lit.`; on expire → returns to `This area is dark.`
- [x] In an already-lit room (e.g., `ROOM_ALWAYS_LIT` set in zonefile or by another mechanic): cast does not change the lit state; on expire the room stays lit

### Adjacent-room messaging (requires a witness PC in an adjacent room)
- [x] On cast, adjacent witness sees `A warm holy light glows from nearby.`
- [x] During the consecration (~18s after cast), adjacent witness sees the same ambient pulse repeat
- [x] At expire, adjacent witness sees `The warm holy light from nearby fades away.`

### Local fade
- [x] In the cast room at expire (~120s), occupants see `The holy light of the consecration fades away.`

### Refresh
- [x] Recasting in an already-consecrated room refreshes duration (look description and effects continue past 120s from original cast)
- [x] Recast does not stack (no double messaging, no doubled buff values)

### Per-character buffs
- [x] `affects` on a being inside the room shows `Affected: Consecration. Approx. duration : ...`
- [x] Imm `stat <being>` inside the room shows the consecration buffs with their immunity types
- [x] Walking out of the room: buff drops within ~10s

### Fear cleanse on cast
- [x] Target in room without fear at cast time → no message for them (only those who actually had fear)

### Paralysis recovery
- [x] Apply paralysis to a target in the consecrated room; observe paralysis duration counts down approximately twice as fast as it would in an unconsecrated room
- [x] Cure paralysis still works as the instant cure (sanity check that nothing was broken)

### Immunity checks
- [x] PC in consecrated room is significantly more resistant to fear (60% boost)
- [x] PC in consecrated room is more resistant to paralysis (40% boost) and life drain (50% boost)
- [x] Undead/demon enemy in consecrated room takes more damage from holy-typed attacks (10% reduction in their holy immunity)
- [x] Effects are also applied to enemies in the room (universal scope — verify a paralyze cast on undead inside the consecration is more likely to be resisted)

### Spam check
- [x] No "can now be renewed" messages firing every few seconds
- [x] No empty-newline spam from buff wear-offs
- [x] Single ambient pulse to adjacent rooms every ~18s, not every tick

### Help and news
- [x] `help consecrate` returns the new help text
- [x] `news` shows the consecrate announcement