### PR TITLE
fix UBSan upcast warning in doGive coin smuggling

### DIFF
--- a/code/code/misc/inventory.cc
+++ b/code/code/misc/inventory.cc
@@ -979,12 +979,12 @@ int TBeing::doGive(const sstring& oarg, giveTypeT flags) {
     }
 
     if (vict) {
+      // int amount smuggled through the pointer slot. Cast to TThing* (the
+      // param's actual type) so no implicit derived->base upcast happens —
+      // UBSan's alignment check fires on the upcast even without a deref.
+      // Spec procs unpack with (long int)o.
       rc = vict->checkSpec(this, CMD_MOB_GIVEN_COINS, arg.c_str(),
-        reinterpret_cast<TObj*>(static_cast<intptr_t>(
-          amount)));  // casts: int amount is passed through what is normally a
-                      // pointer argument, so cast it to a wider type (should be
-                      // safe, unless the proc tries to cast it back to a
-                      // pointer. Right now they don't.)
+        reinterpret_cast<TThing*>(static_cast<intptr_t>(amount)));
 
       if (IS_SET_DELETE(rc, DELETE_THIS)) {
         delete vict;


### PR DESCRIPTION
## Summary

Fixes #673. UBSan was reporting `upcast of misaligned address ... for type 'TObj'` on every `give <amount> talens <vict>` — `inventory.cc:983` cast the `int amount` to `TObj*` to smuggle it through the `checkSpec` pointer parameter, and the implicit `TObj*` → `TThing*` upcast at the call site failed UBSan's alignment check (the bit pattern of small ints is never 8-byte aligned).

## Fix

Cast directly to `TThing*` (the param's actual type) so no implicit upcast happens. `reinterpret_cast` is explicit and bypasses UBSan's alignment check, and the dispatch glue at `spec_mobs.cc:108` already does `reinterpret_cast<TObj*>(t2)` to translate back for the spec_proc.

Verified all 4 spec_procs that handle `CMD_MOB_GIVEN_COINS` (`loanShark`, `rumorMonger`, `beggar`, `idCardProvider`) unpack the smuggled value with `(long int)o` and never dereference, so the fix is safe end-to-end.

Updated the surrounding comment to explain *why* `TThing*` specifically and to point future readers at the unpack convention.

## Test plan

Build with UBSan enabled (dev-clang preset is the default), then exercise each handler with `give <N> talens <mob>`. Confirm no UBSan report appears in the log and that the existing per-mob behavior is unchanged.

- [x] **beggar** (spec_proc 17) — vnum **601** "a beggar". Expect tier-based responses by amount (`< 50`: insult; `< 250`: thanks; `< 1000`: emote; `< 10000`: staggered; `< 100000`: speechless; `>=`: passes out)
- [x] **rumorMonger** (spec_proc 114) — vnum **113** "an old sage" (also 403 Madame Alexis, 457 the town gossip). Below the rumor's price → "Those that are GENEROUS are often rewarded"; at/above → speaks a random rumor
- [x] **loanShark** (spec_proc 189) — vnum **31764** "Monti". Take out a loan, then `give <amt> talens monti` to repay; verify principal/interest math and that paying the full amount clears the loan
- [x] **idCardProvider** (spec_proc 213) — vnum **91** "the Grimhaven employment agent". `< 50` talens → asks for 50; `>= 50` → issues an ID card with character DOB
- [x] Plain PC-to-PC `give <N> talens <player>` — should be silent (no spec_proc), just the standard transfer + the existing log lines from the issue