### PR TITLE
Rebalance haste/celerite: non-stacking, tuned lockout, faster casting

### DIFF
--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -2246,14 +2246,9 @@ void TBeing::blowCount(bool check, float& fx, float& fy) const {
     }
   }
 
-  // haste
-  if (affectedBySpell(SPELL_HASTE) && getPosition() >= POSITION_STANDING) {
-    if (fx > 0.0)
-      fx += 0.5;
-    if (fy > 0.0)
-      fy += 0.5;
-  }
-  if (affectedBySpell(SPELL_CELERITE) && getPosition() >= POSITION_STANDING) {
+  // haste/celerite — do not stack for extra attacks
+  if ((affectedBySpell(SPELL_HASTE) || affectedBySpell(SPELL_CELERITE)) &&
+      getPosition() >= POSITION_STANDING) {
     if (fx > 0.0)
       fx += 0.5;
     if (fy > 0.0)

--- a/code/code/misc/spelltask.cc
+++ b/code/code/misc/spelltask.cc
@@ -889,6 +889,29 @@ int TBeing::cast_spell(TBeing* ch, cmdTypeT cmd, int pulse) {
         ch->spelltask->distracted = 0;
       }
 
+      // Haste/Celerite: 25% chance each round to accelerate casting
+      if (rounds > 1 && !ch->spelltask->distracted &&
+          (ch->affectedBySpell(SPELL_HASTE) ||
+            ch->affectedBySpell(SPELL_CELERITE))) {
+        if (::number(1, 100) <= 25) {
+          if (typ == SPELL_CASTER)
+            colorAct(COLOR_SPELLS,
+              "<c>Your magical haste quickens the spell's formation.<z>", false,
+              ch, nullptr, nullptr, TO_CHAR);
+          else if (typ == SPELL_PRAYER)
+            colorAct(COLOR_SPELLS,
+              "<c>Your heightened speed lets you complete the prayer's "
+              "gestures faster.<z>",
+              false, ch, nullptr, nullptr, TO_CHAR);
+          else if (typ == SPELL_DANCER)
+            colorAct(COLOR_SPELLS,
+              "<B>Your hastened movements quicken the ritual.<z>", false, ch,
+              nullptr, nullptr, TO_CHAR);
+          ch->spelltask->rounds--;
+          rounds--;
+        }
+      }
+
       // set counter
       if (IS_SET(ch->spelltask->flags, CASTFLAG_CAST_INDEFINITE)) {
         counter = 1;

--- a/code/code/misc/utility.cc
+++ b/code/code/misc/utility.cc
@@ -1547,11 +1547,11 @@ void TPerson::addToWait(int orig_amt) {
   if (affectedBySpell(SPELL_ACCELERATE))
     mod = 80;
   if (affectedBySpell(SPELL_CHEVAL))
-    mod = 75;
+    mod = 80;
   if (affectedBySpell(SPELL_HASTE))
-    mod = 60;
+    mod = 70;
   if (affectedBySpell(SPELL_CELERITE))
-    mod = 60;
+    mod = 70;
 
   int amt = orig_amt * mod / 100;
 

--- a/lib/help/_spells/celerite
+++ b/lib/help/_spells/celerite
@@ -2,5 +2,12 @@ Celerite is an advanced form of the Cheval ritual. The houngan gains all of
 the advantages of the possession and additionally receives an extra 1/2 an
 attack with each hand during combat.
 
+While under celerite there is a chance each round of any tasked spell,
+prayer, or ritual to shave a round off the casting time.
+
 WARNING: The loa do NOT like the houngan to use their aid in conjunction
-         with magical abilities of the same nature.
+         with magical abilities of the same nature. Celerite and haste
+         do not stack -- being under both grants only one set of bonus
+         attacks, not two.
+
+See Also: HASTE, CHEVAL

--- a/lib/help/_spells/haste
+++ b/lib/help/_spells/haste
@@ -1,10 +1,16 @@
-Haste is a radically improved acceleration spell.  The target gains all the
-advantages of acceleration, and additionally receives an extra 1/2 an attack
-with each hand during combat.
+Haste is a radically improved acceleration spell.  The target gains all
+the advantages of acceleration, and additionally receives an extra 1/2 an
+attack with each hand during combat.
+
+While hasted, there is a chance each round of any tasked spell, prayer,
+or ritual to shave a round off the casting time.
 
 Duration is similar to the acceleration spell.
 
 Haste can be cast on yourself, on another character, or with no target
 to buff your group members in the room.
 
-See Also: ACCELERATE
+Note: Haste and celerite do not stack -- being under both grants only
+one set of bonus attacks, not two.
+
+See Also: ACCELERATE, CELERITE

--- a/lib/txt/news.d/2026-05-12-haste-celerite-rebalance
+++ b/lib/txt/news.d/2026-05-12-haste-celerite-rebalance
@@ -1,0 +1,20 @@
+Rebalanced haste, celerite, and cheval.
+
+1) Haste and celerite no longer stack for bonus attacks.
+   - Being under both grants only one set of extra attacks, not two.
+   - Stacking the two has always been against the spirit of celerite's
+     warning text; the mechanics now match.
+
+2) Adjusted the command lockout reduction granted by these spells.
+   - Haste:     was 40% reduction, now 30%.
+   - Celerite:  was 40% reduction, now 30%.
+   - Cheval:    was 25% reduction, now 20%.
+   - Accelerate is unchanged at 20%.
+
+3) Haste and celerite now help you cast tasked spells faster.
+   - Each round of a tasked spell, prayer, or ritual has a 25% chance
+     to be shaved off while you are under haste or celerite.
+   - This applies to mage spells, cleric prayers, and shaman rituals
+     alike.
+
+See HELP HASTE and HELP CELERITE for full details.


### PR DESCRIPTION
## Summary

- Haste and celerite no longer stack their bonus-attack effect — being under both grants one set of extra attacks instead of two (`offense.cc:blowCount`).
- Eased the command lockout reduction these spells provide so they're less of a must-have: haste/celerite 40% → 30%, cheval 25% → 20%, accelerate unchanged at 20% (`utility.cc:TPerson::addToWait`).
- While under haste or celerite, each round of a tasked spell/prayer/ritual has a 25% chance to be shaved off (`spelltask.cc:cast_spell`).
- Updated `lib/help/_spells/haste` and `lib/help/_spells/celerite` to reflect the new behavior and added a news item.

## Test plan

- [x] Cast haste and celerite on the same target; confirm `blowCount` only grants one +0.5 attack pair.
- [x] Verify command lag with each of accelerate / haste / celerite / cheval matches the new mods.
- [x] Cast a multi-round spell under haste (and separately under celerite); confirm the colored "quickens" message fires and rounds drop on roughly 25% of ticks.
- [x] Confirm the casting-shave doesn't trigger when distracted or on a 1-round cast.
- [x] `help haste`, `help celerite`, and news file render correctly in-game.