### PR TITLE
Guard impactSpec body-part lookups and add advanced-kicking impact

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -369,6 +369,8 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
   // This handles messaging, bleeding, equipment damage, etc.
   wearSlotT attackerLimb = isHoldingShield ? getSecondaryHold() : atkLimb;
+  if (!victim->hasPart(limb))
+    limb = victim->getPartHit(this, true);
   shieldDam += impactSpec(this, victim, attackerLimb, limb);
 
   if (reconcileDamage(victim, shieldDam, SKILL_BASH) == -1)

--- a/code/code/cmd/cmd_chop.cc
+++ b/code/code/cmd/cmd_chop.cc
@@ -120,6 +120,9 @@ static int chopHit(TBeing* c, TBeing* v, int score) {
     handSlot = WEAR_HAND_L;
   }
 
+  if (!v->hasPart(pos))
+    pos = v->getPartHit(c, true);
+
   // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
   dam += impactSpec(c, v, handSlot, pos);
 

--- a/code/code/cmd/cmd_headbutt.cc
+++ b/code/code/cmd/cmd_headbutt.cc
@@ -102,7 +102,7 @@ int TBeing::headbuttHit(TBeing* victim) {
     static constexpr const char* headbutt_msg =
       "%s headbutt %s, slamming %s head into %s %s.";
 
-    const char* target_area;
+    sstring target_area;
     bool causes_wait = false;
 
     if (hgt < victim->getPartMinHeight(ITEM_WEAR_LEGS)) {
@@ -140,7 +140,12 @@ int TBeing::headbuttHit(TBeing* victim) {
       causes_wait = true;
     }
 
-    act(format(headbutt_msg) % "$n" % "$N" % "$s" % "$N's" % target_area, FALSE,
+    if (!victim->hasPart(pos)) {
+      pos = victim->getPartHit(this, true);
+      target_area = victim->describeBodySlot(pos);
+    }
+
+    act(format(headbutt_msg) % "$n" % "$N" % "$s" % "$N's" % target_area, false,
       this, 0, victim, TO_NOTVICT);
     act(format(headbutt_msg) % "You" % "$N" % "your" % "$S" % target_area,
       FALSE, this, 0, victim, TO_CHAR);

--- a/code/code/cmd/cmd_kick.cc
+++ b/code/code/cmd/cmd_kick.cc
@@ -304,6 +304,9 @@ static int kickHit(TBeing* caster, TBeing* victim, int score, int level,
     }
   }
 
+  if (!victim->hasPart(slot))
+    slot = victim->getPartHit(caster, true);
+
   // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
   dam += impactSpec(caster, victim, caster->getPrimaryFoot(), slot);
 

--- a/code/code/cmd/cmd_kneestrike.cc
+++ b/code/code/cmd/cmd_kneestrike.cc
@@ -135,7 +135,8 @@ int TBeing::kneestrikeMiss(TBeing* v, int type) {
       addToWait(combatRound(0.25));
 
       // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
-      dam += impactSpec(v, this, v->getPrimaryFoot(), WEAR_BODY);
+      dam += impactSpec(v, this, v->getPrimaryFoot(),
+        hasPart(WEAR_BODY) ? WEAR_BODY : getPartHit(v, true));
 
       if (v->reconcileDamage(this, dam, DAMAGE_KICK_HEAD) == -1)
         return DELETE_THIS;
@@ -345,6 +346,8 @@ int TBeing::kneestrikeHit(TBeing* victim) {
   // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
   // This includes automatic hardness-based damage to equipment/limbs
   caster_pos = (::number(0, 1) ? WEAR_LEG_L : WEAR_LEG_R);
+  if (!victim->hasPart(pos))
+    pos = victim->getPartHit(this, true);
   dam += impactSpec(this, victim, caster_pos, pos);
   if ((rc = reconcileDamage(victim, dam, dam_type)) == -1)
     return DELETE_VICT;

--- a/code/code/cmd/cmd_stomp.cc
+++ b/code/code/cmd/cmd_stomp.cc
@@ -159,6 +159,9 @@ int TBeing::stompHit(TBeing* victim) {
       TO_VICT, ANSI_RED);
   }
 
+  if (!victim->hasPart(targetLimb))
+    targetLimb = victim->getPartHit(this, true);
+
   // Use impactSpec to handle all impact effects (spikes, thornflesh, hardness)
   dam += impactSpec(this, victim, getPrimaryFoot(), targetLimb);
 

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -4368,17 +4368,22 @@ int TBeing::oneHit(TBeing* vict, primaryTypeT isprimary, TThing* weapon,
 
     if (mess_sent == 0) {
       if (doesKnowSkill(SKILL_ADVANCED_KICKING) && !weapon && isPc()) {
-        // switch some "hits" to "kicks"
-        // this is strictly textual and doesn't impact damage at all
-        // damage modification form this is taken into account in ADVKICK
-        // modification to number of hits per round
+        // switch some "hits" to "kicks" -- the hit/kick split is textual;
+        // advanced kicking's damage comes from its modification to the
+        // number of hits per round (handled in ADVKICK).
         double iskick = getSkillValue(SKILL_ADVANCED_KICKING) / 100.0;
         iskick += 1.25;
         iskick *= (isprimary ? 0.6 : 0.4);
 
-        if (*f <= iskick)
+        if (*f <= iskick) {
           normalHitMessage(vict, NULL, TYPE_KICK, dam, part_hit);
-        else
+          // A strong kick drives the boot home: route through impactSpec so
+          // spiked/heavy footwear adds real damage and procs as a follow-on
+          // to the kick line above.
+          if (isStrong())
+            dam += impactSpec(this, vict,
+              isprimary ? getPrimaryFoot() : getSecondaryFoot(), part_hit);
+        } else
           normalHitMessage(vict, NULL, w_type, dam, part_hit);
       } else
         normalHitMessage(vict, weapon, w_type, dam, part_hit);

--- a/code/code/obj/obj_general_weapon.cc
+++ b/code/code/obj/obj_general_weapon.cc
@@ -264,12 +264,14 @@ int hardHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT vicLimb, wearSlotT 
       // Case 1: Weapon hits victim's equipment
     if (weap && vicEq) {
       static constexpr const char* weap_vs_eq_msg =
-        "%s $p strikes %s $P with a solid impact!";
+        "%s %s strikes %s %s with a solid impact!";
       dam += weap->getWeight()/4;
 
-      act(format(weap_vs_eq_msg) % "Your" % "$N's", FALSE, ch, weap, vicEq, TO_CHAR);
-      act(format(weap_vs_eq_msg) % "$n's" % "your", FALSE, ch, weap, vicEq, TO_VICT);
-      act(format(weap_vs_eq_msg) % "$n's" % "$N's", FALSE, ch, weap, vicEq, TO_NOTVICT);
+      sstring weapNoun = fname(weap->name);
+      sstring vicEqNoun = fname(vicEq->name);
+      act(format(weap_vs_eq_msg) % "Your" % weapNoun % "$N's" % vicEqNoun, false, ch, weap, victim, TO_CHAR);
+      act(format(weap_vs_eq_msg) % "$n's" % weapNoun % "your" % vicEqNoun, false, ch, weap, victim, TO_VICT);
+      act(format(weap_vs_eq_msg) % "$n's" % weapNoun % "$N's" % vicEqNoun, false, ch, weap, victim, TO_NOTVICT);
       vicEq->damageItem(eqDamage);
 
       if (vicEq->getStructPoints() <= 0 && !vicEq->makeScraps()) {
@@ -280,13 +282,14 @@ int hardHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT vicLimb, wearSlotT 
     // Case 2: Weapon hits victim's body part
     else if (weap && !vicEq) {
       static constexpr const char* weap_vs_body_msg =
-        "%s $p strikes %s %s with a solid impact!";
+        "%s %s strikes %s %s with a solid impact!";
       dam += weap->getWeight()/4;
 
+      sstring weapNoun = fname(weap->name);
       sstring bodyPart = victim->describeBodySlot(vicLimb);
-      act(format(weap_vs_body_msg) % "Your" % "$N's" % bodyPart, FALSE, ch, weap, victim, TO_CHAR);
-      act(format(weap_vs_body_msg) % "$n's" % "your" % bodyPart, FALSE, ch, weap, victim, TO_VICT);
-      act(format(weap_vs_body_msg) % "$n's" % "$N's" % bodyPart, FALSE, ch, weap, victim, TO_NOTVICT);
+      act(format(weap_vs_body_msg) % "Your" % weapNoun % "$N's" % bodyPart, false, ch, weap, victim, TO_CHAR);
+      act(format(weap_vs_body_msg) % "$n's" % weapNoun % "your" % bodyPart, false, ch, weap, victim, TO_VICT);
+      act(format(weap_vs_body_msg) % "$n's" % weapNoun % "$N's" % bodyPart, false, ch, weap, victim, TO_NOTVICT);
       if (victim->isLimbFlags(vicLimb, PART_BRUISED)) {
         victim->incrementBruiseStack(vicLimb, 100);
       } else {
@@ -296,12 +299,13 @@ int hardHit(TBeing* victim, TBeing* ch, TObj* obj, wearSlotT vicLimb, wearSlotT 
     // Case 3: Body part hits victim's equipment
     else if (!weap && vicEq) {
       static constexpr const char* body_vs_eq_msg =
-        "%s %s strikes %s $p with a solid impact!";
+        "%s %s strikes %s %s with a solid impact!";
 
       sstring bodyPart = ch->describeBodySlot(chLimb);
-      act(format(body_vs_eq_msg) % "Your" % bodyPart % "$N's", FALSE, ch, vicEq, victim, TO_CHAR);
-      act(format(body_vs_eq_msg) % "$n's" % bodyPart % "your", FALSE, ch, vicEq, victim, TO_VICT);
-      act(format(body_vs_eq_msg) % "$n's" % bodyPart % "$N's", FALSE, ch, vicEq, victim, TO_NOTVICT);
+      sstring vicEqNoun = fname(vicEq->name);
+      act(format(body_vs_eq_msg) % "Your" % bodyPart % "$N's" % vicEqNoun, false, ch, vicEq, victim, TO_CHAR);
+      act(format(body_vs_eq_msg) % "$n's" % bodyPart % "your" % vicEqNoun, false, ch, vicEq, victim, TO_VICT);
+      act(format(body_vs_eq_msg) % "$n's" % bodyPart % "$N's" % vicEqNoun, false, ch, vicEq, victim, TO_NOTVICT);
       vicEq->damageItem(eqDamage);
       if (vicEq->getStructPoints() <= 0 && !vicEq->makeScraps()) {
          delete vicEq;
@@ -333,8 +337,8 @@ int spikesBreak(TBeing* victim, TBeing* ch, TObj* obj) {
     return 0;
 
   if ((obj->isObjStat(ITEM_SPIKED)) && percentChance(25) && victim->isTough()) {
-    static constexpr const char* catch_msg = "$n's $o catches on $N's $o!";
-    static constexpr const char* spikes_break_msg = "Some spikes break off, damaging $n's $o!";
+    static constexpr const char* catch_msg = "%s $o catches on %s's $o!";
+    static constexpr const char* spikes_break_msg = "Some spikes break off, damaging %s $o!";
 
     obj->addToStructPoints(-dam);
     obj->addToMaxStructPoints(-1);
@@ -383,7 +387,7 @@ int spikesBreak(TBeing* victim, TBeing* ch, TObj* obj) {
 
 int impactSpec(TBeing* ch, TBeing* victim, wearSlotT damSource, wearSlotT pos) {
   // Get the object at the damage source (if any)
-  if (!ch || !victim || pos == WEAR_NOWHERE) {
+  if (!ch || !victim || pos == WEAR_NOWHERE || !ch->hasPart(damSource)) {
     return 0;
   }
   TObj* obj = dynamic_cast<TObj*>(ch->equipment[damSource]);


### PR DESCRIPTION
## Summary

Makes impact effects (spikes, thornflesh, hardness via `impactSpec`/`hardHit`) robust when the targeted body part is absent, and extends impact damage to advanced kicking's textual "kick" hits.

## Changes

- **`impactSpec`**: bail early when the attacker lacks the damage-source limb (`!ch->hasPart(damSource)`), so footwear/limb lookups can't operate on a missing part.
- **bash / chop / headbutt / kick / kneestrike / stomp**: when the victim is missing the targeted limb, fall back to `getPartHit()` so the impact lands on an actual part. Headbutt also re-describes the target area so the message matches the part actually hit.
- **`oneHit` (advanced kicking)**: when advanced kicking converts a "hit" to a "kick" line and the attacker `isStrong()`, route through `impactSpec` so spiked/heavy footwear contributes real damage as a follow-on to the kick. Damage-per-round behavior from the hit/kick split is unchanged; this only adds the gear-based impact.
- **`hardHit` / `spikesBreak`**: replace `$p`/`$o` object substitutions with explicit `fname()` nouns and pass `victim` as the act target, so messages render the correct weapon/equipment names.

## Testing

- Builds clean under the default `dev-clang` preset (ASan/UBSan on).