### PR TITLE
Add disarm support for portal and arrow trap types

### DIFF
--- a/code/code/disc/disc_thief_looting.cc
+++ b/code/code/disc/disc_thief_looting.cc
@@ -204,12 +204,16 @@ int TTrap::disarmMe(TBeing* thief) {
 }
 
 int disarmTrapObj(TBeing* thief, TObj* trap) {
-  int rc;
-  rc = trap->disarmMe(thief);
-  if (IS_SET_DELETE(rc, DELETE_VICT)) {
-    return DELETE_THIS;
-  }
-  return FALSE;
+  int rc = trap->disarmMe(thief);
+  int ret = 0;
+  // A sprung trap may kill the thief (DELETE_VICT) and/or destroy the trap
+  // object itself (DELETE_ITEM, e.g. a portal TNT charge) - propagate both so
+  // disarmTrap deletes the object before unwinding the dead thief.
+  if (IS_SET_DELETE(rc, DELETE_VICT))
+    ret |= DELETE_THIS;
+  if (IS_SET_DELETE(rc, DELETE_ITEM))
+    ret |= DELETE_ITEM;
+  return ret;
 }
 
 int disarmTrapDoor(TBeing* thief, dirTypeT door) {

--- a/code/code/obj/obj_arrow.cc
+++ b/code/code/obj/obj_arrow.cc
@@ -82,6 +82,44 @@ doorTrapT TArrow::getTrapDamType() const { return trap_dam_type; }
 
 void TArrow::setTrapDamType(doorTrapT r) { trap_dam_type = r; }
 
+int TArrow::disarmMe(TBeing* thief) {
+  if (getTrapDamType() == DOOR_TRAP_NONE) {
+    act("$p is not trapped.", false, thief, this, nullptr, TO_CHAR);
+    return false;
+  }
+
+  sstring trap_type = trap_types[getTrapDamType()];
+  int bKnown = thief->getSkillValue(SKILL_DISARM_TRAP);
+
+  if (thief->bSuccess(bKnown, SKILL_DISARM_TRAP)) {
+    act(format("Click.  You disarm the %s trap on $p.") % trap_type, false,
+      thief, this, nullptr, TO_CHAR);
+    act("$n disarms $p.", false, thief, this, nullptr, TO_ROOM);
+    setTrapLevel(0);
+    setTrapDamType(DOOR_TRAP_NONE);
+    // TODO(reclaim): once reclaimTrapComps (trap-reclaim / PR #736) lands on
+    // master, salvage the trap's components here, gated on
+    // SKILL_SET_TRAP_ARROW.
+    return true;
+  }
+
+  // Fumble: the trap discharges on the thief. An arrow trap is one-shot, so it
+  // is spent afterward whether it kills, destroys the arrow, or just stings.
+  thief->sendTo("Click. (whoops)\n\r");
+  act("$n tries to disarm $p.", false, thief, this, nullptr, TO_ROOM);
+  int rc = thief->triggerArrowTrap(this);
+  int ret = 0;
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    ret |= DELETE_VICT;  // the trap killed the thief
+  if (IS_SET_DELETE(rc, DELETE_ITEM)) {
+    ret |= DELETE_ITEM;  // the arrow was consumed (e.g. a TNT charge)
+  } else {
+    setTrapLevel(0);
+    setTrapDamType(DOOR_TRAP_NONE);
+  }
+  return ret ? ret : true;
+}
+
 bool TArrow::sellMeCheck(TBeing* ch, TMonster* keeper, int, int) const {
   return TBaseWeapon::sellMeCheck(ch, keeper, 1, 50);
 }

--- a/code/code/obj/obj_arrow.h
+++ b/code/code/obj/obj_arrow.h
@@ -24,6 +24,7 @@ class TArrow : public TBaseWeapon {
     virtual sstring statObjInfo() const;
     virtual itemTypeT itemType() const { return ITEM_ARROW; }
     virtual int suggestedPrice() const;
+    virtual int disarmMe(TBeing*);
 
     int getTrapLevel() const;
     void setTrapLevel(int r);

--- a/code/code/obj/obj_portal.cc
+++ b/code/code/obj/obj_portal.cc
@@ -182,6 +182,42 @@ unsigned short TPortal::getPortalTrapDam() const { return trap_damage; }
 
 void TPortal::setPortalTrapDam(unsigned short r) { trap_damage = r; }
 
+int TPortal::disarmMe(TBeing* thief) {
+  if (!isPortalFlag(EXIT_TRAPPED)) {
+    act("$p is not trapped.", false, thief, this, nullptr, TO_CHAR);
+    return false;
+  }
+
+  sstring trap_type = trap_types[getPortalTrapType()];
+  int bKnown = thief->getSkillValue(SKILL_DISARM_TRAP);
+  // portals mirror doors mechanically, so reuse the door disarm difficulty
+  int learnedness = min(static_cast<int>(MAX_SKILL_LEARNEDNESS), 2 * bKnown);
+
+  if (!thief->bSuccess(learnedness, SKILL_DISARM_TRAP)) {
+    thief->sendTo("Click. (whoops)\n\r");
+    act("$n tries to disarm $p.", false, thief, this, nullptr, TO_ROOM);
+    int rc = thief->triggerPortalTrap(this);
+    int ret = 0;
+    if (IS_SET_DELETE(rc, DELETE_THIS))
+      ret |= DELETE_VICT;  // the trap killed the thief
+    if (IS_SET_DELETE(rc, DELETE_ITEM))
+      ret |= DELETE_ITEM;  // the trap destroyed the portal (e.g. a TNT charge)
+    return ret ? ret : true;
+  }
+
+  act(format("Click.  You disarm the %s trap in $p.") % trap_type, false, thief,
+    this, nullptr, TO_CHAR);
+  act("$n disarms $p.", false, thief, this, nullptr, TO_ROOM);
+  remPortalFlag(EXIT_TRAPPED);
+  setPortalTrapType(DOOR_TRAP_NONE);
+  setPortalTrapDam(0);
+
+  // TODO(reclaim): once reclaimTrapComps (trap-reclaim / PR #736) lands on
+  // master, salvage the trap's components here, gated on SKILL_SET_TRAP_DOOR.
+
+  return true;
+}
+
 void TPortal::showMe(TBeing* ch) const {
   if (isPortalFlag(EXIT_CLOSED))
     ch->sendTo("It is closed.\n\r");

--- a/code/code/obj/obj_portal.h
+++ b/code/code/obj/obj_portal.h
@@ -34,6 +34,7 @@ class TPortal : public TSeeThru {
     virtual void lockMe(TBeing*);
     virtual void unlockMe(TBeing*);
     virtual int enterMe(TBeing*);
+    virtual int disarmMe(TBeing*);
     virtual int objectDecay();
     virtual int detectMe(TBeing*) const;
     virtual void showMe(TBeing*) const;


### PR DESCRIPTION
## Summary

Thieves can now **disarm traps on portals and arrows** — the two trap-bearing target types that previously had no disarm path (both fell through to the generic *"I don't think that's a trap."*). Each gets a `disarmMe` override.

This is independent of the trap-component reclaim work (PR #736) and can merge in either order. Component salvage is intentionally **not** wired here; both overrides carry a `// TODO(reclaim)` marker showing where the `SET_TRAP_*`-gated `reclaimTrapComps` call plugs in once #736 lands on master.

## Portals — `TPortal::disarmMe`

A portal is an environmental hazard you walk into (fires via `triggerPortalTrap` on entry, gated by `EXIT_TRAPPED`) — structurally identical to doors/containers, so this mirrors that flow:

- **Not trapped** → message, no-op.
- **Success** → clears `EXIT_TRAPPED`, zeroes the trap type/damage, success message. Difficulty `2 * disarm` (the door formula).
- **Fumble** → the trap fires on the thief via `triggerPortalTrap`. A portal destroyed by its own **TNT** trap returns `DELETE_ITEM` and is cleaned up by the existing disarm path.

## Arrows — `TArrow::disarmMe`

Arrows have **no "trapped" flag** — an arrow is armed when its trap *damage type* is set (firing checks `getTrapDamType() != DOOR_TRAP_NONE`). So disarming clears the type and level:

- **Not trapped** → message, no-op.
- **Success** → `setTrapLevel(0)` + `setTrapDamType(DOOR_TRAP_NONE)` (the same neutralized state the on-hit code produces after firing). Gated on `SKILL_DISARM_TRAP`.
- **Fumble** → the trap discharges on the thief via the existing `triggerArrowTrap`. Arrow traps are one-shot, so the trap is spent afterward whether it kills the thief, consumes the arrow (TNT → `DELETE_ITEM`), or just stings.

## Shared plumbing — `disarmTrapObj`

`disarmTrapObj` now **OR-accumulates** `DELETE_VICT` and `DELETE_ITEM` instead of returning early on the first. This matters for the portal TNT case, where a single sprung trap can both kill the thief *and* destroy the trap object — previously the second flag was dropped, leaking the object. `TBeing::disarmTrap` already deletes the object before unwinding the dead thief, so propagating both is sufficient.

## Scope / notes

- **Targeting:** disarm resolves objects via `get_obj_vis_accessible`, which scans carried inventory, equipment, and the room floor but **does not recurse into containers**. So an arrow must be loose (in inventory or on the ground) to be disarmed — a quiver'd arrow has to come out first. This is consistent with every other object lookup in the game.
- **Pre-existing leak left alone (out of scope):** the on-hit arrow firing path (`obj_base_weapon.cc`) ignores `triggerArrowTrap`'s `DELETE_ITEM` return and dereferences the arrow afterward, so a TNT arrow that fires on a hit is leaked rather than consumed. The new disarm fumble path handles this correctly; the on-hit path is untouched here and worth a separate fix.

## Testing

- Builds clean on `dev-clang` (ASan + UBSan, full warnings) — no warnings.
- `make test`: **159/159 pass**.
- Both paths live-verified in-game, including a debug-forced arrow fumble to exercise the discharge/consume cases (debug code removed before commit).