### PR TITLE
Randomly trap locked/secret doors at zone reset

### DIFF
--- a/code/code/sys/db.cc
+++ b/code/code/sys/db.cc
@@ -2592,6 +2592,56 @@ void zoneData::closeDoors() {
   }
 }
 
+// Randomly trap closed locked and/or secret doors at zone reset.  Each locked
+// door has a 5% chance and each secret door a 5% chance (10% if both).  Damage
+// scales with the zone's average mob level; the trap type is fully random.
+// Already-trapped doors are skipped so builder- and player-set traps survive.
+void zoneData::trapDoors() {
+  const double avg = num_mobs ? mob_levels / num_mobs : 0.0;
+  const int maxDam = std::max(1, static_cast<int>(avg));
+  const int bottom = zone_nr ? (zone_table[zone_nr - 1].top + 1) : 0;
+
+  for (int rnum = bottom; rnum <= top; rnum++) {
+    TRoom* rp = real_roomp(rnum);
+    if (!rp)
+      continue;
+
+    for (dirTypeT dir = MIN_DIR; dir < MAX_DIR; dir++) {
+      roomDirData* exitp = rp->dir_option[dir];
+      if (!exitp || exitp->door_type == DOOR_NONE ||
+          !IS_SET(exitp->condition, EXIT_CLOSED) ||
+          IS_SET(exitp->condition,
+            EXIT_TRAPPED | EXIT_DESTROYED | EXIT_CAVED_IN))
+        continue;
+
+      int chance = 0;
+      if (IS_SET(exitp->condition, EXIT_LOCKED))
+        chance += 5;
+      if (IS_SET(exitp->condition, EXIT_SECRET))
+        chance += 5;
+      if (chance == 0 || number(1, 100) > chance)
+        continue;
+
+      const short trapInfo = number(DOOR_TRAP_POISON, DOOR_TRAP_PEBBLE);
+      const short trapDam = number(1, maxDam);
+
+      SET_BIT(exitp->condition, EXIT_TRAPPED);
+      exitp->trap_info = trapInfo;
+      exitp->trap_dam = trapDam;
+
+      // mirror onto the far side so the trap fires from either direction
+      if (TRoom* rp2 = real_roomp(exitp->to_room)) {
+        if (roomDirData* back = rp2->dir_option[rev_dir(dir)];
+            back && back->to_room == rnum) {
+          SET_BIT(back->condition, EXIT_TRAPPED);
+          back->trap_info = trapInfo;
+          back->trap_dam = trapDam;
+        }
+      }
+    }
+  }
+}
+
 // procZoneUpdate
 procZoneUpdate::procZoneUpdate(const int& p) {
   trigger_pulse = p;
@@ -3652,8 +3702,10 @@ void zoneData::resetZone(bool bootTime, bool findLoadPotential) {
       break;
   }
 
-  if (!findLoadPotential)
+  if (!findLoadPotential) {
     doGenericReset();  // sends CMD_GENERIC_RESET to all objects in zone
+    trapDoors();       // randomly trap locked/secret doors based on zone level
+  }
 
   this->age = 0;
 }

--- a/code/code/sys/db.h
+++ b/code/code/sys/db.h
@@ -224,6 +224,7 @@ class zoneData {
     bool isEmpty(void);
     void resetZone(bool bootTime, bool findLoadPotential = false);
     void closeDoors(void);
+    void trapDoors(void);
     void logError(char, const char*, int, int);
     void nukeMobs(void);
     void sendTo(sstring, int exclude_room = -1);


### PR DESCRIPTION
## Summary

Adds `zoneData::trapDoors()`, called at the end of `resetZone()` (on every reset, including boot). It gives locked and secret doors a chance to be trapped, scaling danger to the zone and rewarding groups that bring a thief.

## Behavior

- Iterates the zone's room range (same pattern as `closeDoors()`), all directions.
- Considers only **closed, real** doors that aren't already trapped/destroyed/caved-in.
- **Chance:** +5% if locked, +5% if secret (10% if both), resolved as one roll against the summed chance. Doors that are neither are not eligible.
- **Type:** fully random across all 15 door-trap types.
- **Damage:** `number(1, avgLevel)` d8 dice, where `avgLevel = mob_levels / num_mobs` (floored to at least 1 for mob-less zones) — the same average the `zone` command reports.
- **Both sides:** mirrors `EXIT_TRAPPED` + type + damage onto the far room's reverse exit (with the `back->to_room == in_room` guard from `task_trap_door`), so the trap fires from either direction.
- **Skips already-trapped doors:** builder `T`-command traps and player-set traps are preserved, never overwritten.

## Notes

- Trap state is in-memory only and re-rolls each reset — disarmed/triggered doors become eligible again on the next repop.
- Only sets condition bits and two shorts at reset time; no combat or deletion paths, so no DELETE-flag/iterator invariants are involved.
- Detection/disarm interaction is unchanged: a thief with detect trap gets the usual chance to spot it and decline to open, exactly like a trapped container.