### PR TITLE
update duration and refactor

### DIFF
--- a/code/code/disc/disc_mage_air.cc
+++ b/code/code/disc/disc_mage_air.cc
@@ -1227,12 +1227,11 @@ int castTornado(TBeing* caster) {
 namespace {
 
   // Returns false when affectJoin can't renew an existing non-expired affect.
-  // GroupCastMessages::Suppressed silences affectJoin's "can't increase
-  // duration" message so group-cast loops roll up a single epilogue instead
-  // of one message per target.  See disc_mage_group.h.
+  // SILENT_YES silences affectJoin's "can't increase duration" message so
+  // group-cast loops roll up a single epilogue instead of one message per
+  // target.
   [[nodiscard]] bool applyFeatheryDescent(TBeing* caster, TBeing* victim,
-    int level, int duration,
-    GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int level, int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_FEATHERY_DESCENT;
     aff.level = level;
@@ -1241,7 +1240,7 @@ namespace {
     aff.location = APPLY_NONE;
     aff.bitvector = 0;
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     act("$N seems lighter on $S feet!", false, caster, nullptr, victim,
@@ -1271,7 +1270,7 @@ namespace {
     int duration = caster->durationModify(SPELL_FEATHERY_DESCENT,
       level * Pulse::UPDATES_PER_MUDHOUR);
     if (crit)
-      duration >>= 1;
+      duration *= 2;
     return duration;
   }
 
@@ -1332,8 +1331,7 @@ int castFeatheryDescent(TBeing* caster, TBeing* victim) {
         discArray[SPELL_FEATHERY_DESCENT]->alignMod);
   } else {
     bool anyBuffed = forEachGroupBuffTarget(caster, [&](TBeing* target) {
-      if (!applyFeatheryDescent(caster, target, level, duration,
-            GroupCastMessages::Suppressed))
+      if (!applyFeatheryDescent(caster, target, level, duration, SILENT_YES))
         return false;
       caster->reconcileHelp(target,
         discArray[SPELL_FEATHERY_DESCENT]->alignMod);
@@ -1353,7 +1351,7 @@ namespace {
 
   // See applyFeatheryDescent for quiet/return semantics.
   [[nodiscard]] bool applyFly(TBeing* caster, TBeing* victim, int level,
-    int duration, GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_FLY;
     aff.level = level;
@@ -1366,7 +1364,7 @@ namespace {
     weightCorrectDuration(victim, &aff);
 
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     victim->sendTo("You feel much \"lighter\"!\n\r");
@@ -1392,7 +1390,7 @@ namespace {
     int duration =
       caster->durationModify(SPELL_FLY, 3 * Pulse::UPDATES_PER_MUDHOUR * level);
     if (crit)
-      duration >>= 1;
+      duration *= 2;
     return duration;
   }
 
@@ -1467,8 +1465,7 @@ int castFly(TBeing* caster, TBeing* victim) {
     bool anyBuffed = forEachGroupBuffTarget(
       caster,
       [&](TBeing* target) {
-        if (!applyFly(caster, target, level, duration,
-              GroupCastMessages::Suppressed))
+        if (!applyFly(caster, target, level, duration, SILENT_YES))
           return false;
         caster->reconcileHelp(target, discArray[SPELL_FLY]->alignMod);
         return true;
@@ -1680,7 +1677,7 @@ namespace {
 
   // See applyFeatheryDescent for quiet/return semantics.
   [[nodiscard]] bool applyFalconWings(TBeing* caster, TBeing* victim, int level,
-    int duration, GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_FALCON_WINGS;
     aff.level = level;
@@ -1691,7 +1688,7 @@ namespace {
     weightCorrectDuration(victim, &aff);
 
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     victim->sendTo("Feathers sprout from your arms!\n\r");
@@ -1720,7 +1717,7 @@ namespace {
     int duration = caster->durationModify(SPELL_FALCON_WINGS,
       3 * Pulse::UPDATES_PER_MUDHOUR);
     if (crit)
-      duration >>= 1;
+      duration *= 2;
     return duration;
   }
 
@@ -1783,8 +1780,7 @@ int castFalconWings(TBeing* caster, TBeing* victim) {
     bool anyBuffed = forEachGroupBuffTarget(
       caster,
       [&](TBeing* target) {
-        if (!applyFalconWings(caster, target, level, duration,
-              GroupCastMessages::Suppressed))
+        if (!applyFalconWings(caster, target, level, duration, SILENT_YES))
           return false;
         caster->reconcileHelp(target, discArray[SPELL_FALCON_WINGS]->alignMod);
         return true;

--- a/code/code/disc/disc_mage_group.h
+++ b/code/code/disc/disc_mage_group.h
@@ -2,14 +2,9 @@
 
 #include <functional>
 
-class TBeing;
+#include "enum.h"
 
-// Whether an applyX helper should let affectJoin emit its own
-// "can't increase the duration of that effect any further" message.
-// Single-target casts want Verbose so the user sees feedback when re-casting
-// on an already-buffed target; group casts want Suppressed so the per-target
-// messages don't spam, leaving the caller to roll up a single epilogue.
-enum class GroupCastMessages { Verbose, Suppressed };
+class TBeing;
 
 // Iterates the caster's room, applying applyFn to each TBeing the caster
 // considers in-group.  skipFn is consulted before applyFn and lets per-spell

--- a/code/code/disc/disc_mage_sorcery.cc
+++ b/code/code/disc/disc_mage_sorcery.cc
@@ -1246,8 +1246,7 @@ namespace {
   // See applyFeatheryDescent (disc_mage_air.cc) for quiet/return semantics.
   // The caller plays the room sound once for the whole cast, not per target.
   [[nodiscard]] bool applySorcerersGlobe(TBeing* caster, TBeing* victim,
-    int level, int duration,
-    GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int level, int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_SORCERERS_GLOBE;
     aff.level = level;
@@ -1257,7 +1256,7 @@ namespace {
     aff.bitvector = 0;
 
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     act("$n is instantly surrounded by a hardened wall of air!", false, victim,
@@ -1316,14 +1315,14 @@ int sorcerersGlobe(TBeing* caster, TBeing* victim) {
   taskDiffT diff;
 
   if (!bPassMageChecks(caster, SPELL_SORCERERS_GLOBE, victim))
-    return FALSE;
+    return false;
 
   lag_t rounds = discArray[SPELL_SORCERERS_GLOBE]->lag;
   diff = discArray[SPELL_SORCERERS_GLOBE]->task;
 
   start_cast(caster, victim, nullptr, caster->roomp, SPELL_SORCERERS_GLOBE,
     diff, 1, "", rounds, caster->in_room, 0, 0, true, 0);
-  return TRUE;
+  return true;
 }
 
 int castSorcerersGlobe(TBeing* caster, TBeing* victim) {
@@ -1345,8 +1344,7 @@ int castSorcerersGlobe(TBeing* caster, TBeing* victim) {
     }
   } else {
     bool anyBuffed = forEachGroupBuffTarget(caster, [&](TBeing* target) {
-      if (!applySorcerersGlobe(caster, target, level, duration,
-            GroupCastMessages::Suppressed))
+      if (!applySorcerersGlobe(caster, target, level, duration, SILENT_YES))
         return false;
       caster->reconcileHelp(target, discArray[SPELL_SORCERERS_GLOBE]->alignMod);
       return true;

--- a/code/code/disc/disc_mage_spirit.cc
+++ b/code/code/disc/disc_mage_spirit.cc
@@ -1036,7 +1036,7 @@ namespace {
   // Returns false when affectJoin can't renew an existing non-expired affect.
   // See applyFeatheryDescent (disc_mage_air.cc) for quiet/return semantics.
   [[nodiscard]] bool applyStealth(TBeing* caster, TBeing* victim, int level,
-    int duration, GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_STEALTH;
     aff.level = level;
@@ -1045,7 +1045,7 @@ namespace {
     aff.location = APPLY_NOISE;
     aff.bitvector = 0;
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     act("$N seems more stealthy!", false, caster, nullptr, victim, TO_NOTVICT,
@@ -1136,8 +1136,7 @@ int castStealth(TBeing* caster, TBeing* victim) {
       caster->reconcileHelp(victim, discArray[SPELL_STEALTH]->alignMod);
   } else {
     bool anyBuffed = forEachGroupBuffTarget(caster, [&](TBeing* target) {
-      if (!applyStealth(caster, target, level, duration,
-            GroupCastMessages::Suppressed))
+      if (!applyStealth(caster, target, level, duration, SILENT_YES))
         return false;
       caster->reconcileHelp(target, discArray[SPELL_STEALTH]->alignMod);
       return true;
@@ -1153,7 +1152,7 @@ namespace {
   // See applyFeatheryDescent (disc_mage_air.cc) for quiet/return semantics.
   // The caller plays the room sound once for the whole cast, not per target.
   [[nodiscard]] bool applyAccelerate(TBeing* caster, TBeing* victim, int level,
-    int duration, GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_ACCELERATE;
     aff.level = level;
@@ -1162,7 +1161,7 @@ namespace {
     aff.location = APPLY_NONE;
     aff.bitvector = 0;
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     act("$N seems more nimble on $S feet!", false, caster, nullptr, victim,
@@ -1258,8 +1257,7 @@ int castAccelerate(TBeing* caster, TBeing* victim) {
     }
   } else {
     bool anyBuffed = forEachGroupBuffTarget(caster, [&](TBeing* target) {
-      if (!applyAccelerate(caster, target, level, duration,
-            GroupCastMessages::Suppressed))
+      if (!applyAccelerate(caster, target, level, duration, SILENT_YES))
         return false;
       caster->reconcileHelp(target, discArray[SPELL_ACCELERATE]->alignMod);
       return true;
@@ -1278,7 +1276,7 @@ namespace {
   // See applyFeatheryDescent (disc_mage_air.cc) for quiet/return semantics.
   // The caller plays the room sound once for the whole cast, not per target.
   [[nodiscard]] bool applyHaste(TBeing* caster, TBeing* victim, int level,
-    int duration, GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_HASTE;
     aff.level = level;
@@ -1287,7 +1285,7 @@ namespace {
     aff.location = APPLY_NONE;
     aff.bitvector = 0;
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_YES,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     act("$N has gained a bounce in $S step!", false, caster, nullptr, victim,
@@ -1375,8 +1373,7 @@ int castHaste(TBeing* caster, TBeing* victim) {
     }
   } else {
     bool anyBuffed = forEachGroupBuffTarget(caster, [&](TBeing* target) {
-      if (!applyHaste(caster, target, level, duration,
-            GroupCastMessages::Suppressed))
+      if (!applyHaste(caster, target, level, duration, SILENT_YES))
         return false;
       caster->reconcileHelp(target, discArray[SPELL_HASTE]->alignMod);
       return true;

--- a/code/code/disc/disc_mage_water.cc
+++ b/code/code/disc/disc_mage_water.cc
@@ -970,8 +970,7 @@ namespace {
 
   // See applyFeatheryDescent (disc_mage_air.cc) for quiet/return semantics.
   [[nodiscard]] bool applyGillsOfFlesh(TBeing* caster, TBeing* victim,
-    int level, int duration,
-    GroupCastMessages messages = GroupCastMessages::Verbose) {
+    int level, int duration, silentTypeT silent = SILENT_NO) {
     affectedData aff;
     aff.type = SPELL_GILLS_OF_FLESH;
     aff.level = level;
@@ -981,7 +980,7 @@ namespace {
     aff.location = APPLY_NONE;
     aff.bitvector = AFF_WATERBREATH;
     if (!victim->affectJoin(caster, &aff, AVG_DUR_NO, AVG_EFF_NO,
-          messages == GroupCastMessages::Verbose))
+          silent == SILENT_NO))
       return false;
 
     act("You become one with the fishes!", true, victim, nullptr, nullptr,
@@ -1011,7 +1010,7 @@ namespace {
     int duration = caster->durationModify(SPELL_GILLS_OF_FLESH,
       6 * Pulse::UPDATES_PER_MUDHOUR);
     if (crit)
-      duration >>= 1;
+      duration *= 2;
     return duration;
   }
 
@@ -1069,16 +1068,13 @@ int castGillsOfFlesh(TBeing* caster, TBeing* victim) {
   int duration = gillsOfFleshDuration(caster, crit);
 
   if (victim) {
-    if (canBeGilled(caster, victim))
-      return false;
     if (applyGillsOfFlesh(caster, victim, level, duration))
       caster->reconcileHelp(victim, discArray[SPELL_GILLS_OF_FLESH]->alignMod);
   } else {
     bool anyBuffed = forEachGroupBuffTarget(
       caster,
       [&](TBeing* target) {
-        if (!applyGillsOfFlesh(caster, target, level, duration,
-              GroupCastMessages::Suppressed))
+        if (!applyGillsOfFlesh(caster, target, level, duration, SILENT_YES))
           return false;
         caster->reconcileHelp(target,
           discArray[SPELL_GILLS_OF_FLESH]->alignMod);


### PR DESCRIPTION
Some small fixes on group cast:

 1. Crit doubles duration — >>= 1 → *= 2 in featheryDescentDuration, flyDuration, falconWingsDuration, gillsOfFleshDuration. Per the user policy, all four buff durations now
  match the existing *= 2 behavior of stealth/accelerate/haste/sorcerersGlobe. Note: applyGillsOfFlesh sets aff.renew = duration, so a crit cast now also doubles the renewal
  window — consistent with "crit means 2× duration end-to-end."
  2. Dropped redundant canBeGilled in castGillsOfFlesh victim branch (disc_mage_water.cc:1071-1072) — the start_cast wrapper at line 1045 already gates on canBeGilled, and innate
  waterbreath status can't change mid-cast. This resolves both #2 (bSuccess no longer rolled before the check) and #10 (gills now symmetric with the other six converted spells).
  The group skipFn still calls canBeGilled because group cast bypasses the wrapper for non-target group members.
  3. GroupCastMessages replaced with silentTypeT — deleted the enum from disc_mage_group.h, included enum.h. Updated all 8 apply helpers across air/water/spirit/sorcery and all 7
  group call sites. Comment block in applyFeatheryDescent updated to reference SILENT_YES instead of the old enum.
  4. TRUE/FALSE → true/false in sorcerersGlobe(TBeing*, TBeing*) — the start_cast wrapper that this branch modified.