### PR TITLE
Combat-preview readouts for `consider` (plus supporting refactors)

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -325,11 +325,13 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   shieldDam += impactSpec(this, victim, attackerLimb, limb);
 
   int dealt = 0;
-  if (reconcileDamage(victim, shieldDam, SKILL_BASH, &dealt) == -1)
-    return DELETE_VICT;
+  int rc = reconcileDamage(victim, shieldDam, SKILL_BASH, &dealt);
 
   act(format("Your bash deals <r>%d<z> damage to $N.") % dealt, false, this,
     nullptr, victim, TO_CHAR);
+
+  if (rc == -1)
+    return DELETE_VICT;
 
   int distractionBonus = 1;
   /*
@@ -340,8 +342,8 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   if (isLucky(levelLuckModifier(victim->GetMaxLevel())))
     distractionBonus++;
 
-  int rc = wasMounted ? victim->knockOffMount(getSkillValue(skill) / 5)
-                      : victim->crashLanding();
+  rc = wasMounted ? victim->knockOffMount(getSkillValue(skill) / 5)
+                  : victim->crashLanding();
   if (IS_SET_DELETE(rc, DELETE_THIS))
     return DELETE_VICT;
 

--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -198,59 +198,12 @@ static int bash(TBeing* attacker, TBeing* victim, spellNumT skill) {
   }
 
   /*
-    Calculate modifier for specialAttack
-
-    Per combat.cc balance notes, 16.667 points of mod is equivalent to one
-    level's worth of advantage/disadvantage.
+    The circumstantial modifier for specialAttack (advanced-disc mastery plus
+    weight differential) lives in TBeing::bashSituationalModifier so the live
+    attack and the `consider` readout share one source. Other situational
+    factors (stats, environment, group effects) could be folded in there too.
   */
-  const float ONE_LEVEL = 16.667;
-  float modifier = 0.0;
-
-  /*
-     Maxed advanced disc lets one bash as if they were 10 levels higher. Bonus
-     increases linearly with advanced disc learnedness.
-   */
-  modifier += ONE_LEVEL * ((float)advLearnedness / 10.0);
-
-  /*
-    Attacker with advanced disc using shield to bash can get another bonus of
-    up to +5 levels to distinguish shield bashing from weapon/shoulder bashing
-    and also makes bash more of a tank-centric ability.
-  */
-  modifier += ONE_LEVEL * ((float)advLearnedness / 20.0);
-
-  float attackerWeight = attacker->getWeight();
-  float victimWeight = victim->getWeight();
-
-  // Include attacker's shield or two-handed weapon in weight calculation
-  if (isHoldingShield)
-    attackerWeight += itemInSecondaryHand->getWeight();
-  else if (isWielding2Hander)
-    attackerWeight += weaponInPrimaryHand->getWeight();
-
-  // Each 20% weight difference between attacker and victim modifies
-  // chance by one level's worth, up to max of +/- 10 levels.
-  if (attackerWeight > victimWeight)
-    modifier +=
-      ONE_LEVEL * min(10.0, ((attackerWeight - victimWeight) / victimWeight) *
-                              100.0 / 20.0);
-  else if (victimWeight > attackerWeight)
-    modifier -=
-      ONE_LEVEL * min(10.0, ((victimWeight - attackerWeight) / attackerWeight) *
-                              100.0 / 20.0);
-
-  /*
-    Other possible modifiers that could be applied here: stat-based
-    (bonus/penalty based on low/high attacker/victim str/bra/agi/spd?),
-    environmental factors such as weather/lighting, group-related situations (#
-    of attackers, certain spell effects on victim?)
-
-    Basically, anything that would situationally affect the success of *this
-    specific attempt* can be converted into a +/- level modifier passed to the
-    specialAttack overload, in effect using the circumstances at the time of the
-    attack to make it more or less likely to land against this specific victim
-    based on their level/AC/other defense.
-  */
+  int modifier = attacker->skillSituationalModifier(victim, skill);
 
   int bKnown = attacker->getSkillValue(skill);
   bool wasSkillExecutionSuccessful = attacker->bSuccess(bKnown, skill);
@@ -371,8 +324,12 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   wearSlotT attackerLimb = isHoldingShield ? getSecondaryHold() : atkLimb;
   shieldDam += impactSpec(this, victim, attackerLimb, limb);
 
-  if (reconcileDamage(victim, shieldDam, SKILL_BASH) == -1)
+  int dealt = 0;
+  if (reconcileDamage(victim, shieldDam, SKILL_BASH, &dealt) == -1)
     return DELETE_VICT;
