### PR TITLE
Helpfiles: add skulk, refresh backstab and stab for stealth changes

### DIFF
--- a/lib/help/_skills/backstab
+++ b/lib/help/_skills/backstab
@@ -3,11 +3,16 @@ Syntax: backstab <victim>
 Backstab is an exceptionally powerful attack whereby a small, pierce-style
 weapon is thrust violently into the victim's back.
 
-Only certain weapons may be used to backstab with (small and pointy) and in
-addition, the attacker MUST be moving silently enough to be undetected.  A
-victim in a fight is slightly easier to hit.  A thief must be sneaking to
-successfully backstab and a thief's chances to hit a backstab will dramatically
-improve if the thief is silent.
+Only certain weapons may be used to backstab with (small and pointy), and the
+attacker must approach without being noticed.  Noisy armor or a wary,
+watchful victim will reduce the chance of the strike landing cleanly.  A
+victim already engaged in a fight is slightly easier to hit.
+
+The thief's stealth posture matters greatly.  Sneaking, hiding, and skulking
+each lend their own bonus to the attempt, and a backstab launched from any
+of those states is far more likely to find its mark.  Entering combat this
+way breaks cover -- the thief leaps from their hiding spot, and sneak or
+skulk fall away as the attack begins.
 
 Backstabbing is a physical attack, and as such, requires the murderer be able
 to successfully hit the victim.  Failure to do so will cause the attempt to

--- a/lib/help/_skills/skulk
+++ b/lib/help/_skills/skulk
@@ -1,0 +1,28 @@
+Syntax: skulk [option]
+Options: off, stop
+
+Skulking is a thief's prepared stealth posture, taught alongside hide and
+sneak.  Rather than a single quick attempt at concealment, the thief spends
+time settling into a low, watchful stance, blending into shadows and
+adjusting movement until any approach can be made on careful terms.
+
+Skulking takes time to enter.  The thief cannot skulk while in combat or
+mounted, and the build-up is tiring -- movement drains steadily during the
+attempt, and being attacked aborts it outright.  More skilled thieves
+prepare the posture faster and at lower cost.
+
+Once the posture is set, the thief gains a marked bonus to perception and
+agility, and is harder for others to see.  These benefits last for a
+considerable time, but are removed by the usual things that disturb
+stealth.
+
+A skulking thief also stores an extra burst of focus for the moment they
+break cover.  When the thief next launches a special combat skill --
+backstab, stab, slam and the like -- that stored focus is spent for an
+additional bonus on the attempt.  The bonus is consumed regardless of
+whether the attack lands.
+
+To stop skulking, type "skulk off" or "skulk stop".  Doing so clears only
+the skulk posture; an unrelated sneak or hide is left alone.
+
+See Also: HIDE, SNEAK, BACKSTAB, STAB

--- a/lib/help/_skills/stab
+++ b/lib/help/_skills/stab
@@ -5,4 +5,9 @@ into the victim and then twist it in the wound.  The attack form typically
 causes the thief to over-extend their attack and it may take a round or two
 for the murderer to recover from this attack.
 
+Like other special combat skills, stab is sharper when the thief moves into
+it from stealth.  Sneaking, hiding, and skulking each improve the chance of
+landing the strike, and any of those stealth states is consumed when the
+attack opens combat.
+
 Stabbing is slightly tiring.


### PR DESCRIPTION
## Summary
- Adds `lib/help/_skills/skulk` — covers the build-up, the persistent perception/agility/CBS buffs, the one-shot stealth bonus on the next special-attack skill, and the `skulk off` / `skulk stop` controls.
- Refreshes `backstab` and `stab` to reflect the recent widening of stealth-as-attack-bonus across specialAttack-routed skills (PRs that added skulk and broadened `willBreakHide`). All three of sneak, hide, and skulk now lend a bonus to these attempts, and any of those stealth states is consumed when combat opens.
- Drops the old `backstab` claim that a thief MUST be sneaking — the code has never required it; sneak/hide/skulk are bonuses, and noisy armor / a wary victim are the actual penalties.

## Notes
- Helpfiles only. No code changes, no rebuild required.
- Did not touch the `hide` helpfile or create one for the `fighting` thief discipline (no helpfile exists for that discipline today).

## Test plan
- [ ] In-game: `help skulk`, `help backstab`, `help stab` render the updated text
- [ ] No formatting regressions (line wrap matches surrounding files)