+
+  act(format("Your bash deals <r>%d<z> damage to $N.") % dealt, false, this,
+    nullptr, victim, TO_CHAR);
 
   int distractionBonus = 1;
   /*

--- a/code/code/cmd/cmd_consider.cc
+++ b/code/code/cmd/cmd_consider.cc
@@ -336,6 +336,8 @@ void TBeing::doConsider(const char* argument) {
         namebuf);
       return;
     }
+    if ((GetMaxLevel() <= MAX_MORT) && !::number(0, roll))
+      learnFromDoing(sknum, SILENT_NO, 0);
     addToWait(combatRound(1));
 
     // Display the skill under the name the player typed (the base skill), but

--- a/code/code/cmd/cmd_consider.cc
+++ b/code/code/cmd/cmd_consider.cc
@@ -51,6 +51,31 @@ namespace {
                     : "Your blows will almost never land.";
   }
 
+  // Map a generic special-attack landing percent to prose, for lore readouts
+  // below the exact-figure tier. Attacker's perspective only (your specials
+  // landing on the mob), in ten-point bands.
+  const char* specialAttackChanceDescr(int pct) {
+    if (pct >= 90)
+      return "Your special attacks will almost always land.";
+    if (pct >= 80)
+      return "Your special attacks will land easily.";
+    if (pct >= 70)
+      return "Your special attacks will hit a reliable amount.";
+    if (pct >= 60)
+      return "Your special attacks are likely to land.";
+    if (pct >= 50)
+      return "Your special attacks will land more often than not.";
+    if (pct >= 40)
+      return "Your special attacks will hit a bit less than half the time.";
+    if (pct >= 30)
+      return "Your special attacks will land sometimes, but not often.";
+    if (pct >= 20)
+      return "Your special attacks might hit, but you shouldn't bet on it.";
+    if (pct >= 10)
+      return "Your special attacks will rarely land.";
+    return "Your special attacks have only the barest hope of hitting.";
+  }
+
   // The looker's lore value for this mob: the highest learnedness among the
   // creature-knowledge skills that apply to its type. When `announce`, emit the
   // flavorful "you determine that X is a Y" line (suppressed for the focused
@@ -431,6 +456,17 @@ void TBeing::doConsider(const char* argument) {
         sendTo(format("%s\n\r") % hitChanceDescr(myHit, false));
         sendTo(format("%s\n\r") % hitChanceDescr(itsHit, true));
       }
+
+      // Generic special-attack landing chance, level-gap driven -- deliberately
+      // skill-agnostic (the `consider <mob> <skill>` readout is the exact one).
+      // Prose here, exact percentage once lore reaches 50.
+      int specHit = genericSpecialAttackChance(tmon);
+      if (learn >= 50)
+        sendTo(format("Your special attacks will land about %d%% of the "
+                      "time.\n\r") %
+               specHit);
+      else
+        sendTo(format("%s\n\r") % specialAttackChanceDescr(specHit));
     }
 
     // Damage -- your output per hand and its output against you. Prose at 50,

--- a/code/code/cmd/cmd_consider.cc
+++ b/code/code/cmd/cmd_consider.cc
@@ -6,21 +6,146 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include <cmath>
-
 #include "handler.h"
 #include "extern.h"
 #include "being.h"
 #include "cmd_trophy.h"
 #include "person.h"
 #include "monster.h"
+#include "obj_base_weapon.h"
+
+namespace {
+  // Map a per-swing melee hit percent to a prose description. `incoming`
+  // selects the defender's perspective (the mob's blows landing on you) versus
+  // the attacker's (your blows landing on the mob). Both ladders mirror the
+  // full range so a comfortable fight reassures just as a losing one warns.
+  const char* hitChanceDescr(int pct, bool incoming) {
+    if (pct >= 90)
+      return incoming ? "Their blows will almost always land."
+                      : "Your blows will rarely miss.";
+    if (pct >= 80)
+      return incoming ? "Their attacks will strike you easily."
+                      : "Your attacks will connect easily.";
+    if (pct >= 70)
+      return incoming ? "They are very likely to hit you."
+                      : "You are very likely to hit them.";
+    if (pct >= 60)
+      return incoming ? "They are likely to hit you."
+                      : "You are likely to hit them.";
+    if (pct >= 50)
+      return incoming ? "Their attacks will hit you more often than not."
+                      : "You will hit more often than not.";
+    if (pct >= 40)
+      return incoming ? "Their attacks will miss you more often than not."
+                      : "You will miss more often than not.";
+    if (pct >= 30)
+      return incoming ? "They are likely to miss you."
+                      : "You are likely to miss them.";
+    if (pct >= 20)
+      return incoming ? "They are very likely to miss you."
+                      : "You are very likely to miss them.";
+    if (pct >= 10)
+      return incoming ? "Their attacks will rarely find you."
+                      : "Your attacks will rarely connect.";
+    return incoming ? "Their blows will almost never find you."
+                    : "Your blows will almost never land.";
+  }
+
+  // The looker's lore value for this mob: the highest learnedness among the
+  // creature-knowledge skills that apply to its type. When `announce`, emit the
+  // flavorful "you determine that X is a Y" line (suppressed for the focused
+  // skill readout). sknum/roll report which skill drove the value so the caller
+  // can grant a learn-by-doing tick.
+  int considerLore(TBeing* ch, TMonster* tmon, const char* namebuf,
+    bool announce, spellNumT& sknum, int& roll) {
+    int learn = 0;
+    sknum = TYPE_UNDEFINED;
+    roll = 0;
+
+    auto note = [&](spellNumT skill, int rollVal, const char* lore) {
+      sknum = skill;
+      roll = rollVal;
+      learn = max(learn, static_cast<int>(ch->getSkillValue(skill)));
+      if (announce)
+        ch->sendTo(COLOR_MOBS,
+          format(
+            "Using your knowledge %s, you determine that %s is %s %s.\n\r") %
+            lore % namebuf %
+            (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
+            tmon->getMyRace()->getSingularName());
+    };
+
+    if (tmon->isAnimal() && ch->doesKnowSkill(SKILL_CONS_ANIMAL))
+      note(SKILL_CONS_ANIMAL, 1, "of animal lore");
+    if (tmon->isVeggie() && ch->doesKnowSkill(SKILL_CONS_VEGGIE))
+      note(SKILL_CONS_VEGGIE, 1, "of vegetable lore");
+    if (tmon->isDiabolic() && ch->doesKnowSkill(SKILL_CONS_DEMON))
+      note(SKILL_CONS_DEMON, 1, "of demon lore");
+    if (tmon->isReptile() && ch->doesKnowSkill(SKILL_CONS_REPTILE))
+      note(SKILL_CONS_REPTILE, 2, "of reptile lore");
+    if (tmon->isUndead() && ch->doesKnowSkill(SKILL_CONS_UNDEAD))
+      note(SKILL_CONS_UNDEAD, 2, "of the undead");
+    if (tmon->isGiantish() && ch->doesKnowSkill(SKILL_CONS_GIANT))
+      note(SKILL_CONS_GIANT, 1, "of giant lore");
+    if (tmon->isPeople() && ch->doesKnowSkill(SKILL_CONS_PEOPLE))
+      note(SKILL_CONS_PEOPLE, 2, "of human and demi-human lore");
+    if (tmon->isOther() && ch->doesKnowSkill(SKILL_CONS_OTHER))
+      note(SKILL_CONS_OTHER, 1, "of monster lore");
+
+    return min(learn, static_cast<int>(MAX_SKILL_LEARNEDNESS));
+  }
+
+  // Whether `consider`'s hit-chance line is meaningful for this skill: true
+  // only for skills that resolve through TBeing::specialAttack. For backstab
+  // and throatslit the estimate reflects the thief's current stealth state and
+  // the non-wary opening strike. Keep in sync with the specialAttack call
+  // sites.
+  bool usesSpecialAttack(spellNumT skill) {
+    switch (skill) {
+      case SKILL_BASH:
+      case SKILL_BODYSLAM:
+      case SKILL_SLAM:
+      case SKILL_KICK:
+      case SKILL_HEADBUTT:
+      case SKILL_KNEESTRIKE:
+      case SKILL_STOMP:
+      case SKILL_SPIN:
+      case SKILL_CHOP:
+      case SKILL_WHIRLWIND:
+      case SKILL_TRIP:
+      case SKILL_DISARM:
+      case SKILL_GRAPPLE:
+      case SKILL_STABBING:
+      case SKILL_BONEBREAK:
+      case SKILL_QUIV_PALM:
+      case SKILL_CHARGE:
+      case SKILL_SHOCK_CAVALRY:
+      case SKILL_DEATHSTROKE:
+      case SKILL_SUBTERFUGE:
+      case SKILL_BACKSTAB:
+      case SKILL_THROATSLIT:
+      case SKILL_KINETIC_WAVE:
+      case SKILL_HURL:
+      case SKILL_SHOULDER_THROW:
+      case SKILL_DEFENESTRATE:
+        return true;
+      default:
+        return false;
+    }
+  }
+}  // namespace
 
 void TBeing::doConsider(const char* argument) {
   TBeing* victim;
   char namebuf[256];
+  char skillbuf[256];
   int diff = 0;
+  spellNumT considerSkill = TYPE_UNDEFINED;
 
-  strcpy(namebuf, argument);
+  // "consider <target> <skill>" -- the optional trailing skill name asks for
+  // that special attack's damage estimate alongside the usual assessment.
+  half_chop_safe(argument, namebuf, sizeof(namebuf), skillbuf,
+    sizeof(skillbuf));
 
   if (is_abbrev(namebuf, "self"))
     strcpy(namebuf, getNameNOC(this).c_str());
@@ -146,11 +271,76 @@ void TBeing::doConsider(const char* argument) {
     }
   }
 
+  if (skillbuf[0]) {
+    // Take the first (base) match rather than demanding a unique one: a bare
+    // "bash" also name-matches the class variant "bash-deikhan", and a unique
+    // search would reject it as ambiguous. Base skills precede their variants
+    // in the enum, so the first exact hit is the generic skill -- which
+    // getSkillNum then routes to the version this class actually trains, just
+    // as the live `bash` command does. Prefer an exact hit before an
+    // abbreviation so a short name isn't shadowed by a longer one.
+    considerSkill = searchForSpellNum(skillbuf, EXACT_YES, false);
+    if (considerSkill == TYPE_UNDEFINED)
+      considerSkill = searchForSpellNum(skillbuf, EXACT_NO, false);
+    if (considerSkill == TYPE_UNDEFINED ||
+        !doesKnowSkill(getSkillNum(considerSkill))) {
+      sendTo(format("You don't know a skill called '%s'.\n\r") % skillbuf);
+      considerSkill = TYPE_UNDEFINED;
+    }
+  }
+
   // everything should be a monster by this point
   TMonster* tmon = dynamic_cast<TMonster*>(victim);
 
   act("$n looks $N over.", TRUE, this, 0, tmon, TO_NOTVICT);
   act("$n looks you over.", TRUE, this, 0, tmon, TO_VICT);
+
+  // "consider <target> <skill>": a focused readout for one attack -- its
+  // execution odds and damage against this target -- and nothing else.
+  if (considerSkill != TYPE_UNDEFINED) {
+    if (!getDiscipline(DISC_ADVENTURING)) {
+      sendTo("You lack the training to size up your attacks that way.\n\r");
+      return;
+    }
+    spellNumT sknum;
+    int roll;
+    int learn = considerLore(this, tmon, namebuf, false, sknum, roll);
+    if (learn < 40) {
+      sendTo(
+        format("You don't know enough about %s to gauge your attacks.\n\r") %
+        namebuf);
+      return;
+    }
+    addToWait(combatRound(1));
+
+    // Display the skill under the name the player typed (the base skill), but
+    // drive the odds and damage from the class-specific version they actually
+    // train -- its learnedness, not the base skill's, is what governs a real
+    // execution. For skills without a class variant these are the same number.
+    sstring skillName = sstring(discArray[considerSkill]->name).cap();
+    spellNumT trainedSkill = getSkillNum(considerSkill);
+    sendTo(format("You have a %d%% chance of successfully executing a %s "
+                  "attack.\n\r") %
+           skillExecuteChance(trainedSkill) % skillName);
+
+    // Landing chance, once executed -- only meaningful for specialAttack
+    // skills.
+    if (usesSpecialAttack(considerSkill))
+      sendTo(
+        format("Once executed, it will connect about %d%% of the time.\n\r") %
+        specialAttackChance(tmon, trainedSkill));
+
+    // Some specialAttack skills (trip, disarm, grapple) resolve as pure
+    // control moves and deal no direct damage -- say so plainly rather than
+    // implying the attack couldn't be evaluated (its odds just were).
+    auto [kmin, kmax] = skillDamageRange(tmon, trainedSkill);
+    if (kmax > 0)
+      sendTo(format("Your %s attack will do %d-%d damage against %s.\n\r") %
+             skillName % kmin % kmax % namebuf);
+    else
+      sendTo(format("A %s deals no direct damage.\n\r") % skillName);
+    return;
+  }
 
 #if 0
   diff = tmon->GetMaxLevel() - GetMaxLevel();
@@ -201,100 +391,9 @@ void TBeing::doConsider(const char* argument) {
   }
 
   if (getDiscipline(DISC_ADVENTURING)) {
-    int learn = 0;
     spellNumT sknum = TYPE_UNDEFINED;
     int roll = 0;
-
-    if (tmon->isAnimal() && doesKnowSkill(SKILL_CONS_ANIMAL)) {
-      sknum = SKILL_CONS_ANIMAL;
-      roll = 1;
-      learn = getSkillValue(SKILL_CONS_ANIMAL);
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of animal lore, you determine that %s is "
-               "%s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isVeggie() && doesKnowSkill(SKILL_CONS_VEGGIE)) {
-      sknum = SKILL_CONS_VEGGIE;
-      roll = 1;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_VEGGIE));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of vegetable lore, you determine that %s "
-               "is %s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isDiabolic() && doesKnowSkill(SKILL_CONS_DEMON)) {
-      sknum = SKILL_CONS_DEMON;
-      roll = 1;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_DEMON));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of demon lore, you determine that %s is "
-               "%s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isReptile() && doesKnowSkill(SKILL_CONS_REPTILE)) {
-      sknum = SKILL_CONS_REPTILE;
-      roll = 2;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_REPTILE));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of reptile lore, you determine that %s is "
-               "%s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isUndead() && doesKnowSkill(SKILL_CONS_UNDEAD)) {
-      sknum = SKILL_CONS_UNDEAD;
-      roll = 2;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_UNDEAD));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of the undead, you determine that %s is "
-               "%s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isGiantish() && doesKnowSkill(SKILL_CONS_GIANT)) {
-      sknum = SKILL_CONS_GIANT;
-      roll = 1;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_GIANT));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of giant lore, you determine that %s is "
-               "%s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isPeople() && doesKnowSkill(SKILL_CONS_PEOPLE)) {
-      sknum = SKILL_CONS_PEOPLE;
-      roll = 2;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_PEOPLE));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of human and demi-human lore, you "
-               "determine that %s is %s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (tmon->isOther() && doesKnowSkill(SKILL_CONS_OTHER)) {
-      sknum = SKILL_CONS_OTHER;
-      roll = 1;
-      learn = max(learn, (int)getSkillValue(SKILL_CONS_OTHER));
-      sendTo(COLOR_MOBS,
-        format("Using your knowledge of monster lore, you determine that %s is "
-               "%s %s.\n\r") %
-          namebuf %
-          (tmon->getMyRace()->getSingularName().startsVowel() ? "an" : "a") %
-          tmon->getMyRace()->getSingularName());
-    }
-    if (learn > MAX_SKILL_LEARNEDNESS)
-      learn = MAX_SKILL_LEARNEDNESS;
+    int learn = considerLore(this, tmon, namebuf, true, sknum, roll);
 
     if (!learn)
       return;
@@ -305,38 +404,114 @@ void TBeing::doConsider(const char* argument) {
 
     addToWait(combatRound(1));
 
-    int num = GetApprox(tmon->hitLimit(), max(80, learn));
-    double fnum =
-      hitLimit() ? ((double)num / (double)hitLimit()) : (num ? 10.0 : 0.0);
-    if (learn > 5)
-      sendTo(format("Est Max HP are: %s.\n\r") % DescRatio(fnum));
+    // Figures shared by several readouts. Hit chance is a single
+    // character-vs-target value (not per hand), so both hands share it; damage
+    // genuinely differs by hand, computed below.
+    double itsMult = tmon->getMult();
+    int myHit = meleeHitChance(tmon);
+    int itsHit = tmon->meleeHitChance(this);
 
-    // mob's AC : expressed as a level (use mob scale for AC-lev)
-    num = GetApprox(max(((1000 - tmon->getArmor()) - 400) / 20, 0),
-      10 * max(80, learn));
-    // my AC : expressed as a level  (use PC scale for AC-lev)
-    int num2 = (int)max(((1000 - getArmor()) - 500) / 25, 0);
-    // take the difference
-    num -= num2;  // if positive, mob has better armor
-    // normalize it
-    fnum = ((double)num / get_doubling_level(GetMaxLevel()));
-    // if same ACs, num = 0 and want it to be 1.0
-    // if mob had AC of twice as good mob, num = 1, want it to be 2.0
-    // if mob had AC of 4X as good mob, num = 2, want it to be 4.0
-    // if mob had AC of twice as bad mob, num = -1, want it to be 0.5
-    fnum = pow(2.0, fnum);
-
-    if (learn > 20)
-      sendTo(format("Est. armor class is : %s.\n\r") % DescRatio(fnum));
-
-    if (learn > 40)
+    // Its number of attacks: prose while your lore is rough, a count at 40.
+    if (learn >= 40)
+      sendTo(
+        format("Est. # of attacks: about %d.\n\r") %
+        max(1, GetApprox(static_cast<int>(itsMult + 0.5), max(80, learn))));
+    else
       sendTo(format("Est. # of attacks: %s.\n\r") %
-             DescAttacks(GetApprox((int)tmon->getMult(), max(80, learn))));
+             DescAttacks(GetApprox(static_cast<int>(itsMult), max(80, learn))));
 
-    if (learn > 60) {
-      num = GetApprox((int)tmon->baseDamage(), max(80, learn));
-      fnum = (double)num;
-      sendTo(format("Est. damage of attacks: %s.\n\r") % DescDamage(fnum));
+    // Hit chance, both directions: prose at 40, exact percentages at 50.
+    if (learn >= 40) {
+      if (learn >= 50) {
+        sendTo(format("You will hit %s about %d%% of the time.\n\r") % namebuf %
+               myHit);
+        sendTo(format("%s will hit you about %d%% of the time.\n\r") %
+               sstring(namebuf).cap() % itsHit);
+      } else {
+        sendTo(format("%s\n\r") % hitChanceDescr(myHit, false));
+        sendTo(format("%s\n\r") % hitChanceDescr(itsHit, true));
+      }
+    }
+
+    // Damage -- your output per hand and its output against you. Prose at 50,
+    // exact figures at 70.
+    if (learn >= 50) {
+      TThing* primWeap = heldInPrimHand();
+      TObj* primObj = dynamic_cast<TObj*>(primWeap);
+      bool paired = primObj && primObj->isPaired();
+      auto [pmin, pmax] = meleeDamageRange(tmon, primWeap, HAND_PRIMARY);
+      TThing* secWeap = paired ? nullptr : heldInSecHand();
+      auto [smin, smax] = paired
+                            ? std::pair<int, int>{0, 0}
+                            : meleeDamageRange(tmon, secWeap, HAND_SECONDARY);
+
+      // Its damage against you: a wielded weapon uses the real weapon pipeline
+      // (resistance-aware); a natural attacker uses its base damage, since the
+      // barehand path models a humanoid punch, not a beast's bite.
+      TThing* mobWeap = tmon->heldInPrimHand();
+      bool mobArmed = dynamic_cast<TBaseWeapon*>(mobWeap);
+      int mmin, mmax;
+      if (mobArmed) {
+        std::tie(mmin, mmax) =
+          tmon->meleeDamageRange(this, mobWeap, HAND_PRIMARY);
+      } else {
+        int base = max(1, static_cast<int>(tmon->baseDamage()));
+        mmin = max(1, base * 3 / 4);
+        mmax = max(mmin, base * 5 / 4);
+      }
+      int mobAvg =
+        mobArmed ? (mmin + mmax + 1) / 2 : static_cast<int>(tmon->baseDamage());
+
+      if (learn >= 70) {
+        if (pmax > 0) {
+          if (paired)
+            sendTo(
+              format("A hit with %s will do %d-%d damage when held in both "
+                     "hands.\n\r") %
+              primWeap->getName() % pmin % pmax);
+          else if (primWeap)
+            sendTo(format("A hit with %s will do %d-%d damage in your primary "
+                          "hand.\n\r") %
+                   primWeap->getName() % pmin % pmax);
+          else
+            sendTo(
+              format("You will do %d-%d damage with your primary hand.\n\r") %
+              pmin % pmax);
+        }
+        if (!paired && smax > 0) {
+          if (secWeap)
+            sendTo(
+              format("A hit with %s will do %d-%d damage in your secondary "
+                     "hand.\n\r") %
+              secWeap->getName() % smin % smax);
+          else
+            sendTo(
+              format("You will do %d-%d damage with your secondary hand.\n\r") %
+              smin % smax);
+        }
+        if (mobArmed)
+          sendTo(
+            format("%s will do an average of %d damage to you with %s.\n\r") %
+            sstring(namebuf).cap() % max(1, mobAvg) % mobWeap->getName());
+        else
+          sendTo(format("%s will hit you for an average of %d damage per "
+                        "hit.\n\r") %
+                 sstring(namebuf).cap() % max(1, mobAvg));
+      } else {
+        if (pmax > 0)
+          sendTo(format("Your attacks would do: %s.\n\r") %
+                 DescDamage((pmin + pmax) / 2.0));
+        sendTo(format("Its attacks would do: %s.\n\r") %
+               DescDamage((mmin + mmax) / 2.0));
+      }
+    }
+
+    // Critical-hit chance: the mastery reveal, numbers only.
+    if (learn >= 80) {
+      double crit = critChancePercent(tmon, heldInPrimHand());
+      if (crit > 0.0)
+        sendTo(format("You have a %.1f%% chance to score a critical hit.\n\r") %
+               crit);
     }
   }
   immortalEvaluation(tmon);

--- a/code/code/cmd/cmd_grapple.cc
+++ b/code/code/cmd/cmd_grapple.cc
@@ -71,8 +71,7 @@ static int grapple(TBeing* c, TBeing* victim, spellNumT skill) {
 
   if ((c->bSuccess(bKnown + percent, skill) &&
         // insure they can hit this critter
-        (i = c->specialAttack(victim, skill, 0, STAT_STR, STAT_DEX, STAT_BRA,
-           STAT_AGI, false)) &&
+        (i = c->specialAttack(victim, skill, 0, false)) &&
         i != GUARANTEED_FAILURE &&
         // make sure they have reasonable training
         (percent < bKnown)) ||

--- a/code/code/cmd/cmd_stab.cc
+++ b/code/code/cmd/cmd_stab.cc
@@ -29,14 +29,14 @@ static void stabHitMsg(TBeing* thief, TBeing* victim, TGenWeapon* weapon,
     case 1:
       act(format("You stab $N in $S %s with your $o!") % limbName, FALSE, thief,
         weapon, victim, TO_CHAR, ANSI_ORANGE);
-      act(format("$n stabs you in your %s with $s $o!") % limbName, FALSE, thief,
-        weapon, victim, TO_VICT, ANSI_ORANGE);
+      act(format("$n stabs you in your %s with $s $o!") % limbName, FALSE,
+        thief, weapon, victim, TO_VICT, ANSI_ORANGE);
       act(format("$n stabs $N in $S %s with $s $o!") % limbName, FALSE, thief,
         weapon, victim, TO_NOTVICT, ANSI_ORANGE);
       break;
     case 2:
-      act(format("You gouge $N in $S %s with your $o!") % limbName, FALSE, thief,
-        weapon, victim, TO_CHAR, ANSI_ORANGE);
+      act(format("You gouge $N in $S %s with your $o!") % limbName, FALSE,
+        thief, weapon, victim, TO_CHAR, ANSI_ORANGE);
       act(format("$n gouges you in your %s with $s $o!") % limbName, FALSE,
         thief, weapon, victim, TO_VICT, ANSI_ORANGE);
       act(format("$n gouges $N in $S %s with $s $o!") % limbName, FALSE, thief,
@@ -80,11 +80,14 @@ static void stabBleedCheck(TBeing* thief, TBeing* victim, TGenWeapon* weapon,
       victim->incrementBleedStack(limb, duration);
     } else {
       sstring limbName(victim->describeBodySlot(limb));
-      act(format("Your stab opens a <r>bleeding wound<z> on $N's %s!") % limbName,
+      act(
+        format("Your stab opens a <r>bleeding wound<z> on $N's %s!") % limbName,
         FALSE, thief, nullptr, victim, TO_CHAR);
-      act(format("$n's stab opens a <r>bleeding wound<z> on your %s!") % limbName,
+      act(
+        format("$n's stab opens a <r>bleeding wound<z> on your %s!") % limbName,
         FALSE, thief, nullptr, victim, TO_VICT);
-      act(format("$n's stab opens a <r>bleeding wound<z> on $N's %s!") % limbName,
+      act(
+        format("$n's stab opens a <r>bleeding wound<z> on $N's %s!") % limbName,
         FALSE, thief, nullptr, victim, TO_NOTVICT);
 
       victim->rawBleed(limb, duration, SILENT_YES, CHECK_IMMUNITY_NO);
@@ -95,8 +98,7 @@ static void stabBleedCheck(TBeing* thief, TBeing* victim, TGenWeapon* weapon,
 // Resolves a single stab attempt for one weapon — hit roll through weapon
 // spec proc. Shared between primary-hand and offhand attacks.
 static int stabCore(TBeing* thief, TBeing* victim, TGenWeapon* weapon) {
-  int specResult = thief->specialAttack(victim, SKILL_STABBING, 0, STAT_DEX,
-    STAT_SPE, STAT_AGI, STAT_PER, false);
+  int specResult = thief->specialAttack(victim, SKILL_STABBING, 0, false);
   if (specResult != COMPLETE_SUCCESS && specResult != GUARANTEED_SUCCESS) {
     stabMissMsg(thief, victim, weapon);
     return TRUE;
@@ -129,8 +131,8 @@ static int stabCore(TBeing* thief, TBeing* victim, TGenWeapon* weapon) {
   stabBleedCheck(thief, victim, weapon, limb);
   stabPoisonCheck(victim, weapon);
 
-  int specRc = weapon->checkSpec(victim, CMD_STAB,
-    reinterpret_cast<char*>(limb), thief);
+  int specRc =
+    weapon->checkSpec(victim, CMD_STAB, reinterpret_cast<char*>(limb), thief);
   if (IS_SET_DELETE(specRc, DELETE_ITEM))
     return DELETE_THIS;  // thief destroyed by weapon spec
   if (IS_SET_DELETE(specRc, DELETE_VICT))
@@ -158,7 +160,7 @@ static int stabPrimAtk(TBeing* thief, TBeing* victim, TGenWeapon* primWeapon,
     int warDual = thief->getSkillValue(SKILL_DUAL_WIELD);
     if (thief->getAdvLearning(SKILL_STABBING) > 50) {
       if ((thief->doesKnowSkill(SKILL_DUAL_WIELD) &&
-          thief->bSuccess(warDual, SKILL_DUAL_WIELD)) ||
+            thief->bSuccess(warDual, SKILL_DUAL_WIELD)) ||
           ((thief->doesKnowSkill(SKILL_DUAL_WIELD_THIEF) &&
             thief->bSuccess(thiefDual, SKILL_DUAL_WIELD_THIEF)))) {
         act("You shift your weight and ready an attack with your offhand.",
@@ -195,31 +197,34 @@ static int stab(TBeing* thief, TBeing* victim, bool isChain = false) {
     return false;
   }
   if (thiefMount && thief->getSkillValue(SKILL_RIDE) < 80) {
-    thief->sendTo("You aren't a skilled enough rider to stab while mounted!\n\r");
+    thief->sendTo(
+      "You aren't a skilled enough rider to stab while mounted!\n\r");
     return false;
   }
 
   TBeing* victimMount = dynamic_cast<TBeing*>(victim->riding);
-  bool thiefAirborne = thief->isFlying() || (thiefMount && thiefMount->isFlying());
-  bool victimAirborne = victim->isFlying() || (victimMount && victimMount->isFlying());
+  bool thiefAirborne =
+    thief->isFlying() || (thiefMount && thiefMount->isFlying());
+  bool victimAirborne =
+    victim->isFlying() || (victimMount && victimMount->isFlying());
   // Mid-fight against the same target bypasses the airborne mismatch —
   // engaging a flying opponent puts them in stab range. (Backstab has no
   // such carve-out; its mid-fight gate already requires off-feet, which
   // flying opponents inherently aren't.)
   if (victimAirborne && !thiefAirborne && thief->fight() != victim) {
-    thief->sendTo("You can't stab a flying person with your feet on the ground!\n\r");
+    thief->sendTo(
+      "You can't stab a flying person with your feet on the ground!\n\r");
     return false;
   }
 
   if (thief->noHarmCheck(victim))
     return FALSE;
 
-  TGenWeapon* primWeapon =
-    dynamic_cast<TGenWeapon*>(thief->heldInPrimHand());
-  TGenWeapon* offWeapon =
-    dynamic_cast<TGenWeapon*>(thief->heldInSecHand());
+  TGenWeapon* primWeapon = dynamic_cast<TGenWeapon*>(thief->heldInPrimHand());
+  TGenWeapon* offWeapon = dynamic_cast<TGenWeapon*>(thief->heldInSecHand());
 
-  bool primCanStab = primWeapon && (primWeapon->canStab() || primWeapon->isPolearm());
+  bool primCanStab =
+    primWeapon && (primWeapon->canStab() || primWeapon->isPolearm());
   bool offCanStab = offWeapon && offWeapon->canStab();
 
   if (!primCanStab && !offCanStab) {
@@ -236,7 +241,8 @@ static int stab(TBeing* thief, TBeing* victim, bool isChain = false) {
   }
 
   int bKnown = thief->getSkillValue(SKILL_STABBING);
-  bool stabSuccess = !victim->awake() || thief->bSuccess(bKnown, SKILL_STABBING);
+  bool stabSuccess =
+    !victim->awake() || thief->bSuccess(bKnown, SKILL_STABBING);
 
   victim->addHated(thief);
 

--- a/code/code/disc/disc_thief_murder.cc
+++ b/code/code/disc/disc_thief_murder.cc
@@ -156,8 +156,8 @@ int TBeing::backstabHit(TBeing* victim, TThing* obj, int modifier) {
         auto weapon = dynamic_cast<TBaseWeapon*>(obj);
 
         if (weapon) {
-          int specRc = weapon->checkSpec(victim, CMD_BACKSTAB,
-            "-special-", this);
+          int specRc =
+            weapon->checkSpec(victim, CMD_BACKSTAB, "-special-", this);
           if (IS_SET_DELETE(specRc, DELETE_THIS))
             weapon = nullptr;  // weapon destroyed, skip poison
           if (IS_SET_DELETE(specRc, DELETE_ITEM))
@@ -242,7 +242,9 @@ int TBeing::doBackstab(const char* argument, TBeing* vict) {
   if (!vict && !victim) {
     arg = one_argument(arg, namebuf);
 
-    if (!(victim = get_char_room_vis(this, namebuf))) {
+    // Fall back to the current opponent so a bare "backstab" mid-fight targets
+    // whom you're already fighting (as bash and the other attacks do).
+    if (!(victim = get_char_room_vis(this, namebuf)) && !(victim = fight())) {
       sendTo("Backstab whom?\n\r");
       return FALSE;
     }
@@ -315,14 +317,18 @@ int backstab(TBeing* thief, TBeing* victim) {
     return false;
   }
   if (thiefMount && thief->getSkillValue(SKILL_RIDE) < 80) {
-    thief->sendTo("You aren't a skilled enough rider to backstab while mounted!\n\r");
+    thief->sendTo(
+      "You aren't a skilled enough rider to backstab while mounted!\n\r");
     return false;
   }
   TBeing* victimMount = dynamic_cast<TBeing*>(victim->riding);
-  bool thiefAirborne = thief->isFlying() || (thiefMount && thiefMount->isFlying());
-  bool victimAirborne = victim->isFlying() || (victimMount && victimMount->isFlying());
+  bool thiefAirborne =
+    thief->isFlying() || (thiefMount && thiefMount->isFlying());
+  bool victimAirborne =
+    victim->isFlying() || (victimMount && victimMount->isFlying());
   if (victimAirborne && !thiefAirborne) {
-    thief->sendTo("You can't backstab a flying person with your feet on the ground!\n\r");
+    thief->sendTo(
+      "You can't backstab a flying person with your feet on the ground!\n\r");
     return FALSE;
   }
   if (dynamic_cast<TBeing*>(victim->rider)) {
@@ -342,7 +348,9 @@ int backstab(TBeing* thief, TBeing* victim) {
       return FALSE;
     }
     if (victim->getPosition() > POSITION_SITTING) {
-      thief->sendTo("Your target must be off their feet to backstab while under attack.\n\r");
+      thief->sendTo(
+        "Your target must be off their feet to backstab while under "
+        "attack.\n\r");
       return FALSE;
     }
   }
@@ -360,24 +368,21 @@ int backstab(TBeing* thief, TBeing* victim) {
 
   if (thief->fight()) {
     if (bKnown <= 65) {
-      thief->sendTo("You aren't skilled enough to backstab during a fight.\n\r");
+      thief->sendTo(
+        "You aren't skilled enough to backstab during a fight.\n\r");
       return FALSE;
     }
     if (victim->getPosition() > POSITION_SITTING) {
-      thief->sendTo("Your target must be off their feet to backstab mid-fight.\n\r");
+      thief->sendTo(
+        "Your target must be off their feet to backstab mid-fight.\n\r");
       return FALSE;
     }
   }
   thief->reconcileHurt(victim, 0.04);
 
-  int modifier = 0;
+  int modifier = thief->skillSituationalModifier(victim, SKILL_BACKSTAB);
 
-  modifier -= noise(thief) / 20;
-  modifier += thief->visibility() / 15;
-
-  if (thief->makesNoise() && victim->awake()) {
-    modifier -= 10;
-
+  if (thief->canHearThief(victim)) {
     act(
       "$n's armor makes too much noise, and $N is alerted to $n's backstab "
       "attempt.",
@@ -389,10 +394,7 @@ int backstab(TBeing* thief, TBeing* victim) {
       "backstab you.",
       FALSE, thief, 0, victim, TO_VICT);
   }
-  if (victim->awake() && victim->canSee(thief) && !victim->isPc() &&
-      dynamic_cast<TMonster*>(victim)->isSusp()) {
-    modifier -= 10;
-
+  if (thief->spottedBySuspiciousMob(victim)) {
     act("$E is able to see you and notices you coming at the last moment.",
       FALSE, thief, 0, victim, TO_CHAR);
     act("You sense $m coming as $n attempts to murder you.", FALSE, thief, 0,
@@ -548,8 +550,7 @@ int TBeing::throatSlitHit(TBeing* victim, TThing* obj, int modifier) {
         auto weapon = dynamic_cast<TGenWeapon*>(heldInPrimHand());
 
         if (weapon) {
-          int specRc = weapon->checkSpec(victim, CMD_SLIT,
-            "-special-", this);
+          int specRc = weapon->checkSpec(victim, CMD_SLIT, "-special-", this);
           if (IS_SET_DELETE(specRc, DELETE_THIS))
             weapon = nullptr;  // weapon destroyed, skip poison
           if (IS_SET_DELETE(specRc, DELETE_ITEM))
@@ -692,7 +693,8 @@ int throatSlit(TBeing* thief, TBeing* victim) {
     return FALSE;
   }
   if (6 * thief->getHeight() < 3 * victim->getHeight() &&
-      !(thief->isFlying() || (victim->getPosition() < POSITION_STANDING && victim->getPosition() != POSITION_FIGHTING))) {
+      !(thief->isFlying() || (victim->getPosition() < POSITION_STANDING &&
+                               victim->getPosition() != POSITION_FIGHTING))) {
     thief->sendTo("You don't stand a chance, that creature is too tall.\n\r");
     return FALSE;
   }
@@ -734,14 +736,9 @@ int throatSlit(TBeing* thief, TBeing* victim) {
   }
   thief->reconcileHurt(victim, 0.04);
 
-  int modifier = 0;
+  int modifier = thief->skillSituationalModifier(victim, SKILL_THROATSLIT);
 
-  modifier -= noise(thief) / 20;
-  modifier += thief->visibility() / 15;
-
-  if (thief->makesNoise() && victim->awake()) {
-    modifier -= 10;
-
+  if (thief->canHearThief(victim)) {
     act(
       "$n's armor makes too much noise, and $N is alerted to $n's murder "
       "attempt.",
@@ -753,10 +750,7 @@ int throatSlit(TBeing* thief, TBeing* victim) {
       "you.",
       FALSE, thief, 0, victim, TO_VICT);
   }
-  if (victim->awake() && victim->canSee(thief) && !victim->isPc() &&
-      dynamic_cast<TMonster*>(victim)->isSusp()) {
-    modifier -= 10;
-
+  if (thief->spottedBySuspiciousMob(victim)) {
     act("$E is able to see you and notices you coming at the last moment.",
       FALSE, thief, 0, victim, TO_CHAR);
     act("You sense $m coming as $n attempts to murder you.", FALSE, thief, 0,

--- a/code/code/disc/disc_thief_stealth.cc
+++ b/code/code/disc/disc_thief_stealth.cc
@@ -1142,20 +1142,10 @@ int subterfugeSuccess(TBeing* thief, TBeing* victim) {
     act("You seem less wary now.", FALSE, thief, NULL, victim, TO_VICT);
   }
 
-  // For mobs, do specialAttack
-  int situationalMod = 0;
-  if (!victim->isWise()) {
-    situationalMod -= 10;
-  }
-  if (!victim->isIntelligent()) {
-    situationalMod -= 10;
-  }
-  if (thief->isCharismatic()) {
-    situationalMod += 10;
-  }
-
+  // For mobs, do specialAttack. Modifier and stats come from the shared
+  // per-skill source (skillSituationalModifier / specialAttackStats).
   int attackValue = thief->specialAttack(victim, SKILL_SUBTERFUGE,
-    situationalMod, STAT_CHA, STAT_INT, STAT_PER, STAT_WIS, true);
+    thief->skillSituationalModifier(victim, SKILL_SUBTERFUGE), true);
 
   if (attackValue <= FAILURE) {
     return subterfugeMiss(thief, victim);
@@ -1391,13 +1381,15 @@ int skulk(TBeing* thief, spellNumT skill) {
   thief->addToMove(-15);
 
   thief->sendTo("You begin practicing your skulking technique.\n\r");
-  act("$n begins practicing $s skulking technique.", TRUE, thief, 0, 0, TO_ROOM);
+  act("$n begins practicing $s skulking technique.", TRUE, thief, 0, 0,
+    TO_ROOM);
 
   // Calculate task time based on skill
   int taskTime = max(5, 20 - (thief->getSkillValue(skill) / 10));
 
   // Start the task
-  start_task(thief, NULL, NULL, TASK_SKULK, "", taskTime, thief->in_room, 0, 0, 0);
+  start_task(thief, NULL, NULL, TASK_SKULK, "", taskTime, thief->in_room, 0, 0,
+    0);
 
   return TRUE;
 }

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -587,6 +587,23 @@ class TBeing : public TThing {
     int specialAttack(TBeing* target, spellNumT, int, bool);
     int specialAttack(TBeing* target, spellNumT, int, statTypeT, statTypeT,
       statTypeT, statTypeT, bool);
+    // The offense/defense stat quartet a skill feeds to specialAttack. Defaults
+    // to FOC/KAR (offense) vs AGI/PER (defense); a few skills override. Single
+    // source so the live roll and the `consider` readout use the same stats.
+    struct SpecialAttackStats {
+        statTypeT off1, off2, def1, def2;
+    };
+    static SpecialAttackStats specialAttackStats(spellNumT skill);
+    // The circumstantial +/- level modifier a specific skill contributes to its
+    // specialAttack roll (on top of specAttackMod's baseline). 0 for most.
+    int skillSituationalModifier(TBeing* victim, spellNumT skill);
+    int bashSituationalModifier(TBeing* victim);
+    // Stealth-strike detection predicates (backstab/throatslit): whether the
+    // victim hears this thief's noisy gear, and whether a suspicious mob spots
+    // the approach. Each drives both a -10 modifier and its own warning
+    // message.
+    bool canHearThief(TBeing* victim);
+    bool spottedBySuspiciousMob(TBeing* victim);
 
     void updateStatistics();
     bool checkForDiceHeld() const;
@@ -982,7 +999,7 @@ class TBeing : public TThing {
     int reconcileLifeforce(spellNumT, bool, int = 0);
     int useLifeforce(spellNumT);
     double usePiety(spellNumT);
-    int reconcileDamage(TBeing*, int, spellNumT);
+    int reconcileDamage(TBeing*, int, spellNumT, int* damDealt = nullptr);
     virtual int doRent(const sstring&);
     void doRestring(const sstring&);
     void doRelease(const sstring&);
@@ -1466,7 +1483,7 @@ class TBeing : public TThing {
     virtual void reconcileHurt(TBeing*, double) { return; }
     int oneHit(TBeing*, primaryTypeT, TThing*, int, float*);
     bool isHitableAggr(TBeing*);
-    void normalHitMessage(TBeing*, TThing*, spellNumT, int, wearSlotT);
+    void normalHitMessage(TBeing*, TThing*, spellNumT, int, wearSlotT, int);
     int monkDodge(TBeing*, TThing*, int*, int, wearSlotT);
     int thiefDodge(TBeing*, TThing*, int*, int, wearSlotT);
     int parryWarrior(TBeing*, TThing*, int*, int, wearSlotT);
@@ -1491,7 +1508,7 @@ class TBeing : public TThing {
     int getActualDamage(TBeing*, TThing*, int, spellNumT);
     int damageEm(int, sstring, spellNumT);
     int skipImmortals(int) const;
-    int applyDamage(TBeing*, int, spellNumT);
+    int applyDamage(TBeing*, int, spellNumT, int* damDealt = nullptr);
     int preProcDam(spellNumT, int);
     int preProcDam(TBeing*, spellNumT, int);
     TBeing* findAnAttacker() const;
@@ -1522,7 +1539,7 @@ class TBeing : public TThing {
     int damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
       int* dam);
     int damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
-      int* dam, spellNumT attackType);
+      int* dam, spellNumT attackType, int* limbDamageDealt = nullptr);
     affectedData* isBleeding(wearSlotT limb);
     affectedData* isBruised(wearSlotT limb);
     affectedData* isInfected(wearSlotT limb);

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -620,6 +620,10 @@ class TBeing : public TThing {
     // Deterministic percent chance (0-100) that specialAttack lands this skill
     // against victim -- mirrors the roll math without rolling. For `consider`.
     int specialAttackChance(TBeing* victim, spellNumT skill);
+    // Skill-agnostic landing chance driven by level gap alone: the
+    // specialAttackChance math stripped to its level-diff term. A rough gauge
+    // for basic `consider`; the per-skill readout stays exact.
+    int genericSpecialAttackChance(TBeing* victim);
 
     void updateStatistics();
     bool checkForDiceHeld() const;

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -592,6 +592,8 @@ class TBeing : public TThing {
     bool canAttack(primaryTypeT);
     int attackRound(const TBeing* target) const;
     int defendRound(const TBeing* attacker) const;
+    // Per-swing melee hit chance vs target, as a percent (5-95).
+    int meleeHitChance(const TBeing* target) const;
     int specAttackMod(const TBeing* target) const;
     int specialAttack(TBeing* target, spellNumT);
     int specialAttack(TBeing* target, spellNumT, int);
@@ -615,6 +617,9 @@ class TBeing : public TThing {
     // message.
     bool canHearThief(TBeing* victim);
     bool spottedBySuspiciousMob(TBeing* victim);
+    // Deterministic percent chance (0-100) that specialAttack lands this skill
+    // against victim -- mirrors the roll math without rolling. For `consider`.
+    int specialAttackChance(TBeing* victim, spellNumT skill);
 
     void updateStatistics();
     bool checkForDiceHeld() const;
@@ -1479,8 +1484,21 @@ class TBeing : public TThing {
     std::pair<int, int> monkBareHandDamRange() const;
     int scaleWeaponDam(const TThing* wielded, primaryTypeT isprimary,
       int wepDam, int rollDam, damRoundT round) const;
+    // Effective melee damage range (min-max) for one hand vs a vital part of v.
+    std::pair<int, int> meleeDamageRange(const TBeing* v, const TThing* wielded,
+      primaryTypeT isprimary) const;
+    // Estimated post-mitigation damage range for a special attack against v,
+    // mirroring reconcileDamage's reductions (resistance, magic-weapon
+    // immunity, protection). Deterministic; brackets the live spread.
+    std::pair<int, int> skillDamageRange(const TBeing* v,
+      spellNumT skill) const;
+    // Percent chance of landing this skill's execution roll (bSuccess),
+    // deterministic and side-effect free -- for consider's skill readout.
+    int skillExecuteChance(spellNumT skill) const;
     // Accumulated crit chance (critSuccessChance units, 1000 == 1%).
     double getCritChance() const;
+    // Per-hit chance to land a critical against v, as a percent.
+    double critChancePercent(const TBeing* v, const TThing* weapon) const;
     virtual float getStrDamModifier() const;
     virtual float getWisDamModifier() const;
     int getDexReaction() const;
@@ -1495,7 +1513,8 @@ class TBeing : public TThing {
     float getChaShopPenalty() const;
     float getSwindleBonus();
     void combatFatigue(TThing*);
-    int weaponCheck(TBeing* v, TThing* o, spellNumT type, int dam);
+    int weaponCheck(const TBeing* v, const TThing* o, spellNumT type,
+      int dam) const;
     virtual void reconcileHelp(TBeing*, double) { return; }
     virtual void reconcileHurt(TBeing*, double) { return; }
     int oneHit(TBeing*, primaryTypeT, TThing*, int, float*);

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -330,7 +330,8 @@ class equipmentData {
 
     // Finds the total sum for objAffect.modifier1 and objAffect.modifier2
     // amongst all worn equipment for the given applyTypeT
-    std::pair<int64_t, int64_t> sumAffectsByApplyType(applyTypeT affectType) {
+    std::pair<int64_t, int64_t> sumAffectsByApplyType(
+      applyTypeT affectType) const {
       int64_t mod1 = 0;
       int64_t mod2 = 0;
 
@@ -357,6 +358,15 @@ class equipmentData {
     equipmentData(const equipmentData& a);
     equipmentData& operator=(const equipmentData& a);
     ~equipmentData();
+};
+
+// Selects which point of a skill's damage spread getSkillDam returns. Random
+// (the default) rolls live; Min/Max return the deterministic endpoints so
+// skillDamageRange can bracket the spread without side effects.
+enum class SkillDamRoll {
+  Random,
+  Min,
+  Max
 };
 
 class TBeing : public TThing {
@@ -571,7 +581,8 @@ class TBeing : public TThing {
     int getAdvLearning(spellNumT) const;
     int getAdvDoLearning(spellNumT) const;
     spellNumT getSkillNum(spellNumT) const;
-    int getSkillDam(const TBeing*, spellNumT, int, int) const;
+    int getSkillDam(const TBeing*, spellNumT, int, int,
+      SkillDamRoll = SkillDamRoll::Random) const;
     void assignCorpsesToRooms();
     void initSkillsBasedOnDiscLearning(discNumT);
     void addAffects(const TObj*);
@@ -1464,6 +1475,12 @@ class TBeing : public TThing {
     int numValidSlots();
     int checkShield(TBeing*, TThing*, wearSlotT, spellNumT, int);
     int getWeaponDam(const TBeing*, const TThing*, primaryTypeT) const;
+    int weaponRollDam(primaryTypeT isprimary) const;
+    std::pair<int, int> monkBareHandDamRange() const;
+    int scaleWeaponDam(const TThing* wielded, primaryTypeT isprimary,
+      int wepDam, int rollDam, damRoundT round) const;
+    // Accumulated crit chance (critSuccessChance units, 1000 == 1%).
+    double getCritChance() const;
     virtual float getStrDamModifier() const;
     virtual float getWisDamModifier() const;
     int getDexReaction() const;

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -1930,50 +1930,29 @@ int TBeing::extraDam(const TBeing* vict, const TBaseWeapon* weap) const {
   return plus;
 }
 
-static int getMonkWeaponDam(const TBeing* ch, const TBeing* v,
-  primaryTypeT isprimary, int rollDam) {
-  int wepDam;
+// KUBO barehand base damage range, before stat/rollDam scaling.
+// getMonkWeaponDam rolls uniformly within this; damage estimates bracket with
+// the endpoints.
+std::pair<int, int> TBeing::monkBareHandDamRange() const {
+  // treat KUBO learnedness as an effective level, then convert to damage
+  double value = 3.0 * double(getSkillValue(SKILL_KUBO)) / 10.0;
+  value = min(max(value, 0.0), 50.0);
+  float weapDam = (6.0 * sqrt(value) / 2.0);
+  weapDam *= balanceCorrectionForLevel(GetMaxLevel());
 
-  if (!ch->doesKnowSkill(SKILL_KUBO))
-    wepDam = ::number(1, 2);
-  else {
-    // somewhat a clumsy way to do this, but realize that player could be
-    // partially learned in KUBO but have some learning in the advanced spec.
-    double value = 3.0 * double(ch->getSkillValue(SKILL_KUBO)) / 10.0;
+  int center = (int)weapDam;
+  int flux = center / 10;
 
-    // enforce range
-    value = min(max(value, 0.0), 50.0);
+  // force an equivalence to ::number(1,2) for low damages
+  int lo = (flux < 1) ? max(1, center - 1) : center - flux;
+  int hi = (flux < 1) ? center + 1 : center + flux;
+  return {max(1, lo), max(1, hi)};
+}
 
-    // essentially, we can treat "value" as being effectively equivalent to
-    // level at this point.  Realize it is made up by looking at how learned
-    // they are in skills rather than simply doing a GetMaxLevel though.
-
-    // convert level to dam
-    float weapDam = (6.0 * sqrt(value) / 2.0);
-
-    // make balance adjustment
-    weapDam *= balanceCorrectionForLevel(ch->GetMaxLevel());
-    wepDam = (int)weapDam;
-
-    // small randomization around value
-    int flux = wepDam / 10;
-
-    // force an equivalence to ::number(1,2) for low damages
-    if (flux < 1)
-      wepDam = ::number(max(1, wepDam - 1), wepDam + 1);
-    else
-      wepDam = ::number(wepDam - flux, wepDam + flux);
-
-    wepDam = max(1, wepDam);
-  }
-
-  // OK, so if they are incap'd, make the kill go quickly...
-  if (v->getPosition() <= POSITION_INCAP)
-    wepDam += max((3 * wepDam / 10), 1);
-
-  if (v->getPosition() <= POSITION_DEAD)
-    return (0);
-
+// Stat/rounding/global scaling half of KUBO barehand damage, split out so
+// estimates can reuse the exact math with a forced rounding direction.
+static int scaleMonkWeaponDam(const TBeing* ch, int wepDam, int rollDam,
+  damRoundT round) {
   // account for stats
   float statDam = ch->getStrDamModifier();
 
@@ -1991,8 +1970,17 @@ static int getMonkWeaponDam(const TBeing* ch, const TBeing* v,
   int dam = (int)(wepDam * statDam);
 
   float tmp = ((wepDam * statDam) - dam) * 100;
-  if (tmp > ::number(0, 99)) {
-    dam++;
+  switch (round) {
+    case DAM_ROUND_STOCHASTIC:
+      if (tmp > ::number(0, 99))
+        dam++;
+      break;
+    case DAM_ROUND_UP:
+      if (tmp > 0)
+        dam++;
+      break;
+    case DAM_ROUND_DOWN:
+      break;
   }
 
   // add bonuses
@@ -2001,12 +1989,34 @@ static int getMonkWeaponDam(const TBeing* ch, const TBeing* v,
   // adjust for global values
   dam = (int)(dam * stats.barehand_damage_mod);
 
+  return dam;
+}
+
+static int getMonkWeaponDam(const TBeing* ch, const TBeing* v,
+  primaryTypeT isprimary, int rollDam) {
+  int wepDam;
+
+  if (!ch->doesKnowSkill(SKILL_KUBO))
+    wepDam = ::number(1, 2);
+  else {
+    auto [lo, hi] = ch->monkBareHandDamRange();
+    wepDam = ::number(lo, hi);
+  }
+
+  // OK, so if they are incap'd, make the kill go quickly...
+  if (v->getPosition() <= POSITION_INCAP)
+    wepDam += max((3 * wepDam / 10), 1);
+
+  if (v->getPosition() <= POSITION_DEAD)
+    return (0);
+
+  int dam = scaleMonkWeaponDam(ch, wepDam, rollDam, DAM_ROUND_STOCHASTIC);
+
 #if DAMAGE_DEBUG
   vlogf(LOG_COMBAT,
-    format(
-      "MONK %s (%d %s) barehand dam = %d , wep = %d roll = %d, stats = %.2f") %
+    format("MONK %s (%d %s) barehand dam = %d , wep = %d roll = %d") %
       ch->getName() % ch->GetMaxLevel() % ch->getProfName() % dam % wepDam %
-      rollDam % statDam);
+      rollDam);
 #endif
 
   return (dam);
@@ -2033,21 +2043,11 @@ static int getMonkWeaponDam(const TBeing* ch, const TBeing* v,
 // 2h (unlearned) = 110% dam
 // 2h maxed spec = 165% dam
 //
-int TBeing::getWeaponDam(const TBeing* v, const TThing* wielded,
-  primaryTypeT isprimary) const {
-  int bonusDam = 0;
-  int rollDam = 0;
-  int wepLearn = 0;
-  float tempDam = 0.0;
-  float statDam = 0.0;
-  int dam = 0;
-  spellNumT skill = SKILL_BAREHAND_PROF;
-  char buf[MAX_NAME_LENGTH];
+// Damroll for one hand, less the off-hand weapon's damroll when dual-wielding
+// unpaired weapons (so each hand only counts its own contribution).
+int TBeing::weaponRollDam(primaryTypeT isprimary) const {
+  int rollDam = getDamroll();
 
-  rollDam += getDamroll();
-  strcpy(buf, "Barehand");
-
-  // strip off affects of dual wields
   if (isprimary) {
     TObj* obj = dynamic_cast<TObj*>(heldInSecHand());
     if (obj && !obj->isPaired())
@@ -2057,6 +2057,13 @@ int TBeing::getWeaponDam(const TBeing* v, const TThing* wielded,
     if (obj && !obj->isPaired())
       rollDam -= obj->itemDamroll();
   }
+
+  return rollDam;
+}
+
+int TBeing::getWeaponDam(const TBeing* v, const TThing* wielded,
+  primaryTypeT isprimary) const {
+  int rollDam = weaponRollDam(isprimary);
 
   int wepDam = 0;
   const TMonster* tmon = dynamic_cast<const TMonster*>(this);
@@ -2099,21 +2106,32 @@ int TBeing::getWeaponDam(const TBeing* v, const TThing* wielded,
   if (v->getPosition() <= POSITION_DEAD)
     return (0);
 
+  return scaleWeaponDam(wielded, isprimary, wepDam, rollDam,
+    DAM_ROUND_STOCHASTIC);
+}
+
+// The deterministic scaling half of getWeaponDam, split out so damage
+// estimates (see meleeDamageRange) can reuse the exact live-combat math.
+// Only the fractional-rounding step is non-deterministic; `round` selects it:
+// STOCHASTIC reproduces real combat, DOWN/UP give the true min/max for a range.
+int TBeing::scaleWeaponDam(const TThing* wielded, primaryTypeT isprimary,
+  int wepDam, int rollDam, damRoundT round) const {
+  int bonusDam = 0;
+  int wepLearn = 0;
+  float tempDam = 0.0;
+  float statDam = 0.0;
+  int dam = 0;
+  spellNumT skill = SKILL_BAREHAND_PROF;
+
   if (!dynamic_cast<const TMonster*>(this) || (polyed == POLY_TYPE_DISGUISE)) {
     if (!wielded) {
       skill = SKILL_BAREHAND_PROF;
-      // skill2 = SKILL_BAREHAND_SPEC;
-      strcpy(buf, "Barehand");
       statDam = getStrDamModifier();
     } else if (wielded->isBluntWeapon()) {
       skill = SKILL_BLUNT_PROF;
-      // skill2 = SKILL_BLUNT_SPEC;
-      strcpy(buf, "Blunt");
       statDam = getStrDamModifier();
     } else if (wielded->isPierceWeapon()) {
       skill = SKILL_PIERCE_PROF;
-      // skill2 = SKILL_PIERCE_SPEC;
-      strcpy(buf, "Pierce");
       statDam = getStrDamModifier();
 
       // pierce weapons only get 1/3 of the strength modifier
@@ -2122,8 +2140,6 @@ int TBeing::getWeaponDam(const TBeing* v, const TThing* wielded,
       statDam += 1;
     } else if (wielded->isSlashWeapon()) {
       skill = SKILL_SLASH_PROF;
-      // skill2 = SKILL_SLASH_SPEC;
-      strcpy(buf, "Slash");
       statDam = getStrDamModifier();
 
       // slash weapons only get 1/2 of the strength modifier
@@ -2157,18 +2173,20 @@ int TBeing::getWeaponDam(const TBeing* v, const TThing* wielded,
     weapDam *= min(wepLearn, 4 * GetMaxLevel());
     weapDam /= 100;
 
-#if 0
-// Whoa, don't make specialize do more dam, it adds attacks so would
-// double count...
-    // take specialize into account
-    // weapDam is about 25, want to add about 10 for L25 to L35
-    weapDam += .004 * max((byte) 0, getSkillValue(skill2)) * weapDam;
-#endif
-
     dam = (int)weapDam;
     tempDam = weapDam - dam;
-    if (::number(0, 100) < (tempDam * 100))
-      dam += 1;
+    switch (round) {
+      case DAM_ROUND_STOCHASTIC:
+        if (::number(0, 100) < (tempDam * 100))
+          dam += 1;
+        break;
+      case DAM_ROUND_UP:
+        if (tempDam > 0)
+          dam += 1;
+        break;
+      case DAM_ROUND_DOWN:
+        break;
+    }
 
     // c.f. BALANCE NOTES for discussion of why this is done
     // basically, we don't want dual-wielding to be on par with single-wielding

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -2228,6 +2228,79 @@ int TBeing::scaleWeaponDam(const TThing* wielded, primaryTypeT isprimary,
   return (dam);
 }
 
+// Vital-part effective melee damage range (min-max) for one hand against v,
+// mirroring the live pipeline: scaleWeaponDam -> damage-type resistance ->
+// vital-slot armor absorption. Deterministic (rounds forced), so it brackets
+// the same spread real combat rolls. Returns {0,0} when no melee estimate
+// applies (guns, non-weapon items, or KUBO-barehand which uses its own damage
+// pipeline).
+std::pair<int, int> TBeing::meleeDamageRange(const TBeing* v,
+  const TThing* wielded, primaryTypeT isprimary) const {
+  if (dynamic_cast<const TGun*>(wielded))
+    return {0, 0};
+
+  int rollDam = weaponRollDam(isprimary);
+  int rawMin = 0, rawMax = 0;
+  if (const TBaseWeapon* weap = dynamic_cast<const TBaseWeapon*>(wielded)) {
+    // Bracket swungObjectDamage(): baseDamage +/- flux, plus the deterministic
+    // extraDam bonus vs the target.
+    double base = weap->baseDamage();
+    int flux = static_cast<int>(base * weap->getWeapDamDev() / 10.0);
+    int extra = extraDam(v, weap);
+    rawMin = scaleWeaponDam(wielded, isprimary,
+      static_cast<int>(base) - flux + extra, rollDam, DAM_ROUND_DOWN);
+    rawMax = scaleWeaponDam(wielded, isprimary,
+      static_cast<int>(base) + flux + extra, rollDam, DAM_ROUND_UP);
+  } else if (!wielded && doesKnowSkill(SKILL_KUBO)) {
+    // KUBO barehand uses its own damage pipeline (getMonkWeaponDam).
+    auto [lo, hi] = monkBareHandDamRange();
+    rawMin = scaleMonkWeaponDam(this, lo, rollDam, DAM_ROUND_DOWN);
+    rawMax = scaleMonkWeaponDam(this, hi, rollDam, DAM_ROUND_UP);
+  } else if (!wielded) {
+    // plain barehand: ::number(1, 3)
+    rawMin = scaleWeaponDam(wielded, isprimary, 1, rollDam, DAM_ROUND_DOWN);
+    rawMax = scaleWeaponDam(wielded, isprimary, 3, rollDam, DAM_ROUND_UP);
+  } else {
+    return {0,
+      0};  // holding a non-weapon (shield, light, etc.): no melee swing
+  }
+
+  spellNumT wtype = getAttackType(wielded, isprimary);
+  int imm = v->getImmunity(getTypeImmunity(wtype));
+  int protection = v->getProtection();
+
+  // Apply the non-armor damage reductions in combat order: damage-type
+  // resistance (preProcDam), magic-weapon immunity (weaponCheck), then
+  // sanctuary/protection (applyDamage). Armor absorption is intentionally NOT
+  // applied, and limb-specific reductions (brawn, level-split) don't apply to a
+  // body hit. Chance-based mitigation (dodge/parry, pierce-resist proc) is also
+  // omitted.
+  auto effective = [&](int raw) {
+    int dam = raw * max(0, 100 - imm) / 100;
+    dam = weaponCheck(v, wielded, wtype, dam);
+    dam = (dam * (100 - protection) + 50) / 100;
+    return max(1, dam);
+  };
+
+  return {effective(rawMin), effective(rawMax)};
+}
+
+// Attacker's per-hit chance to land a critical vs v, as a percent. Mirrors the
+// crit-chance accumulation in critSuccessChance() -- keep the two in sync --
+// and applies the same gun/immunity guards. Severity (crit size) is
+// HP-dependent and deliberately not modeled here.
+double TBeing::critChancePercent(const TBeing* v, const TThing* weapon) const {
+  if (dynamic_cast<const TGun*>(weapon) || isAffected(AFF_ENGAGER))
+    return 0.0;
+
+  spellNumT wtype = getAttackType(weapon, HAND_PRIMARY);
+  if (v->isImmune(getTypeImmunity(wtype), WEAR_BODY))
+    return 0.0;
+
+  // getCritChance() returns critSuccessChance's units where 1000 == 1%.
+  return max(0.0, getCritChance() / 1000.0);
+}
+
 static void checkLearnFromHit(TBeing* ch, int tarLevel, TThing* o,
   bool isPrimary, spellNumT w_type) {
   int myLevel = ch->GetMaxLevel();
@@ -3231,6 +3304,51 @@ int TBeing::skillSituationalModifier(TBeing* victim, spellNumT skill) {
   }
 }
 
+// Deterministic mirror of specialAttack's landing probability: the percentage
+// of d100 rolls that resolve to a hit (COMPLETE_SUCCESS or better), using the
+// same modifier, clamp, level, and stat math the live roll runs -- but without
+// rolling or any side effects. For the `consider` readout. Must be kept in
+// lockstep with the roll logic in specialAttack() below. Models skulk's
+// post-clamp bonus while that affect is active (a consumed one-shot: the shown
+// odds hold for the next strike only), but not the stealth/surprise wary
+// penalty, so it is only offered for non-surprise specialAttack skills.
+int TBeing::specialAttackChance(TBeing* victim, spellNumT skill) {
+  int mod = skillSituationalModifier(victim, skill) + specAttackMod(victim);
+
+  if (mod < SITUATIONAL_MOD_LOWER_BOUND)
+    mod = SITUATIONAL_MOD_LOWER_BOUND;
+  else if (mod > SITUATIONAL_MOD_UPPER_BOUND)
+    mod = SITUATIONAL_MOD_UPPER_BOUND;
+
+  // Skulk is a prepared one-shot added past the clamp, so it lifts the odds
+  // above the situational cap for exactly the next strike. Mirror the live
+  // post-clamp add so a skulking attacker's readout matches the real roll.
+  if (affectedBySpell(SKILL_SKULK))
+    mod += 3 + std::min(4, getSkillValue(SKILL_SKULK) / 25);
+
+  // Level difference is applied after the clamp, matching specialAttack.
+  int attackerLevel = GetMaxLevel(), defenderLevel = victim->GetMaxLevel();
+  mod += (attackerLevel > defenderLevel && isPc())
+           ? (attackerLevel - defenderLevel)
+           : ((attackerLevel - defenderLevel) / 5);
+
+  SpecialAttackStats s = specialAttackStats(skill);
+  double statRatio = getStatMod(s.off1) *
+                     plotStat(STAT_CURRENT, s.off2, 0.92, 1.08, 1.0) /
+                     victim->getStatMod(s.def1) /
+                     victim->plotStat(STAT_CURRENT, s.def2, 0.92, 1.08, 1.0);
+
+  // roll' = (roll - mod) * statRatio; the attack lands when roll' <
+  // SUCCESS_THRESHOLD (guaranteed-success rolls are a subset). Count the d100
+  // outcomes that land -- the count is the percentage.
+  int hits = 0;
+  for (int roll = 1; roll <= 100; roll++) {
+    if ((roll - mod) * statRatio < SUCCESS_THRESHOLD)
+      hits++;
+  }
+  return hits;
+}
+
 // specialAttack() is used for combat specials like kick, bash, grapple, etc.
 int TBeing::specialAttack(TBeing* target, spellNumT skill) {
   int rc = specialAttack(target, skill, 0);
@@ -3406,6 +3524,15 @@ int TBeing::hits(TBeing* v, int mod) {
     return TRUE;
   else
     return FALSE;
+}
+
+// Per-swing chance to land a normal melee hit on target, as a percent.
+// Mirrors the factor math in hits(): the 5% guaranteed hit/miss zones clamp
+// the result to 5-95 regardless of how lopsided the modifiers are.
+int TBeing::meleeHitChance(const TBeing* target) const {
+  int mod = attackRound(target) - target->defendRound(this);
+  int factor = min(max(600 + 9 * mod / 5, 50), 950);
+  return factor / 10;
 }
 
 // returns DELETE_THIS
@@ -4772,7 +4899,8 @@ int TBeing::preProcDam(TBeing* vict, spellNumT type, int dam) {
 
 // Handles the reduction of weapon damage due to weapon-related resists. Only
 // affects attacks that are resisted by slash, blunt, or pierce immunity.
-int TBeing::weaponCheck(TBeing* vict, TThing* o, spellNumT type, int dam) {
+int TBeing::weaponCheck(const TBeing* vict, const TThing* o, spellNumT type,
+  int dam) const {
   immuneTypeT attackResistType = getTypeImmunity(type);
 
   // Check immunity type of incoming attack. If it deals slash, blunt, or pierce
@@ -4793,7 +4921,7 @@ int TBeing::weaponCheck(TBeing* vict, TThing* o, spellNumT type, int dam) {
   };
 
   int magicLevel = 0;
-  auto* tobj = dynamic_cast<TObj*>(o);
+  const auto* tobj = dynamic_cast<const TObj*>(o);
 
   if (tobj) {
     magicLevel = min(tobj->itemHitroll(), 3);

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -3349,6 +3349,27 @@ int TBeing::specialAttackChance(TBeing* victim, spellNumT skill) {
   return hits;
 }
 
+// Skill-agnostic sibling of specialAttackChance: the same d100 count reduced to
+// its level-gap term only -- no situational modifier, and a stat ratio fixed at
+// 1.0. Models the "bonus vs lower-level foes" asymmetry the live roll applies (a
+// PC gains a full point per level it out-levels the target, but loses only a
+// fifth of a point per level under). A coarse "does my level let me land
+// specials here" gauge for basic `consider`. Keep the level-diff formula in
+// lockstep with specialAttack() below.
+int TBeing::genericSpecialAttackChance(TBeing* victim) {
+  int attackerLevel = GetMaxLevel(), defenderLevel = victim->GetMaxLevel();
+  int mod = (attackerLevel > defenderLevel && isPc())
+              ? (attackerLevel - defenderLevel)
+              : ((attackerLevel - defenderLevel) / 5);
+
+  int hits = 0;
+  for (int roll = 1; roll <= 100; roll++) {
+    if (roll - mod < SUCCESS_THRESHOLD)
+      hits++;
+  }
+  return hits;
+}
+
 // specialAttack() is used for combat specials like kick, bash, grapple, etc.
 int TBeing::specialAttack(TBeing* target, spellNumT skill) {
   int rc = specialAttack(target, skill, 0);

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -2247,10 +2247,27 @@ std::pair<int, int> TBeing::meleeDamageRange(const TBeing* v,
     double base = weap->baseDamage();
     int flux = static_cast<int>(base * weap->getWeapDamDev() / 10.0);
     int extra = extraDam(v, weap);
-    rawMin = scaleWeaponDam(wielded, isprimary,
-      static_cast<int>(base) - flux + extra, rollDam, DAM_ROUND_DOWN);
-    rawMax = scaleWeaponDam(wielded, isprimary,
-      static_cast<int>(base) + flux + extra, rollDam, DAM_ROUND_UP);
+    int swungMin = static_cast<int>(base) - flux + extra;
+    int swungMax = static_cast<int>(base) + flux + extra;
+
+    const TMonster* tmon = dynamic_cast<const TMonster*>(this);
+    if (tmon && !(polyed == POLY_TYPE_DISGUISE)) {
+      // NPC wielding: raw damage is the mob's innate damage plus 1/10 of the
+      // weapon swing (the weapon bonus is withheld from a PC's charmed pet),
+      // mirroring getWeaponDam()'s NPC branch. The mob's own damage dominates,
+      // so bracketing off the weapon's full base badly misjudges it.
+      auto [mobLo, mobHi] = tmon->getMobDamageRange();
+      bool pet = tmon->master && tmon->master->isPc();
+      rawMin = scaleWeaponDam(wielded, isprimary,
+        max(1, mobLo) + (pet ? 0 : swungMin / 10), rollDam, DAM_ROUND_DOWN);
+      rawMax = scaleWeaponDam(wielded, isprimary,
+        max(1, mobHi) + (pet ? 0 : swungMax / 10), rollDam, DAM_ROUND_UP);
+    } else {
+      rawMin =
+        scaleWeaponDam(wielded, isprimary, swungMin, rollDam, DAM_ROUND_DOWN);
+      rawMax =
+        scaleWeaponDam(wielded, isprimary, swungMax, rollDam, DAM_ROUND_UP);
+    }
   } else if (!wielded && doesKnowSkill(SKILL_KUBO)) {
     // KUBO barehand uses its own damage pipeline (getMonkWeaponDam).
     auto [lo, hi] = monkBareHandDamRange();

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -25,6 +25,8 @@
 #include "materials.h"
 #include "range.h"
 #include "combat.h"
+#include "obj_base_weapon.h"
+#include "obj_base_clothing.h"
 #include "spells.h"
 #include "statistics.h"
 #include "person.h"
@@ -926,7 +928,9 @@ int TBeing::damageLimb(TBeing* v, const wearSlotT part_hit,
 }
 
 int TBeing::damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
-  int* dam, const spellNumT attackType) {
+  int* dam, const spellNumT attackType, int* limbDamageDealt) {
+  if (limbDamageDealt)
+    *limbDamageDealt = 0;
   auto damage = static_cast<double>(*dam);
 
   // Don't do damage to vital limbs, as destroying one would lead to instant
@@ -1027,6 +1031,11 @@ int TBeing::damageLimb(TBeing* v, wearSlotT part_hit, const TThing* maybeWeapon,
 
   // Ensure at least 1 damage is done to the limb
   const int limbDamage = max(static_cast<int>(damage * levelRatio), 1);
+
+  // Report the uncapped limb-portion damage so callers can show real numbers
+  // (hurtLimb below caps the applied amount at the limb's remaining health).
+  if (limbDamageDealt)
+    *limbDamageDealt = limbDamage;
 
   // Prevent accidental negative damage
   const int mainHpDamage = max(static_cast<int>(damage - limbDamage), 0);
@@ -3086,6 +3095,124 @@ int TBeing::specAttackMod(const TBeing* target) const {
   return mod;
 }
 
+// The offense/defense stats a skill rolls with. Most use FOC/KAR vs AGI/PER;
+// the overrides here mirror what each skill's call site historically passed to
+// the eight-argument specialAttack overload.
+TBeing::SpecialAttackStats TBeing::specialAttackStats(spellNumT skill) {
+  switch (skill) {
+    case SKILL_STABBING:
+      return {STAT_DEX, STAT_SPE, STAT_AGI, STAT_PER};
+    case SKILL_GRAPPLE:
+      return {STAT_STR, STAT_DEX, STAT_BRA, STAT_AGI};
+    case SKILL_SUBTERFUGE:
+      return {STAT_CHA, STAT_INT, STAT_PER, STAT_WIS};
+    default:
+      return {STAT_FOC, STAT_KAR, STAT_AGI, STAT_PER};
+  }
+}
+
+// Bash's circumstantial modifier: advanced-discipline mastery plus an
+// attacker/victim weight differential, each converted into "levels" of
+// advantage. Deliberately over-provisioned so a competent basher reliably hits
+// the situational cap even when other bonuses are absent -- see the clamp in
+// specialAttack(). Extracted verbatim from the old inline cmd_bash.cc block so
+// the live attack and the `consider` readout share one source.
+int TBeing::bashSituationalModifier(TBeing* victim) {
+  int advLearnedness = getAdvLearning(getSkillNum(SKILL_BASH));
+  TBaseWeapon* weaponInPrimaryHand =
+    dynamic_cast<TBaseWeapon*>(heldInPrimHand());
+  TBaseClothing* itemInSecondaryHand =
+    dynamic_cast<TBaseClothing*>(heldInSecHand());
+  bool isWielding2Hander =
+    weaponInPrimaryHand && weaponInPrimaryHand->isPaired();
+  bool isHoldingShield = itemInSecondaryHand && itemInSecondaryHand->isShield();
+
+  // Per combat.cc balance notes, 16.667 points of mod is equivalent to one
+  // level's worth of advantage/disadvantage.
+  const float ONE_LEVEL = 16.667;
+  float modifier = 0.0;
+
+  // Maxed advanced disc lets one bash as if they were 10 levels higher. Bonus
+  // increases linearly with advanced disc learnedness.
+  modifier += ONE_LEVEL * ((float)advLearnedness / 10.0);
+
+  // Attacker with advanced disc using shield to bash can get another bonus of
+  // up to +5 levels to distinguish shield bashing from weapon/shoulder bashing
+  // and also makes bash more of a tank-centric ability.
+  modifier += ONE_LEVEL * ((float)advLearnedness / 20.0);
+
+  float attackerWeight = getWeight();
+  float victimWeight = victim->getWeight();
+
+  // Include attacker's shield or two-handed weapon in weight calculation
+  if (isHoldingShield)
+    attackerWeight += itemInSecondaryHand->getWeight();
+  else if (isWielding2Hander)
+    attackerWeight += weaponInPrimaryHand->getWeight();
+
+  // Each 20% weight difference between attacker and victim modifies chance by
+  // one level's worth, up to max of +/- 10 levels.
+  if (attackerWeight > victimWeight)
+    modifier +=
+      ONE_LEVEL * min(10.0, ((attackerWeight - victimWeight) / victimWeight) *
+                              100.0 / 20.0);
+  else if (victimWeight > attackerWeight)
+    modifier -=
+      ONE_LEVEL * min(10.0, ((victimWeight - attackerWeight) / attackerWeight) *
+                              100.0 / 20.0);
+
+  return static_cast<int>(modifier);
+}
+
+// A noisy-geared thief is heard when the victim is awake to hear it.
+bool TBeing::canHearThief(TBeing* victim) {
+  return makesNoise() && victim->awake();
+}
+
+// A suspicious mob that can see the thief catches the approach at the last
+// moment. Players don't get this reflexive detection.
+bool TBeing::spottedBySuspiciousMob(TBeing* victim) {
+  return victim->awake() && victim->canSee(this) && !victim->isPc() &&
+         dynamic_cast<TMonster*>(victim)->isSusp();
+}
+
+// The per-skill situational modifier passed to specialAttack. Most skills add
+// nothing; the ones that do compute it from the attacker/victim matchup.
+int TBeing::skillSituationalModifier(TBeing* victim, spellNumT skill) {
+  switch (skill) {
+    // getSkillNum(SKILL_BASH) yields the deikhan variant for that class.
+    case SKILL_BASH:
+    case SKILL_BASH_DEIKHAN:
+      return bashSituationalModifier(victim);
+    // Backstab and throatslit share the same stealth-approach math: quieter and
+    // less visible is better, minus penalties when the victim hears or spots
+    // you. The matching warning messages live at each skill's call site.
+    case SKILL_BACKSTAB:
+    case SKILL_THROATSLIT: {
+      int mod = -(noise(this) / 20) + visibility() / 15;
+      if (canHearThief(victim))
+        mod -= 10;
+      if (spottedBySuspiciousMob(victim))
+        mod -= 10;
+      return mod;
+    }
+    case SKILL_SUBTERFUGE: {
+      // A dull-witted victim is easier to fool; a charismatic con artist sells
+      // it better.
+      int mod = 0;
+      if (!victim->isWise())
+        mod -= 10;
+      if (!victim->isIntelligent())
+        mod -= 10;
+      if (isCharismatic())
+        mod += 10;
+      return mod;
+    }
+    default:
+      return 0;
+  }
+}
+
 // specialAttack() is used for combat specials like kick, bash, grapple, etc.
 int TBeing::specialAttack(TBeing* target, spellNumT skill) {
   int rc = specialAttack(target, skill, 0);
@@ -3101,14 +3228,16 @@ int TBeing::specialAttack(TBeing* target, spellNumT skill) {
 */
 int TBeing::specialAttack(TBeing* target, spellNumT skill,
   int situationalModifier) {
-  return specialAttack(target, skill, situationalModifier, STAT_FOC, STAT_KAR,
-    STAT_AGI, STAT_PER, false);
+  auto s = specialAttackStats(skill);
+  return specialAttack(target, skill, situationalModifier, s.off1, s.off2,
+    s.def1, s.def2, false);
 }
 
 int TBeing::specialAttack(TBeing* target, spellNumT skill,
   int situationalModifier, bool partialSuccessAllowed) {
-  return specialAttack(target, skill, situationalModifier, STAT_FOC, STAT_KAR,
-    STAT_AGI, STAT_PER, partialSuccessAllowed);
+  auto s = specialAttackStats(skill);
+  return specialAttack(target, skill, situationalModifier, s.off1, s.off2,
+    s.def1, s.def2, partialSuccessAllowed);
 }
 
 int TBeing::specialAttack(TBeing* target, spellNumT skill,
@@ -3632,14 +3761,10 @@ const char* describe_dam(int dam, int dam_capacity, spellNumT wtype) {
   return "pathetically";
 }
 
-static int REALNUM(TBeing* ch, wearSlotT part_hit) {
-  return (
-    isVitalPart(part_hit) ? ch->getHit() + 11 : ch->getCurLimbHealth(part_hit));
-}
-
 void TBeing::normalHitMessage(TBeing* v, TThing* weapon, spellNumT w_type,
-  int dam, wearSlotT part_hit) {
-  char buf[512];
+  int dam, wearSlotT part_hit, int hpCapacity) {
+  // Color the damage number by the pool it hit: red for HP, cyan for limb.
+  const char* dmgColor = isVitalPart(part_hit) ? "<r>" : "<c>";
   TThing* t = NULL;
   TBeing* other;
 
@@ -3681,19 +3806,16 @@ void TBeing::normalHitMessage(TBeing* v, TThing* weapon, spellNumT w_type,
     if (dam || !(other->desc->autobits & AUTO_NOSPAM)) {
       strcpy(namebuf, other->pers(this));
       strcpy(victbuf, other->pers(v));
-      strcpy(buf, sstring(namebuf).cap().c_str());
-      sprintf(buf + strlen(buf), " %s ", attack_hit_text[w_type].plural);
-      sprintf(buf + strlen(buf), "%s's ", victbuf);
-      sprintf(buf + strlen(buf), "%s ", v->describeBodySlot(part_hit).c_str());
-      sprintf(buf + strlen(buf), "%s",
-        describe_dam(dam, REALNUM(v, part_hit), w_type));
-      sprintf(buf + strlen(buf), "%s", (weapon) ? " with " : "");
-      sprintf(buf + strlen(buf), "%s", (weapon) ? hshr() : "");
-      sprintf(buf + strlen(buf), "%s", (weapon) ? " " : "");
-      sprintf(buf + strlen(buf), "%s.\n\r",
-        weapon ? other->objn(weapon).c_str() : "");
+      sstring weaponPart =
+        weapon ? sstring(format(" with %s %s") % hshr() % other->objn(weapon))
+               : sstring("");
+      sstring msg = format("%s %s %s's %s %s%s (%s%d<1>).\n\r") %
+                    sstring(namebuf).cap() % attack_hit_text[w_type].plural %
+                    victbuf % v->describeBodySlot(part_hit) %
+                    describe_dam(dam, hpCapacity, w_type) % weaponPart %
+                    dmgColor % dam;
 
-      other->sendTo(COLOR_MOBS, buf);
+      other->sendTo(COLOR_MOBS, msg);
       if (snd != MIN_SOUND_NUM)
         other->playsound(snd, SOUND_TYPE_COMBAT, 100, 20, 1);
     }
@@ -3706,13 +3828,14 @@ void TBeing::normalHitMessage(TBeing* v, TThing* weapon, spellNumT w_type,
     else
       strcpy(colorBuf, green());
 
-    sprintf(buf, "You %s%s%s $N's %s%s%s %s%s%s.", colorBuf,
-      attack_hit_text[w_type].singular, norm(), colorBuf,
-      v->describeBodySlot(part_hit).c_str(), norm(),
-      describe_dam(dam, REALNUM(v, part_hit), w_type),
-      (weapon) ? " with your " : "", (weapon) ? objn(weapon).c_str() : "");
+    sstring msg = format("You %s%s%s $N's %s%s%s %s%s%s (%s%d<1>).") %
+                  colorBuf % attack_hit_text[w_type].singular % norm() %
+                  colorBuf % v->describeBodySlot(part_hit) % norm() %
+                  describe_dam(dam, hpCapacity, w_type) %
+                  (weapon ? " with your " : "") %
+                  (weapon ? objn(weapon) : sstring("")) % dmgColor % dam;
 
-    act(buf, FALSE, this, 0, v, TO_CHAR);
+    act(msg, false, this, 0, v, TO_CHAR);
     if (snd != MIN_SOUND_NUM)
       playsound(snd, SOUND_TYPE_COMBAT, 100, 20, 1);
   }
@@ -3723,13 +3846,13 @@ void TBeing::normalHitMessage(TBeing* v, TThing* weapon, spellNumT w_type,
     else
       strcpy(colorBuf, v->red());
 
-    sprintf(buf, "$n %s%s%s your %s%s%s %s%s%s.", colorBuf,
-      attack_hit_text[w_type].plural, v->norm(), colorBuf,
-      v->describeBodySlot(part_hit).c_str(), v->norm(),
-      describe_dam(dam, REALNUM(v, part_hit), w_type),
-      ((weapon) ? " with $s " : ""),
-      ((weapon) ? fname(weapon->name).c_str() : ""));
-    act(buf, FALSE, this, 0, v, TO_VICT);
+    sstring msg = format("$n %s%s%s your %s%s%s %s%s%s (%s%d<1>).") % colorBuf %
+                  attack_hit_text[w_type].plural % v->norm() % colorBuf %
+                  v->describeBodySlot(part_hit) % v->norm() %
+                  describe_dam(dam, hpCapacity, w_type) %
+                  (weapon ? " with $s " : "") %
+                  (weapon ? fname(weapon->name) : sstring("")) % dmgColor % dam;
+    act(msg, false, this, 0, v, TO_VICT);
     if (snd != MIN_SOUND_NUM)
       v->playsound(snd, SOUND_TYPE_COMBAT, 100, 20, 1);
   }
@@ -4366,7 +4489,14 @@ int TBeing::oneHit(TBeing* vict, primaryTypeT isprimary, TThing* weapon,
     }
     breakStealth();
 
+    // The hit message is emitted after damage is applied (below) so it can
+    // report the HP actually drained. Decide what to show here; emit later.
+    bool showHitMsg = false;
+    TThing* hitMsgWeapon = weapon;
+    spellNumT hitMsgWtype = w_type;
+
     if (mess_sent == 0) {
+      showHitMsg = true;
       if (doesKnowSkill(SKILL_ADVANCED_KICKING) && !weapon && isPc()) {
         // switch some "hits" to "kicks"
         // this is strictly textual and doesn't impact damage at all
@@ -4376,12 +4506,9 @@ int TBeing::oneHit(TBeing* vict, primaryTypeT isprimary, TThing* weapon,
         iskick += 1.25;
         iskick *= (isprimary ? 0.6 : 0.4);
 
-        if (*f <= iskick)
-          normalHitMessage(vict, NULL, TYPE_KICK, dam, part_hit);
-        else
-          normalHitMessage(vict, NULL, w_type, dam, part_hit);
-      } else
-        normalHitMessage(vict, weapon, w_type, dam, part_hit);
+        hitMsgWeapon = nullptr;
+        hitMsgWtype = (*f <= iskick) ? TYPE_KICK : w_type;
+      }
 
       if (doesKnowSkill(SKILL_CHAIN_ATTACK) && (::number(0, 99) < 10) &&
           getMana() >= 5 && bSuccess(SKILL_CHAIN_ATTACK)) {
@@ -4534,11 +4661,33 @@ int TBeing::oneHit(TBeing* vict, primaryTypeT isprimary, TThing* weapon,
 
     }  // end check for SENT_MESS
 
+    // Measure the damage this hit actually dealt, after all reductions, so the
+    // message can report the real number. A vital hit drains the HP pool; a
+    // limb hit mostly drains the (tiny, easily-overkilled) limb pool, so we add
+    // the uncapped limb-portion damage reported by damageLimb to the HP drain.
+    const int hpBefore = vict->getHit();
+    const int limbCapBefore = vict->getCurLimbHealth(part_hit);
+    int limbDealt = 0;
+    auto emitHitMsg = [&]() {
+      if (!showHitMsg)
+        return;
+      // One number, colored by the pool it hit: HP damage (red) for vital
+      // hits, limb damage (cyan) for limb hits. Judge severity against that
+      // same pool.
+      const int dealt =
+        isVitalPart(part_hit) ? (hpBefore - vict->getHit()) : limbDealt;
+      const int capacity =
+        isVitalPart(part_hit) ? hpBefore + 11 : limbCapBefore;
+      normalHitMessage(vict, hitMsgWeapon, hitMsgWtype, dealt, part_hit,
+        capacity);
+    };
+
     if (vict->equipment[part_hit])
       vict->damageItem(this, part_hit, w_type, weapon, dam);
 
-    damaged_limb = damageLimb(vict, part_hit, weapon, &dam, w_type);
+    damaged_limb = damageLimb(vict, part_hit, weapon, &dam, w_type, &limbDealt);
     if (IS_SET_DELETE(damaged_limb, DELETE_VICT)) {
+      emitHitMsg();
       critKillCheck(this, vict, mess_sent);
       return retCode | DELETE_VICT;
     }
@@ -4552,12 +4701,14 @@ int TBeing::oneHit(TBeing* vict, primaryTypeT isprimary, TThing* weapon,
     if (!damaged_limb) {
       rc = applyDamage(vict, dam, w_type);
       if (IS_SET_DELETE(rc, DELETE_VICT)) {
+        emitHitMsg();
         critKillCheck(this, vict, mess_sent);
         combatFatigue(weapon);
         updatePos();
         return (retCode | DELETE_VICT);
       }
     }
+    emitHitMsg();
   }
 
   combatFatigue(weapon);

--- a/code/code/misc/crit_combat.cc
+++ b/code/code/misc/crit_combat.cc
@@ -561,6 +561,54 @@ void TBeing::critHitEqDamage(TBeing* v, TThing* obj, int eqdam) {
 
 // returns DELETE_VICT if v dead
 // mod is -1 from generic combat, mod == crit desired from immortal command.
+// Accumulated crit chance for this attacker, in critSuccessChance's units where
+// 1000 == 1% crit against its 100000 PC roll range. Factored out so both the
+// live crit roll and the consider readout (critChancePercent) share one source
+// of truth. Target-independent; gun/immunity guards live at the call sites.
+double TBeing::getCritChance() const {
+  // Base crit chance at average karma (105), then scaled -20%..+25% by the
+  // actual karma stat. 1000 == a 1% base crit chance.
+  static constexpr double karmaBaseCritChance = 1000.0;
+
+  // Multiplied by learnedness in the respective skills; 10 == +1% at max.
+  static constexpr int critHittingCritBonus = 20;
+  static constexpr int powerMoveCritBonus = 10;
+
+  // Aura of vengeance bonus; 1000 == +1%.
+  static constexpr int auraOfVengeanceCritBonus = 1000;
+
+  // Per point of APPLY_CRIT_FREQUENCY from spells/gear; 50 == +0.05% (20 points
+  // per 1%).
+  static constexpr int critFrequencyValuePerPoint = 50;
+
+  int critHittingValue =
+    doesKnowSkill(SKILL_CRIT_HIT) ? getSkillValue(SKILL_CRIT_HIT) : 0;
+  int powerMoveValue =
+    doesKnowSkill(SKILL_POWERMOVE) ? getSkillValue(SKILL_POWERMOVE) : 0;
+
+  double critChance =
+    karmaBaseCritChance * plotStat(STAT_CURRENT, STAT_KAR, 0.5, 2.0, 1.0);
+
+  critChance += critHittingCritBonus * critHittingValue;
+  critChance += powerMoveCritBonus * powerMoveValue;
+
+  if (affectedBySpell(SPELL_AURA_VENGEANCE))
+    critChance += auraOfVengeanceCritBonus;
+
+  critChance -= 2 * getCond(DRUNK);
+
+  // Modify crit chance based on APPLY_CRIT_FREQUENCY values from spells and/or
+  // equipment
+  const int64_t affectedMod1Total =
+    affected ? affected->sumAffectsByApplyType(APPLY_CRIT_FREQUENCY).first : 0;
+  const int64_t objAffectMod1Total =
+    equipment.sumAffectsByApplyType(APPLY_CRIT_FREQUENCY).first;
+  critChance += static_cast<double>(affectedMod1Total + objAffectMod1Total) *
+                critFrequencyValuePerPoint;
+
+  return critChance;
+}
+
 int TBeing::critSuccessChance(TBeing* victim, TThing* weapon,
   wearSlotT* partHit, spellNumT weaponDamageType, int* damage, int mod) {
   // This defines the range against crit chance will be calculated. 100,000
@@ -571,22 +619,6 @@ int TBeing::critSuccessChance(TBeing* victim, TThing* weapon,
   // doing substantially fewer crits.
   static constexpr int npcCritRollRange = pcCritRollRange * 10;
 
-  // This defines how much base crit chance one will have with exactly average
-  // karma (so 105) It's then modified by the character's actual karma stat from
-  // -20% up to +25%. In this case, a value of 1000 equals a base crit chance of
-  // 1%.
-  static constexpr double karmaBaseCritChance = 1000.0;
-
-  // These values will be multiplied by the attacker's learnedness in the
-  // respective skills to determine how much extra crit chance is provided. A
-  // value of 10 equals 1% incresed crit chance at max learnedness.
-  static constexpr int critHittingCritBonus = 20;
-  static constexpr int powerMoveCritBonus = 10;
-
-  // This defines the crit chance bonus gained from aura of vengeance. A value
-  // of 1000 equals a 1% increase.
-  static constexpr int auraOfVengeanceCritBonus = 1000;
-
   // This represents the base max crit severity possible when an opponent is at
   // 100% HP. Increasing this will make more severe crits possible earlier in
   // fights. Crit severity is a value from 1-100.
@@ -596,11 +628,6 @@ int TBeing::critSuccessChance(TBeing* victim, TThing* weapon,
   // severity ceiling at all times.
   static constexpr int critHittingSeverityBonus = 5;
   static constexpr int powerMoveSeverityBonus = 15;
-
-  // This value divided by 1000 is how much each point of APPLY_CRIT_FREQUENCY
-  // from spells or gear increases crit chance. Value of 50 = 0.05% increased
-  // crit chance per point of crit frequency, meaning 20 points per 1% increase.
-  static constexpr int critFrequencyValuePerPoint = 50;
 
   if (isAffected(AFF_ENGAGER) || dynamic_cast<TGun*>(weapon))
     return 0;
@@ -637,25 +664,7 @@ int TBeing::critSuccessChance(TBeing* victim, TThing* weapon,
 
   int diceRollResult = dice(1, isPc() ? pcCritRollRange : npcCritRollRange);
 
-  double critChance =
-    karmaBaseCritChance * plotStat(STAT_CURRENT, STAT_KAR, 0.5, 2.0, 1.0);
-
-  critChance += critHittingCritBonus * critHittingValue;
-  critChance += powerMoveCritBonus * powerMoveValue;
-
-  if (affectedBySpell(SPELL_AURA_VENGEANCE))
-    critChance += auraOfVengeanceCritBonus;
-
-  critChance -= 2 * getCond(DRUNK);
-
-  // Modify crit chance based on APPLY_CRIT_FREQUENCY values from spells and/or
-  // equipment
-  const int64_t affectedMod1Total =
-    affected ? affected->sumAffectsByApplyType(APPLY_CRIT_FREQUENCY).first : 0;
-  const int64_t objAffectMod1Total =
-    equipment.sumAffectsByApplyType(APPLY_CRIT_FREQUENCY).first;
-  critChance += static_cast<double>(affectedMod1Total + objAffectMod1Total) *
-                critFrequencyValuePerPoint;
+  double critChance = getCritChance();
 
   int critSeverity = 0;
   // Mod comes in as -1 when critSuccessChance is called normally from the
@@ -2778,7 +2787,8 @@ limb-specific effects.
 int TBeing::critGeneric(TBeing* v, TThing* weapon, wearSlotT* part_hit,
   spellNumT wtype, int* dam, int crit_num) {
   int new_wtype = wtype - TYPE_HIT;
-  sstring limbStr = (weapon ? fname(weapon->name) : getMyRace()->getBodyLimbBlunt());
+  sstring limbStr =
+    (weapon ? fname(weapon->name) : getMyRace()->getBodyLimbBlunt());
 
   if (crit_num > 100) {
     vlogf(LOG_BUG,

--- a/code/code/misc/damage.cc
+++ b/code/code/misc/damage.cc
@@ -260,7 +260,7 @@ namespace {
 }  // namespace
 
 // -1 = v is dead, needs to go bye-bye
-int TBeing::reconcileDamage(TBeing* v, int dam, spellNumT how) {
+int TBeing::reconcileDamage(TBeing* v, int dam, spellNumT how, int* damDealt) {
   int rc = 0;
   spellNumT how2;
 
@@ -348,7 +348,7 @@ int TBeing::reconcileDamage(TBeing* v, int dam, spellNumT how) {
     }
   }
 
-  rc = applyDamage(v, dam, how);
+  rc = applyDamage(v, dam, how, damDealt);
 
   if (IS_SET_DELETE(rc, DELETE_VICT)) {
     //    if (desc);
@@ -365,12 +365,17 @@ int TBeing::reconcileDamage(TBeing* v, int dam, spellNumT how) {
 }
 
 // returns DELETE_VICT if v died
-int TBeing::applyDamage(TBeing* v, int dam, spellNumT dmg_type) {
+int TBeing::applyDamage(TBeing* v, int dam, spellNumT dmg_type, int* damDealt) {
   double percent = 0;
   int learn = 0;
   int rc = 0;
   int questmob;
   bool found = FALSE;
+
+  // Default to zero so early returns (immortal target, bogus fight) report no
+  // damage dealt.
+  if (damDealt)
+    *damDealt = 0;
 
   // ranged damage comes through here via reconcileDamage
   // lets not set them fighting unless we need to
@@ -385,6 +390,12 @@ int TBeing::applyDamage(TBeing* v, int dam, spellNumT dmg_type) {
   int protection = v->getProtection();
   dam *= 100 - protection;
   dam = (dam + 50) / 100;  // the 50 is here to round appropriately
+
+  // Report the gross post-mitigation damage (resistance, magic-weapon immunity,
+  // and protection already applied) before any overkill clamp below. This is
+  // the value the consider estimate predicts, so predict and live agree.
+  if (damDealt)
+    *damDealt = max(0, dam);
 
   if (this != v) {
     if (v->getHit() <= -11) {

--- a/code/code/misc/discipline.cc
+++ b/code/code/misc/discipline.cc
@@ -1392,6 +1392,22 @@ bool TBeing::bSuccess(spellNumT spell) {
   return bSuccess(getSkillValue(spell), spell);
 }
 
+// Deterministic mirror of bSuccess's success probability (the roll < iLimit
+// test below): the percent chance this being lands the skill's execution roll,
+// scaled by learnedness, difficulty, focus, and karma. No logging or learning.
+int TBeing::skillExecuteChance(spellNumT skill) const {
+  int comp = getSkillValue(skill);
+  if (comp <= 0)
+    return 0;
+  comp = min(comp, (int)MAX_SKILL_LEARNEDNESS);
+
+  double limit = getSkillDiffModifier(skill) * comp / MAX_SKILL_LEARNEDNESS;
+  limit *= getStatMod(STAT_FOC);
+  limit *= plotStat(STAT_CURRENT, STAT_KAR, 0.9, 1.125, 1.0);
+
+  return min(100, max(0, (int)limit));
+}
+
 bool TBeing::bSuccess(int ubCompetence, spellNumT spell) {
   // number of uses
   logSkillAttempts(this, spell, ATTEMPT_ADD_NORM);

--- a/code/code/misc/enum.h
+++ b/code/code/misc/enum.h
@@ -676,6 +676,14 @@ enum primaryTypeT {
   HAND_PRIMARY = true,
 };
 
+// Rounding mode for the fractional step in scaleWeaponDam(). Live combat rounds
+// stochastically; damage estimates force the round down/up to bracket a range.
+enum damRoundT {
+  DAM_ROUND_STOCHASTIC,
+  DAM_ROUND_DOWN,
+  DAM_ROUND_UP,
+};
+
 enum primLegT {
   LEG_SECONDARY = 0,
   LEG_PRIMARY = 1,

--- a/code/code/misc/monster.cc
+++ b/code/code/misc/monster.cc
@@ -451,7 +451,11 @@ unsigned short TMonster::getDamPrecision() const { return damPrecision; }
 
 void TMonster::setDamPrecision(unsigned short n) { damPrecision = n; }
 
-int TMonster::getMobDamage() const {
+// Deterministic pre-clamp [min,max] envelope of the random draw getMobDamage()
+// makes, so damage estimates (see meleeDamageRange) can bracket the same
+// spread. Endpoints are the raw draw domain; getMobDamage() applies the final
+// max(1, ...) floor after drawing.
+std::pair<int, int> TMonster::getMobDamageRange() const {
   // this function is based on the balance doctrine
   // we want mob damage to be 0.909 * lev per round
   double dam_rnd = getDamLevel() / 1.1;
@@ -462,10 +466,12 @@ int TMonster::getMobDamage() const {
   int idamrnd = max(1, (int)dam_rnd);
 
   int randomizer_max = (int)(idamrnd * getDamPrecision() / 100);
-  int randomizer_amt = ::number(-randomizer_max, randomizer_max);
+  return {idamrnd - randomizer_max, idamrnd + randomizer_max};
+}
 
-  idamrnd += randomizer_amt;
-  return max(1, idamrnd);
+int TMonster::getMobDamage() const {
+  auto [lo, hi] = getMobDamageRange();
+  return max(1, ::number(lo, hi));
 }
 
 int TMonster::lookForEngaged() {

--- a/code/code/misc/monster.h
+++ b/code/code/misc/monster.h
@@ -177,6 +177,7 @@ class TMonster : public TBeing {
     void setDamLevel(float);
     unsigned short getDamPrecision() const;
     void setDamPrecision(unsigned short);
+    std::pair<int, int> getMobDamageRange() const;
     int getMobDamage() const;
 
     int aiSocialSwitch(TBeing*, TBeing*, cmdTypeT, aiTarg);

--- a/code/code/misc/skill_dam.cc
+++ b/code/code/misc/skill_dam.cc
@@ -550,3 +550,34 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
 
   return dam;
 }
+
+// Estimated post-mitigation damage range for a special attack against v.
+// Brackets getSkillDam's only random term (the ::number(1, level/2) roll) via
+// the Min/Max roll modes, then applies the same deterministic reductions
+// reconcileDamage does -- damage-type resistance (preProcDam), magic-weapon
+// immunity (weaponCheck, always vs a null weapon since reconcileDamage passes
+// none), and protection. The pierce-resist proc and any position/limb effects
+// are chance-based and deliberately omitted, matching meleeDamageRange.
+std::pair<int, int> TBeing::skillDamageRange(const TBeing* v,
+  spellNumT skill) const {
+  int level = getSkillLevel(skill);
+  int adv_learn = getAdvLearning(skill);
+  int rawMin = getSkillDam(v, skill, level, adv_learn, SkillDamRoll::Min);
+  int rawMax = getSkillDam(v, skill, level, adv_learn, SkillDamRoll::Max);
+
+  // getSkillDam returns 0 for skills it doesn't model (non-damage skills);
+  // report an empty range so the caller can say so rather than print "1-1".
+  if (rawMax <= 0)
+    return {0, 0};
+
+  int imm = v->getImmunity(getTypeImmunity(skill));
+  int protection = v->getProtection();
+  auto effective = [&](int raw) {
+    int dam = raw * max(0, 100 - imm) / 100;
+    dam = weaponCheck(v, nullptr, skill, dam);
+    dam = (dam * (100 - protection) + 50) / 100;
+    return max(1, dam);
+  };
+
+  return {effective(rawMin), effective(rawMax)};
+}

--- a/code/code/misc/skill_dam.cc
+++ b/code/code/misc/skill_dam.cc
@@ -89,7 +89,8 @@ enum trimTypeT {
 //    e.g. heals.
 static int genericDam(const TBeing* victim, const TBeing* caster,
   spellNumT skill, discNumT basic_disc, int level, int adv_learn,
-  float class_amt, reduceTypeT reduce, bool npc, trimTypeT trim) {
+  float class_amt, reduceTypeT reduce, bool npc, trimTypeT trim,
+  SkillDamRoll rollMode = SkillDamRoll::Random) {
   int dam;
 
   // Note on level: set the max level for any skill equiv to where the skill
@@ -167,9 +168,22 @@ static int genericDam(const TBeing* victim, const TBeing* caster,
   if (!npc && victim && !victim->isPc())
     fixed_amt *= balanceCorrectionForLevel(level);
 
-  // use a randomizer that avgs to L/4
+  // use a randomizer that avgs to L/4. The estimate paths substitute the
+  // spread's fixed endpoints so skillDamageRange can bracket it
+  // deterministically.
   fixed_amt -= level / 4.0;
-  dam = (int)(fixed_amt + ::number(1, level / 2));
+  int roll;
+  switch (rollMode) {
+    case SkillDamRoll::Min:
+      roll = 1;
+      break;
+    case SkillDamRoll::Max:
+      roll = max(1, level / 2);
+      break;
+    default:
+      roll = ::number(1, level / 2);
+  }
+  dam = (int)(fixed_amt + roll);
 
   // adjust for stats
   if (discArray[skill]->modifierStat <= MAX_STATS_USED) {
@@ -185,7 +199,9 @@ static int genericDam(const TBeing* victim, const TBeing* caster,
 
   dam = max(1, dam);
 
-  if (!npc && ((!trim && ((victim && !victim->isPc()) || !victim)) || trim)) {
+  // Estimate paths (Min/Max) must not perturb the balance telemetry.
+  if (rollMode == SkillDamRoll::Random && !npc &&
+      ((!trim && ((victim && !victim->isPc()) || !victim)) || trim)) {
     discArray[skill]->pot_victims++;
     discArray[skill]->pot_damage += dam;
     discArray[skill]->pot_level += level;
@@ -196,7 +212,7 @@ static int genericDam(const TBeing* victim, const TBeing* caster,
 
 // area effect will send victim as NULL
 int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
-  int adv_learn) const {
+  int adv_learn, SkillDamRoll rollMode) const {
   // this is a centralized repository of damage formulas.
   // Yes, they could be in each of the skill/spells, but putting them here
   // gives us some ability to see the big picture...
@@ -241,45 +257,45 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SKILL_SPIN:
       // other: bash lag is handled based on this is bash
       dam = genericDam(victim, this, skill, DISC_WARRIOR, level, adv_learn,
-        0.50, REDUCE_NO, !isPc(), TRIM_NO);
+        0.50, REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_DEATHSTROKE:
       // damage scaling higher the lower the victim's hp %
       dam = genericDam(victim, this, skill, DISC_WARRIOR, level, adv_learn,
         2.5 - 2.0 * ((double)victim->getHit() / (double)victim->hitLimit()),
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_WHIRLWIND:
       dam = genericDam(victim, this, skill, DISC_WARRIOR, level, adv_learn, 4.0,
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_SAND_BLAST:
     case SPELL_HELLFIRE:
     case SPELL_BLIZZARD:
     case SPELL_ENERGY_DRAIN:
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
-        2 * HARD_TO_FIND_COMPONENT, REDUCE_YES, !isPc(), TRIM_NO);
+        2 * HARD_TO_FIND_COMPONENT, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_DUST_STORM:
     case SPELL_PEBBLE_SPRAY:
     case SPELL_LAVA_STREAM:
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn, 2.5,
-        REDUCE_YES, !isPc(), TRIM_NO);
+        REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_LIGHTNING_BOLT:
       // Single target electricity damage with saving throw
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
-        2.05 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        2.05 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_CHAIN_LIGHTNING:
       // Multi-target electricity damage with saving throw
       // Higher base damage since it costs double mana and has longer lag
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
-        2.05 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        2.05 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_TORNADO:
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
-        2.5 * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO);
+        2.5 * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_COLOR_SPRAY:
     case SPELL_ACID_BLAST:
@@ -291,7 +307,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       // damage also increased due to difficulty in obtaining component
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
         2.05 * HARD_TO_FIND_COMPONENT * HAS_SAVING_THROW, REDUCE_YES, !isPc(),
-        TRIM_NO);
+        TRIM_NO, rollMode);
       break;
     case SPELL_ATOMIZE:
     case SPELL_BLAST_OF_FURY:
@@ -309,27 +325,29 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_SLING_SHOT:
     case SPELL_GRANITE_FISTS:
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
-        2.0 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        2.0 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_METEOR_SWARM:
       dam = genericDam(victim, this, skill, DISC_MAGE, level, adv_learn,
-        2.0 * HAS_SAVING_THROW * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO);
+        2.0 * HAS_SAVING_THROW * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO,
+        rollMode);
       break;
     case SPELL_RAIN_BRIMSTONE:
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn,
-        2.0 * HAS_SAVING_THROW * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO);
+        2.0 * HAS_SAVING_THROW * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO,
+        rollMode);
       break;
     case SPELL_HARM:
     case SPELL_PILLAR_SALT:
     case SPELL_EARTHQUAKE:
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn, 3.0,
-        REDUCE_YES, !isPc(), TRIM_NO);
+        REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       dam = (int)(dam * percModifier());
       break;
     case SPELL_SPONTANEOUS_COMBUST:
     case SPELL_FLAMESTRIKE:
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn,
-        2.5 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        2.5 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
 
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
@@ -337,7 +355,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_CALL_LIGHTNING:
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn,
         3.0 * HAS_SAVING_THROW * OUTDOOR_ONLY * NEED_RAIN_LIGHTNING, REDUCE_YES,
-        !isPc(), TRIM_NO);
+        !isPc(), TRIM_NO, rollMode);
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
       break;
@@ -347,7 +365,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_STORMY_SKIES:
       dam = genericDam(victim, this, skill, DISC_SHAMAN, level, adv_learn,
         3.0 * HARD_TO_FIND_COMPONENT * NEED_RAIN_SNOW_LIGHTNING, REDUCE_YES,
-        !isPc(), TRIM_NO);
+        !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_CARDIAC_STRESS:
     case SPELL_AQUATIC_BLAST:
@@ -355,7 +373,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_DEATHWAVE:
     case SPELL_RAZE:
       dam = genericDam(victim, this, skill, DISC_SHAMAN, level, adv_learn,
-        1.5 * HARD_TO_FIND_COMPONENT, REDUCE_YES, !isPc(), TRIM_NO);
+        1.5 * HARD_TO_FIND_COMPONENT, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_DISTORT:
     case SPELL_STICKS_TO_SNAKES:
@@ -364,12 +382,12 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_FLATULENCE:
     case SPELL_LIFE_LEECH:
       dam = genericDam(victim, this, skill, DISC_SHAMAN, level, adv_learn,
-        2.150 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        2.150 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_LICH_TOUCH:
     case SPELL_VAMPIRIC_TOUCH:
       dam = genericDam(victim, this, skill, DISC_SHAMAN, level, adv_learn,
-        1.9 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        1.9 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
       ///////////////////////
       // END SHAMAN STUFF
@@ -379,7 +397,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_HARM_CRITICAL:
       // other: paralyze lag is based on this logic manually in paralyze
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn, 2.5,
-        REDUCE_YES, !isPc(), TRIM_NO);
+        REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
       break;
@@ -390,7 +408,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       // these are torments, this gets called for anti-salve stuff
       // divide by scale factor to keep under control as castable multiple times
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn,
-        1.667, REDUCE_YES, !isPc(), TRIM_NO);
+        1.667, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_HEAL_LIGHT:
     case SPELL_HEAL_SERIOUS:
@@ -404,42 +422,42 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       // also, lets let the modifier be 1.5* what it is for damage
       // however, in PC v PC case, do decrease the amount being healed
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn, 2.50,
-        REDUCE_NO, !isPc(), TRIM_YES);
+        REDUCE_NO, !isPc(), TRIM_YES, rollMode);
 
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
       break;
     case SPELL_HEALING_GRASP:
       dam = genericDam(victim, this, skill, DISC_CLERIC, level, adv_learn, 2.50,
-        REDUCE_NO, !isPc(), TRIM_YES);
+        REDUCE_NO, !isPc(), TRIM_YES, rollMode);
       break;
     case SKILL_KICK:
     case SKILL_GARROTTE:
     case SKILL_STABBING:
       dam = genericDam(victim, this, skill, DISC_THIEF, level, adv_learn, 1.033,
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     // backstab has some limitations (sneak, opening only), so we allow it to
     // violate the rules slightly (arbitrary)
     case SKILL_BACKSTAB:
       dam = genericDam(victim, this, skill, DISC_THIEF, level, adv_learn, 2.00,
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
       // made this slightly higher than backstab since it is in an advanced
       // discipline
     case SKILL_THROATSLIT:
       dam = genericDam(victim, this, skill, DISC_THIEF, level, adv_learn, 2.01,
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_BASH_DEIKHAN:
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.639, REDUCE_NO, !isPc(), TRIM_NO);
+        0.639, REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       dam = (int)(dam * percModifier());
       break;
     case SKILL_CHARGE:
       // limited to mounted and has other penalties  (3*normal dam)
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.9 * 3, REDUCE_NO, !isPc(), TRIM_NO);
+        0.9 * 3, REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       // additionally, do faction percent modification for deikhan
       dam = (int)(dam * percModifier());
       break;
@@ -447,14 +465,14 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       // this is limited to once a day, and has limits from weapon-use to
       // so lets let it do a LOT of damage
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.639 * 8, REDUCE_YES, !isPc(), TRIM_NO);
+        0.639 * 8, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       // additionally, do faction percent modification for deikhan
       dam = (int)(dam * percModifier());
       break;
     case SPELL_HARM_DEIKHAN:
       // a 4/3 factor added for save cutting into overall damage
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.639 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        0.639 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
       break;
@@ -462,7 +480,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SPELL_HARM_SERIOUS_DEIKHAN:
     case SPELL_HARM_CRITICAL_DEIKHAN:
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.639, REDUCE_YES, !isPc(), TRIM_NO);
+        0.639, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
       break;
@@ -470,7 +488,7 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       // these are torments, this gets called for anti-salve stuff
       // divide by scale factor to keep under control as castable multiple times
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.639 / 5.0, REDUCE_YES, !isPc(), TRIM_NO);
+        0.639 / 5.0, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_HEAL_LIGHT_DEIKHAN:
     case SPELL_HEAL_SERIOUS_DEIKHAN:
@@ -478,18 +496,18 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
       // heal spells should NOT be reduced for casting over leve
       // also, lets let the modifier be 1.5* what it is for damage
       dam = genericDam(victim, this, skill, DISC_DEIKHAN, level, adv_learn,
-        0.959, REDUCE_NO, !isPc(), TRIM_YES);
+        0.959, REDUCE_NO, !isPc(), TRIM_YES, rollMode);
       // additionally, do faction percent modification for clerics
       dam = (int)(dam * percModifier());
       break;
     case SPELL_ROOT_CONTROL:
       // 4/3 factor added here due to save cutting into avg damage
       dam = genericDam(victim, this, skill, DISC_RANGER, level, adv_learn,
-        0.529 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO);
+        0.529 * HAS_SAVING_THROW, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_CHOP:
       dam = genericDam(victim, this, skill, DISC_MONK, level, adv_learn, 0.4,
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_KICK_MONK:
     case SKILL_HURL:
@@ -497,27 +515,31 @@ int TBeing::getSkillDam(const TBeing* victim, spellNumT skill, int level,
     case SKILL_DEFENESTRATE:
     case SKILL_SHOULDER_THROW:
       dam = genericDam(victim, this, skill, DISC_MONK, level, adv_learn, 0.233,
-        REDUCE_NO, !isPc(), TRIM_NO);
+        REDUCE_NO, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_CHI:
       // there is no hits() check on this, so treat like a spell
       dam = genericDam(victim, this, skill, DISC_MONK, level, adv_learn, 0.45,
-        REDUCE_YES, !isPc(), TRIM_NO);
+        REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SKILL_PSI_BLAST:
     case SKILL_MIND_THRUST:
     case SKILL_PSYCHIC_CRUSH:
     case SKILL_KINETIC_WAVE:
       dam = genericDam(victim, this, skill, DISC_PSIONICS, level, adv_learn,
-        1.2, REDUCE_YES, !isPc(), TRIM_NO);
+        1.2, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     case SPELL_SKY_SPIRIT:
     case SPELL_EARTHMAW:
       dam = genericDam(victim, this, skill, DISC_ANIMAL, level, adv_learn,
-        2.5 * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO);
+        2.5 * OUTDOOR_ONLY, REDUCE_YES, !isPc(), TRIM_NO, rollMode);
       break;
     default:
-      vlogf(LOG_BUG, format("Unknown skill %d in call to getSkillDam") % skill);
+      // Estimate probes (skillDamageRange) may ask about non-damage skills;
+      // only flag the unexpected live call.
+      if (rollMode == SkillDamRoll::Random)
+        vlogf(LOG_BUG,
+          format("Unknown skill %d in call to getSkillDam") % skill);
       dam = 0;
   }
 


### PR DESCRIPTION
## Summary

Adds live combat-preview information to the `consider` command, gated behind creature-lore learnedness, on top of behavior-preserving refactors that give the preview and the live combat code a shared source of truth.

Four commits, each building independently:

1. **Refactor special-attack roll inputs and thread actual damage dealt** — extract the per-skill offense/defense stat quartet, situational-modifier logic, and stealth-detection predicates out of the inline skill command bodies into shared `TBeing` members; thread an optional damage-dealt out-param through `reconcileDamage` / `applyDamage` / `damageLimb`, and rework `normalHitMessage` to report the HP or limb amount actually drained (colored by pool).
2. **Extract deterministic damage and crit math into reusable helpers** — split `getWeaponDam` / `getMonkWeaponDam` into a rolling half and a deterministic scaling half (rounding-direction parameterized), factor `getCritChance` out of `critSuccessChance`, and add a `SkillDamRoll` endpoint mode to `getSkillDam`. Live combat is unchanged — the stochastic paths are preserved verbatim.
3. **Add combat-preview readouts to the consider command** — deterministic, side-effect-free estimators (`meleeHitChance`, `meleeDamageRange`, `skillDamageRange`, `skillExecuteChance`, `specialAttackChance`, `critChancePercent`) plus a lore-gated staircase that sharpens each figure from prose to exact numbers as creature knowledge grows. `consider <mob> <skill>` reports one skill's execution odds, landing chance, and damage.
4. **Show a generic special-attack landing estimate in basic consider** — `genericSpecialAttackChance`, the level-gap-only reduction of `specialAttackChance`, surfaced as prose at lore 40 and an exact percentage at 50. Skill-agnostic on purpose; the `<skill>` form remains the exact path.

## Notes

- The damage estimates model a vital body hit and deliberately omit armor absorption and chance-based mitigation (dodge/parry, pierce-resist proc); this is documented at the call sites.
- Not yet runtime-verified on a live server.